### PR TITLE
add github action to sync content with site on every change

### DIFF
--- a/.github/workflows/sync-parent-repo-with-submodule-updates.yml
+++ b/.github/workflows/sync-parent-repo-with-submodule-updates.yml
@@ -1,0 +1,36 @@
+name: Sync submodule updates to parent repository
+
+on:
+  push:
+    branches: 
+      - master
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Write SSH keys
+        run: |
+          install -m 600 -D /dev/null ~/.ssh/id_rsa
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          host='github.com'
+          hosts="$(dig +short "$host" | grep -v '\.$' | sed -z 's|\n|,|g')$host"
+          ssh-keyscan -H "$hosts" > ~/.ssh/known_hosts
+
+      - uses: actions/checkout@v2
+        with: 
+          repository: bitcointranscripts/bitcointranscripts.github.io
+          token: ${{ secrets.PRIVATE_TOKEN }}
+
+      - name: Pull & update submodules recursively
+        run: |
+          git submodule update --init --recursive
+          git submodule update --recursive --remote
+      - name: Commit
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions - content update"
+          git add --all
+          git commit -m "content update" || echo "No changes to commit"
+          git push


### PR DESCRIPTION
This PR fixes #42 to automatically deploy recent changes to the website. (it will need some effort from @adamjonas to add a couple of secrets in the repo).

### Overview
The current workflow to update the content is explained in https://github.com/bitcointranscripts/bitcointranscripts/issues/42#issuecomment-887674468. Basically this repository (_content's repository_) is used as submodule/content for [bitcointranscripts.github.io](https://github.com/bitcointranscripts/bitcointranscripts.github.io) (_website's repository_) which needs a manual update of its submodule in order to deploy the latest changes to the website. 

The idea behind this PR is that every change that is pushed on the _content's repository_ will trigger a submodule update on the _website's repository_. The submodule change will then, based on the current workflow, trigger a deployment with the updated content.

To test/demo this, I mirrored the workflows on my own forks of the repositories ([demo content repository](https://github.com/kouloumos/bitcointranscripts/tree/improve-workflows-demo), [demo website repository](https://github.com/kouloumos/bitcointranscripts.github.io/tree/improve-workflows)) and did some tests. You can observe that after [the demo PR was merged](https://github.com/kouloumos/bitcointranscripts/pull/5), this new github action [was triggered](https://github.com/kouloumos/bitcointranscripts/actions/runs/1973757069) to [create an update content commit in the website repository](https://github.com/kouloumos/bitcointranscripts.github.io/commit/775679245c4cf9199d3f1c5c06440a8476ca3ece) and then [deployed](https://github.com/kouloumos/bitcointranscripts.github.io/actions/runs/1973760691).
The newly added demo transcript can now be found [in the demo deployment website](https://kouloumos.github.io/bitcointranscripts.github.io/magicalcryptoconference/2019/decentralized-mining-pools-for-bitcoin/) but [not in the original website](https://btctranscripts.com/magicalcryptoconference/2019/decentralized-mining-pools-for-bitcoin/).

### Prerequisites
For this to work, the following must be added to the repository secrets by @adamjonas or anyone else with sufficient access.

1. For the github-actions[bot] to be able to commit in the repository, we need to [create a private access token](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) with sufficient permissions (I used scope=repo) to write in the website repository (parent) and [save it as a repository secret](https://docs.github.com/en/actions/reference/encrypted-secrets). In my code, this is under the name `PRIVATE_TOKEN` and the logic has been adapted from https://stackoverflow.com/a/68213855/5800072

2. Because we are using SSH for the submodule, a new SSH key must be [added to the account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account) and the private key (under the name `SSH_PRIVATE_KEY` in my code) must be [added as a repository secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets). The source for the respective code (L13-19) that writes the SSH key is https://stackoverflow.com/a/70447517/5800072 . 


### Notes
During this implementation, I also answered my own question at https://github.com/bitcointranscripts/bitcointranscripts.github.io/issues/34#issue-1121816014 regarding `./public`. During the github actions workflow the hugo page is build and committed at the [gh-pages branch](https://github.com/bitcointranscripts/bitcointranscripts.github.io/tree/gh-pages) and then deployed from there, which makes the `./public` directory redundant. You can also verify that from my demo, in which the demo transcript was deployed but no change was made in the `./public` directory and the content was only updated [here](https://github.com/kouloumos/bitcointranscripts.github.io/commit/1657e356dcdbcb8e51f185428abc43181a75f546). I'll later add a new PR to the website repository to remove `./public` from source control.
