### PR TITLE
correct to follow new guildlines

### DIFF
--- a/advancing-bitcoin/2022/2022-03-03-sanket-kanjalkar-miniscript.zh.md
+++ b/advancing-bitcoin/2022/2022-03-03-sanket-kanjalkar-miniscript.zh.md
@@ -1,22 +1,15 @@
 ---
-title: Sanket Kanjalkar - Miniscript (2022-03-03)
+title: Miniscript
 transcript_by: Michael Folkson
 translation_by: Ajian
 categories: ['conference']
 tags: ['script', 'miniscript']
 speakers: ['Sanket Kanjalkar']
 date: 2022-03-03
+media: https://www.youtube.com/watch?v=Bn1CWsqt3VQ
 ---
 
-演讲者：Sanket Kanjalkar
-
 题目：Miniscript：可组合、可分析、更智能的比特币脚本
-
-场合：Advancing Bitcoin
-
-日期：2022 年 3 月 3 日
-
-视频：<https://www.youtube.com/watch?v=Bn1CWsqt3VQ>
 
 Andrew Poelstra 论 Miniscript：<https://btctranscripts.com/london-bitcoin-devs/2020-02-04-andrew-poelstra-miniscript/>
 

--- a/tabconf/2022/2022-10-14-roast.zh.md
+++ b/tabconf/2022/2022-10-14-roast.zh.md
@@ -1,5 +1,5 @@
 ---
-title: ROAST - Robust asynchronous Schnorr threshold signatures (2022-10-14)
+title: ROAST - Robust asynchronous Schnorr threshold signatures 
 transcript_by: Bryan Bishop
 translation_by: Ajian
 categories: ['core-dev-tech']

--- a/tabconf/2022/2022-10-15-braidpool.zh.md
+++ b/tabconf/2022/2022-10-15-braidpool.zh.md
@@ -1,5 +1,5 @@
 ---
-title: Braidpool (2022-10-15)
+title: Braidpool 
 transcript_by: Bryan Bishop
 translation_by: Ajian
 categories: ['core-dev-tech']

--- a/tabconf/2022/2022-10-15-segwit-vbytes-misconceptions.zh.md
+++ b/tabconf/2022/2022-10-15-segwit-vbytes-misconceptions.zh.md
@@ -1,5 +1,5 @@
 ---
-title: Misconceptions about segwit vbytes (2022-10-15)
+title: Misconceptions about segwit vbytes 
 transcript_by: Bryan Bishop
 translation_by: Ajian
 categories: ['core-dev-tech']

--- a/tabconf/2022/2022-10-15-silent-payments.zh.md
+++ b/tabconf/2022/2022-10-15-silent-payments.zh.md
@@ -1,5 +1,5 @@
 ---
-title: Silent Payments and Alternatives (2022-10-15)
+title: Silent Payments and Alternatives 
 transcript_by: Bryan Bishop
 translation_by: Ajian
 categories: ['core-dev-tech']


### PR DESCRIPTION
Correct heads of Chinese translations of TABConf 2022 and Advancing Bitcoin 2022, to follow new guildlines.