### PR TITLE
MCC 2019 transcript links to YouTube vids

### DIFF
--- a/magicalcryptoconference/2019/bitcoin-protocol-development-panel.md
+++ b/magicalcryptoconference/2019/bitcoin-protocol-development-panel.md
@@ -5,6 +5,8 @@ categories: ['conference']
 tags: ['mining', 'lightning', 'taproot']
 ---
 
+Video: https://youtu.be/8B1fX2i4dMY
+
 Bitcoin protocol development panel
 
 Eric Lombrozo, Matt Corallo, John Newbery, Luke Dashjr, Katherine Wu

--- a/magicalcryptoconference/2019/bitcoin-satellite-network.md
+++ b/magicalcryptoconference/2019/bitcoin-satellite-network.md
@@ -8,6 +8,8 @@ Bitcoin satellite network
 
 Adam Back
 
+Video: https://youtu.be/tJOI2i6h3HM
+
 # Bitcoin in Spaaace!
 
 I am going to be talking about the bitcoin satellite service that Blockstream has been offering for a few years now. I am going to talk about what it does and why that's interesting to users.

--- a/magicalcryptoconference/2019/bitcoin-without-internet.md
+++ b/magicalcryptoconference/2019/bitcoin-without-internet.md
@@ -8,6 +8,8 @@ Bitcoin without internet
 
 Adam Back, Rodolfo Novak (Coinkite), Elaine Ou, Adam Back, Richard Myers (GoTenna)
 
+Video: https://youtu.be/5Fim6g2BMZI
+
 SM: We have a special announcement to make. Let me kick it over to Richard right now.
 
 RM: We completed a project that will integrate the GoTenna mesh radio system with Blockstream's blocksat satellite system. It's pretty exciting. It's called txtenna. It will allow anybody to send a signed bitcoin transaction from an off-grid full node that is receiving blockchain data from the blocksat network, and then relay it over the GoTenna mesh network. It's not just signed transactions but also API data. I want to thank everyone at Blockstream who has made this possible. Check it out at <http://txtenna.com/>.

--- a/magicalcryptoconference/2019/crypto-in-cryptocurrency.md
+++ b/magicalcryptoconference/2019/crypto-in-cryptocurrency.md
@@ -9,6 +9,8 @@ The "crypto" in cryptocurrency: Why everything is weird and hard
 
 Andrew Poelstra
 
+Video: https://youtu.be/mRl3c9ppO78
+
 I do not have any slides for you. This is my attempt to keep this non-technical, by depriving myself of any ability to write equations on screen. The topic of my talk is why everything is weird and hard in cryptocurrency. What is cryptography as a mathematics and field of science? And how does this work in practice?
 
 # Encryption

--- a/magicalcryptoconference/2019/cryptographic-hocus-pocus.md
+++ b/magicalcryptoconference/2019/cryptographic-hocus-pocus.md
@@ -11,6 +11,8 @@ or: "Peter Todd's secret love letter to Zooko"
 
 Peter Todd
 
+Video: https://youtu.be/YHieWJWwVbE
+
 # Background
 
 See <http://web.archive.org/web/20170717025249/https://petertodd.org/2016/cypherpunk-desert-bus-zcash-trusted-setup-ceremony>

--- a/magicalcryptoconference/2019/fork-dynamics.md
+++ b/magicalcryptoconference/2019/fork-dynamics.md
@@ -8,6 +8,8 @@ Fork dynamics
 
 Eric Lombrozo
 
+Video: https://youtu.be/zFN__b6ARH4?t=12523
+
 Thank you, Samson, for that great introduction and thank you for organizing this awesome event. It's great seeing everyone. A few years ago, the situation was extremely different. When Samson originally asked me to give a talk, I kind of thought a little bit about what I should talk about and I wasn't sure what's most interesting. A few years ago, it was much more clear about the set of things going on. I had something to say about those things. I guess now, I would like to broadly talk about some important areas of topics that we wouldn't usually talk about. I kept asking for a topic.
 
 What I'm going to talk about is really what we've got ourselves into with this. People get into this space and they think we're really dumb getting into this. Bitcoin is really hard to explain to people what it is. One of the things I think is really unique is that you see people that really have higher pursuits they are going out to do, but there's basis level of human behavior. It doesn't appeal to human greed and other things like that... so in a sense we're trying to build something to improve humanity and rise above the current human condition and how people think about money, but at the same time people really want to make money.

--- a/magicalcryptoconference/2019/future-of-privacy-coins.md
+++ b/magicalcryptoconference/2019/future-of-privacy-coins.md
@@ -7,6 +7,8 @@ tags: ['privacy', 'taproot', 'schnorr']
 
 Future of privacy coins
 
+Video: https://youtu.be/eGpa45y4_HQ
+
 Brandon Goodell, Andrew Poelstra, Alexandra Moxin
 
 AM: That's not good. Hi everyone. Thanks for coming to the future of privacy coins panel. I want to spend a minute talking ablout backgrounds and interest in this area.

--- a/magicalcryptoconference/2019/htc.md
+++ b/magicalcryptoconference/2019/htc.md
@@ -8,6 +8,8 @@ HTC / Exodus
 
 Phil Chen
 
+Video: https://youtu.be/CyieujRFk3g?t=8077
+
 # Introduction
 
 SM: This conversation started a couple months ago in Hong Kong with Phil Chen and Adam Back were sitting in a bar talking about the bitcoin industry and what would move it forward. Without further adue, please welcome Phil Chen.

--- a/magicalcryptoconference/2019/intro.md
+++ b/magicalcryptoconference/2019/intro.md
@@ -6,6 +6,8 @@ categories: ['conference']
 
 Intro
 
+Video: https://youtu.be/CyieujRFk3g
+
 Whalepanda
 
 Hello? Ladies and gentlemen, please take your seats and we're going to start now. Good afternoon everyone. I'm a self-proclaimed VP of operations and swag for this crypto conference. I'm also a friend of the Magical Crypto Friends. I'm very happy to see the turnout for this conference. I see people who are clearly passionate based on the way they dress. Thank you all for coming. I am going to ask a question. What's your favorite thing about this conference so far? Nothing about ICOs. I like that answer. I like your shirt also. My shirt says "Satoshi is Black" ((applause)). "He's a woman, too". Looks like we're ready now. Without further adue, here are the crypto friends to come on stage.

--- a/magicalcryptoconference/2019/lightning-payments.md
+++ b/magicalcryptoconference/2019/lightning-payments.md
@@ -9,6 +9,8 @@ Lightning payments (and more) on the web
 
 Will O'Beirne
 
+Video: https://youtu.be/wd-dNd2Wck4
+
 CL: Thank you Elizabeth and Stacy for that great talk. Who runs a lightning node here? So a lot of you. Are you guys excited about lightning? Great, we have like four more talks on lightning. Next we have Will O'Beirne who will be talking about lightning payments on the web. Big round of applause.
 
 # Introduction

--- a/magicalcryptoconference/2019/ln-present-and-future-panel.md
+++ b/magicalcryptoconference/2019/ln-present-and-future-panel.md
@@ -9,6 +9,8 @@ Lightning network present & future panel
 
 Will O'Beirne, Lisa Neigut, Alex Bosworth, Leigh Cuen
 
+Video: https://youtu.be/OzpfiieV5C4
+
 LC: Can everyone hear me now? Alright, alright.
 
 WO: It's getting some good usage. A lot of those are businesses. Definitely it's in the early stage. Elizabeth talked about this. There's a lot of things that are mostly for fun, it's not really at ecommerce yet.

--- a/magicalcryptoconference/2019/mcf-episode.md
+++ b/magicalcryptoconference/2019/mcf-episode.md
@@ -4,6 +4,9 @@ transcript_by: Bryan Bishop
 categories: ['conference']
 ---
 
+Video: https://youtu.be/0MnuvKybuo0?t=1463
+
+Video MCF Short: https://youtu.be/SnfKIKL_Ghk
 
 WP: The short was not about Craig Wright. It was not about him being a fraud, because he is not a fraud.
 

--- a/magicalcryptoconference/2019/state-of-lightning-network.md
+++ b/magicalcryptoconference/2019/state-of-lightning-network.md
@@ -9,6 +9,8 @@ Fireside chat on the state of the lightning network
 
 Stacy Herbert, Elizabeth Stark
 
+Video: https://youtu.be/kk2dUD6QXgw
+
 # Introduction
 
 WP: We have a fireside chat with Stacy Herbert from Kaiser Report and Elizabeth Stark. Some people say she is the CEO of Lightning Network, but she is the CEO of Lightning Labs. Let's invite them on stage.

--- a/magicalcryptoconference/2019/submarine-swaps.md
+++ b/magicalcryptoconference/2019/submarine-swaps.md
@@ -9,6 +9,8 @@ Bridging off-chain and on-chain with submarine swaps
 
 Alex Bosworth
 
+Video: https://youtu.be/SCxaV2HCQ5o
+
 # Introduction
 
 Hi, I work at Lightning Labs. I want to talk about the dawn of hyperloop. It's a new concept.

--- a/magicalcryptoconference/2019/taxonomy-of-ln-nodes.md
+++ b/magicalcryptoconference/2019/taxonomy-of-ln-nodes.md
@@ -9,6 +9,8 @@ Taxonomy of lightning nodes
 
 Lisa Neigut
 
+Video: https://youtu.be/A4i5cEI1jnc
+
 # Introduction
 
 Hello. I work at Blockstream on c-lightning. I am here today to talk to you about a taxonomy of nodes about who's who on the lightning network. I wnat ot go through the tools that have been built, looking through the perspectives of what different nodes are trying to accomplish.

--- a/magicalcryptoconference/2019/why-block-sizes-should-not-be-too-big.md
+++ b/magicalcryptoconference/2019/why-block-sizes-should-not-be-too-big.md
@@ -11,6 +11,8 @@ Luke Dashjr
 
 slides: <https://luke.dashjr.org/tmp/code/block-sizes-mcc.pdf>
 
+Video: https://youtu.be/JJF5Gnro1GU
+
 I am luke-jr. I am going to go over why block size shouldn't be too big.
 
 # How does bitcoin work?


### PR DESCRIPTION
I thought it might be useful to add the links to the vids that are the source of the actual transcripts.

Not sure if there was a reason for those links not to be included in the first place. Other transcripts have a de facto practice of including those links.