### PR TITLE
Fix duplicate frontmatter keys

### DIFF
--- a/bitcoin-core-dev-tech/2019-06-07-p2p-encryption.md
+++ b/bitcoin-core-dev-tech/2019-06-07-p2p-encryption.md
@@ -4,7 +4,6 @@ date: 2019-06-07
 transcript_by: Bryan Bishop
 categories: ['core-dev-tech']
 tags: ['P2P', 'bitcoin core']
-date: 2019-06-07
 ---
 
 <https://twitter.com/kanzure/status/1136939003666685952>

--- a/greg-maxwell/2018-09-23-greg-maxwell-bitcoin-core-testing.md
+++ b/greg-maxwell/2018-09-23-greg-maxwell-bitcoin-core-testing.md
@@ -1,7 +1,6 @@
 ---
 title: Bitcoin Core Testing 
 transcript_by: Michael Folkson
-transcript_by: Bryan Bishop
 tags: ['bitcoin core', 'testing']
 speakers: ['Greg Maxwell']
 date: 2018-09-23


### PR DESCRIPTION
There are two duplicate frontmatter keys that make the yaml header invalid:

- In `bitcoin-core-dev-tech/2019-06-07-p2p-encryption.md` the date is already present.
- In `greg-maxwell/2018-09-23-greg-maxwell-bitcoin-core-testing.md` I believe @michaelfolkson meant to replace Bryan Bishop's name with his. (#1).