### PR TITLE
Update tweet for transcript github action

### DIFF
--- a/.github/workflows/tweet-for-new-transcript.yml
+++ b/.github/workflows/tweet-for-new-transcript.yml
@@ -17,52 +17,93 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Get comma-delimited added files in order to then check for the
-      # existence of a comma that indicates multiple added files
-      # we only want to tweet if a single file has been added
       - id: files
         uses: Ana06/get-changed-files@v1.2
         with:
-          format: "csv"
+          format: 'json'
       - id: variables
         name: Setup variables
         run: |
-          # Check that there is only one changed file (no comma exists)
-          FILE_PATH=${{steps.files.outputs.added}}
-          if [[ "$FILE_PATH" == *","* ]]; then
-            echo ::set-output name=MULTIPLE::true
+          # Find the transcript in the added files, if exist
+          readarray -t added_files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.added }}')"
+          for added_file in ${added_files[@]}; do
+            if [[ "${added_file}" == *".md" ]] && [[ "${added_file}" != *"_index"* ]]; then
+              FILE_PATH=${added_file}
+            fi
+          done
+
+          if [[ -n "$FILE_PATH" ]]; then
+            BASE_URL="https://btctranscripts.com/" # initialize url
+
+            # Determine the language of the changed file
+            if [[ $FILE_PATH == *".es.md" ]]; then
+              BASE_URL+="es/"
+            elif [[ $FILE_PATH == *".pt.md" ]]; then
+              BASE_URL+="pt/"
+            fi
+
+            echo ::set-output name=FILE_PATH::${FILE_PATH}
+            echo ::set-output name=URL::"${BASE_URL}${FILE_PATH%%.*}/" # remove file-type (*.md) from file-name to create the new transcript url
           fi
-          # Determine the language of the changed file
-          if [[ $FILE_PATH == *".es.md" ]]
-            then
-            echo ::set-output name=LANGUAGE_ES::true
-          elif [[ $FILE_PATH == *".pt.md" ]]
-            then
-            echo ::set-output name=LANGUAGE_PT::true
-          elif [[ $FILE_PATH == *".md" ]]
-            then
-            echo ::set-output name=LANGUAGE_EN::true
+      - uses: actions/checkout@v3
+      - id: transcript
+        # This script extracts the neccessary data from the file's metadata
+        # to construct the tweet. It replaces names with twitter handles when 
+        # they are available in `twitter_handles.json`
+        name: Extract transcript details
+        if: |
+          steps.variables.outputs.URL
+        run: |
+          # Extract Hugo front matter
+          TRANSCRIPT=$(cat ${{ steps.variables.outputs.FILE_PATH }})
+          FRONTMATTER="${TRANSCRIPT#*---}" # trim through '---' from the front (left)
+          FRONTMATTER="${FRONTMATTER%---*}" # trim through '---' from the back (right)
+          echo "$FRONTMATTER"
+
+          # Get details
+          TITLE=$(echo "$FRONTMATTER" | grep "title")
+          TITLE=${TITLE#*title:}
+          TRANSCRIPT_BY=$(echo "$FRONTMATTER" | grep "transcript_by")
+          TRANSCRIPT_BY=${TRANSCRIPT_BY#*transcript_by: }
+          TRANSLATION_BY=$(echo "$FRONTMATTER" | grep "translation_by" || true)
+          if [[ -n $TRANSLATION_BY ]]; then
+            TRANSLATION_BY=${TRANSLATION_BY#*translation_by: }
           fi
-          # remove file-type (*.md) from file-name to create the new transcript url
-          echo ::set-output name=URL_PATH::${FILE_PATH%%.*}
+          SPEAKERS=$(echo "$FRONTMATTER" | grep "speakers" || true)
+          SPEAKERS=$(echo "$SPEAKERS" | tr -d "\'][")
+          SPEAKERS="$(echo ${SPEAKERS#*speakers: } | tr ' ' '_')"
+
+          # Construct tweet title
+          TWEET="${TITLE} "
+          if [[ -n $SPEAKERS ]]; then
+            TWEET+="by "
+            SPEAKERS_ARRAY=($(echo $SPEAKERS | tr "," " "))
+            for SPEAKER in "${SPEAKERS_ARRAY[@]}"; do
+              SPEAKER_NAME=""$(echo ${SPEAKER} | tr '_' ' ' | xargs)""
+              SPEAKER_TWITTER=$(cat twitter_handles.json | jq '."'"${SPEAKER_NAME}"'"' --raw-output)
+              if [[ $SPEAKER_TWITTER == null ]]; then TWEET+="${SPEAKER_NAME}, "; else TWEET+="@${SPEAKER_TWITTER}, "; fi
+            done
+            TWEET="${TWEET%??}" # to remove the last `, ` after speakers loop
+          fi
+          TWEET+=" has been added!"
+          echo ::set-output name=TITLE::${TWEET}
+
+          # Construct tweet transcription details
+          TWEET="Transcript by "
+          TRANSCRIPT_BY_TWITTER=$(cat twitter_handles.json | jq '."'"${TRANSCRIPT_BY}"'"' --raw-output)
+          if [[ $TRANSCRIPT_BY_TWITTER == null ]]; then TWEET+="${TRANSCRIPT_BY}"; else TWEET+="@${TRANSCRIPT_BY_TWITTER} "; fi
+          if [[ -n $TRANSLATION_BY ]]; then
+            TWEET+=" and translation by "
+            TRANSLATION_BY_TWITTER=$(cat twitter_handles.json | jq '."'"${TRANSLATION_BY}"'"' --raw-output)
+            if [[ $TRANSLATION_BY_TWITTER == null ]]; then TWEET+="${TRANSLATION_BY}"; else TWEET+="@${TRANSLATION_BY_TWITTER} "; fi
+          fi
+          echo ::set-output name=CONTRIBUTORS::${TWEET}
+
+          # add delay to give time to the site to update
+          sleep 4m
       - uses: Eomm/why-don-t-you-tweet@v1
-        name: Tweet for English transcript
+        name: Tweet for transcript
         if: |
-          !steps.variables.outputs.MULTIPLE && 
-          steps.variables.outputs.LANGUAGE_EN
+          steps.variables.outputs.URL
         with:
-          tweet-message: "A new transcript has been added! \n https://btctranscripts.com/${{ steps.variables.outputs.URL_PATH }}/"
-      - uses: Eomm/why-don-t-you-tweet@v1
-        name: Tweet for Spanish transcript
-        if: |
-          !steps.variables.outputs.MULTIPLE && 
-          steps.variables.outputs.LANGUAGE_ES
-        with:
-          tweet-message: "A new spanish transcript has been added! \n https://btctranscripts.com/es/${{ steps.variables.outputs.URL_PATH }}/"
-      - uses: Eomm/why-don-t-you-tweet@v1
-        name: Tweet for Portuguese transcript
-        if: |
-          !steps.variables.outputs.MULTIPLE && 
-          steps.variables.outputs.LANGUAGE_PT
-        with:
-          tweet-message: "A new portuguese transcript has been added! \n https://btctranscripts.com/pt/${{ steps.variables.outputs.URL_PATH }}/"
+          tweet-message: "${{ steps.transcript.outputs.TITLE }}\n\n${{ steps.transcript.outputs.CONTRIBUTORS }}\n${{ steps.variables.outputs.URL }}"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Each transcript is a markdown file, which requires to include the `title` and `t
 ---
 title: Carl Dong - Reproducible Builds (2020-11-30)
 transcript_by: Bryan Bishop
-speaker: Carl Dong
+speakers: ['Carl Dong']
 categories: ['podcast']
 tag: ['build systems']
 ---
@@ -54,6 +54,8 @@ video: <https://www.youtube.com/watch?v=L_sI_tXmy2U>
 ```
 
 *Note* that valid markdown has `<>`s around urls like the video example above.
+
+When a transcript is added, [@bitcoinwritings](https://twitter.com/bitcoinwritings) will tweet for it and tag speakers & contributors  as long as they have been associated with a twitter username at [twitter_handles.json](/twitter_handles.json)
 
 ### Transcription Style
 
@@ -76,7 +78,7 @@ Each transcript is a markdown file, which requires to include the `title` and `t
 title: Andreas Antonopoulos - Firmas Schnorr (2018-10-07)
 transcript_by: Michael Folkson
 translation_by: Blue Moon
-speaker: Andreas Antonopoulos
+speakers: ['Andreas Antonopoulos']
 categories: ['podcast']
 tag: ['schnorr']
 ---

--- a/twitter_handles.json
+++ b/twitter_handles.json
@@ -1,0 +1,5 @@
+{
+  "Blue Moon": "moon33_blue",
+  "Bryan Bishop": "kanzure",
+  "Michael Folkson": "michaelfolkson"
+}


### PR DESCRIPTION
This PR updates the GitHub action introduced in https://github.com/bitcointranscripts/bitcointranscripts/pull/168 to include more details about the transcript in the tweet. 

The script extracts the neccesary data from the file's metadata ([Hugo's front matter](https://gohugo.io/content-management/front-matter/)) to construct a tweet of the format
```
<transcript-title> by <speaker-1>, ... <speaker-n> has been added!

Transcript by <transcript-contributor> and translation by <translation-contributor>
<transcript-url>
```

The tweet will also tag speakers & contributors  as long as they have been associated with a twitter username at `twitter_handles.json` [demo-tweet](https://twitter.com/bitcoinrugs/status/1545691858843496448)

For the github action to recognize speakers they must be defined as part of the front matter as 
```
speakers: ['Speaker1', 'Speaker2']
```
This allows for more than one speakers and follows the proposed change at https://github.com/bitcointranscripts/bitcointranscripts.github.io/pull/42 which allows for better by-speaker filtering.

Other issues resolved:

- The action can now tweet when there are multiple files added/modified.
- A delay has been added to the tweet to give time to the site to update in order for the preview of the link to be displayed.



