### PR TITLE
lightning-specification: remove # from agenda numbers and standardize names

### DIFF
--- a/lightning-specification/2021-11-22-specification-call.md
+++ b/lightning-specification/2021-11-22-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning specification call - Agenda #936
+title: Lightning Specification Meeting - Agenda 0936
 transcript_by: Michael Folkson
 categories: ['meetup']
 tags: ['lightning']

--- a/lightning-specification/2021-12-06-specification-call.md
+++ b/lightning-specification/2021-12-06-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning specification call - Agenda #943
+title: Lightning Specification Meeting - Agenda 0943
 transcript_by: Michael Folkson
 categories: ['meetup']
 tags: ['lightning']

--- a/lightning-specification/2022-01-03-specification-call.md
+++ b/lightning-specification/2022-01-03-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning specification call - Agenda #949
+title: Lightning Specification Meeting - Agenda 0949
 transcript_by: Michael Folkson
 categories: ['meetup']
 tags: ['lightning']

--- a/lightning-specification/2022-01-31-specification-call.md
+++ b/lightning-specification/2022-01-31-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning specification call - Agenda #955
+title: Lightning Specification Meeting - Agenda 0955
 transcript_by: Michael Folkson
 categories: ['meetup']
 tags: ['lightning']

--- a/lightning-specification/2022-02-14-specification-call.md
+++ b/lightning-specification/2022-02-14-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning specification call - Agenda #957
+title: Lightning Specification Meeting - Agenda 0957
 transcript_by: Michael Folkson
 categories: ['meetup']
 tags: ['lightning']

--- a/lightning-specification/2022-03-14-specification-call.md
+++ b/lightning-specification/2022-03-14-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning specification call - Agenda #969
+title: Lightning Specification Meeting - Agenda 0969
 transcript_by: Michael Folkson
 categories: ['meetup']
 tags: ['lightning']

--- a/lightning-specification/2023-01-30-specification-call.md
+++ b/lightning-specification/2023-01-30-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning specification call - Agenda #1053
+title: Lightning Specification Meeting - Agenda 1053
 transcript_by: Generated
 categories: ['meeting']
 tags: ['lightning']

--- a/lightning-specification/2023-02-13-specification-call.md
+++ b/lightning-specification/2023-02-13-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning specification call - Agenda #1055
+title: Lightning Specification Meeting - Agenda 1055
 transcript_by: Generated, Human-Verified by Carla Kirk-Cohen
 categories: ['meeting']
 tags: ['lightning']

--- a/lightning-specification/2023-04-24-specification-call.md
+++ b/lightning-specification/2023-04-24-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning Specification Meeting - Agenda #1067
+title: Lightning Specification Meeting - Agenda 1067
 transcript_by: Gurwinder Sahota via TBTBTC v1.0.0
 tags: ['lightning']
 date: 2023-04-24

--- a/lightning-specification/2023-05-08-specification-call.md
+++ b/lightning-specification/2023-05-08-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning Specification Meeting - Agenda #1076
+title: Lightning Specification Meeting - Agenda 1076
 transcript_by: Gurwinder Sahota via TBTBTC v1.0.0
 tags: ['lightning']
 date: 2023-05-08

--- a/lightning-specification/2023-05-22-specification-call.md
+++ b/lightning-specification/2023-05-22-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning Specification Meeting - Agenda #1082
+title: Lightning Specification Meeting - Agenda 1082
 transcript_by: Gurwinder Sahota via TBTBTC v1.0.0
 tags: ['lightning']
 date: 2023-05-22

--- a/lightning-specification/2023-06-05-specification-call.md
+++ b/lightning-specification/2023-06-05-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning Specification Meeting - Agenda #1085
+title: Lightning Specification Meeting - Agenda 1085
 transcript_by: Gurwinder Sahota via TBTBTC v1.0.0
 tags: ['lightning']
 date: 2023-06-05

--- a/lightning-specification/2023-06-19-specification-call.md
+++ b/lightning-specification/2023-06-19-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning Specification Meeting - Agenda #1088
+title: Lightning Specification Meeting - Agenda 1088
 transcript_by: Gurwinder Sahota via TBTBTC v1.0.0
 tags: ['lightning']
 date: 2023-06-19

--- a/lightning-specification/2023-07-17-specification-call.md
+++ b/lightning-specification/2023-07-17-specification-call.md
@@ -1,5 +1,5 @@
 ---
-title: Lightning Specification Meeting - Agenda #1094
+title: Lightning Specification Meeting - Agenda 1094
 transcript_by: Gurwinder Sahota via TBTBTC v1.0.0
 tags: ['lightning']
 date: 2023-07-17


### PR DESCRIPTION
Seems like the # before agenda number hides the value on the UI. 

<img width="524" alt="Screenshot 2023-07-26 at 9 46 44 AM" src="https://github.com/bitcointranscripts/bitcointranscripts/assets/42311294/9f4e855c-d637-426a-a2fb-bb492b7f0097">

Updated to remove # and standardize names of spec calls. _Actually_ tested against the website this time, sorry for the extra roundtrip to get this right.

<img width="480" alt="Screenshot 2023-07-26 at 10 28 11 AM" src="https://github.com/bitcointranscripts/bitcointranscripts/assets/42311294/15c3c45c-cad4-4c2e-afa3-57f561995018">
