### PR TITLE
Add new AI-generated transcripts

### DIFF
--- a/adopting-bitcoin/2021/onboarding-bitcoin-and-lightning-developers.md
+++ b/adopting-bitcoin/2021/onboarding-bitcoin-and-lightning-developers.md
@@ -1,0 +1,829 @@
+---
+title: "Onboarding Bitcoin and Lightning Developers"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://www.youtube.com/watch?v=-uJSdfo4z7c
+tags: ['bitcoin-core', 'lightning']
+speakers: ['Gloria Zhao', 'Will Clark', 'Adam Jonas', 'Jonas Nick']
+categories: ['conference']
+date: 2021-11-16
+---
+## Onboarding Bitcoin and Lightning Developers
+
+Speaker 0: 00:00:15
+
+Okay, so the next talk is going to be onboarding Bitcoin and Lightning developers with Will Clark, Gloria Zhao.
+This is Josie, Bitcoin Core contributor.
+Jonas, Nick.
+Please come to the stage.
+
+Speaker 1: 00:00:32
+
+One mic short.
+Hey, guys.
+How are you doing?
+Welcome.
+So we are going to be talking about that onboarding Bitcoin and Lightning developers.
+Do you guys want to introduce yourself?
+I think all of you have been on stage already, but want to do a quick round?
+
+Speaker 2: 00:00:51
+
+So I'm Will Clark, I have been doing some work with Global Mesh Labs which is now finished, so I'm not actually doing as my badge says, and I'm working on sort of becoming a Bitcoin core contributor myself, so I'm in the middle of some of this stuff that we're going to be talking about today.
+
+Speaker 3: 00:01:10
+
+I'm Jonas, I work at Blockstream in the research group.
+I work on various open source projects and also kind of try to bridge blockstreams to research to the academic side.
+
+Speaker 4: 00:01:26
+
+I'm Adam Jonas.
+Definitely not to be confused with Jonas Nick, who's the real Jonas.
+I'm also not Josie.
+I'm a much shorter version of Josie, and I apologize for those that came out to see him.
+I work at Chaincode.
+We do education programming.
+And yeah, happy to be here.
+
+Speaker 0: 00:01:52
+
+I'm Gloria.
+I'm a fellow at Brink.
+I work on Bitcoin Core.
+
+Speaker 1: 00:01:58
+
+Awesome thanks.
+So we've have and I'm Pablo I am not a Bitcoin Core contributor, so I think this is interesting because you are kind of fairly new, right?
+You've been around Core for a while, and you've maintained the SEC P256K1, right?
+So that's like the cryptographic part of Bitcoin.
+You do education and you've been a core, well, education with chain code, I mean.
+And you've been, how long Have you been a core contributor?
+
+Speaker 5: 00:02:35
+
+A year and a half.
+
+Speaker 1: 00:02:36
+
+Yeah, okay.
+So we have like a broad range of expertise.
+Fantastic.
+I thought that maybe we could start by discussing like different, have you guys observed different interests or reasons why people want to join as contributors like why different personas if you will of why people want to become a core or lightning developer?
+Maybe, Adam?
+
+Speaker 4: 00:03:05
+
+Sure.
+So I think, to sort of set the stage, I think there are three buckets that we think about when we're thinking about developers in general.
+So there's the open source bucket.
+And that can be anything from Bitcoin Core to Mempool Space or anything that's sort of open source that people don't need permission to contribute to.
+Then there's the industry piece, which is getting a job and actually working in the industry.
+And then there is the entrepreneurship piece.
+So I think people are motivated by different things.
+There are some people, I think we mostly see open source contributors coming from the Western world because they have the luxury of being able to take a break from their job or something like that.
+And in terms of participation in industry, that's also pretty relegated to the Western world.
+But I think we're hoping to change those things.
+But the motivation is very, I think people want to be involved with contributing to the new monetary system.
+So. Why did, I'm sorry, I'm not moderating, But why did you get involved, Gloria?
+
+Speaker 0: 00:04:19
+
+I think I share a personality trait with a lot of Bitcoiners, which is that I'm very ideologically oriented.
+So it was very important to me when I was looking for a job that I actually cared about what I was working on.
+But I think what really put the nail in the coffin for me in Bitcoin was it's fun on a day to day.
+It's just very interesting.
+It wasn't it didn't take very long after like cloning the Bitcoin core repo, where like every day I have two feelings.
+One is, oh my god, this is so beautiful, like this is everything I was learning about in school.
+And then the other feeling is, oh my god, this is disgusting, we need to fix this.
+I think that combination is a perfect nerd snipe.
+So, you know, when I wake up in the morning, I'm really excited to be working on it.
+And then when I go to bed, I'm like, that was an amazing day.
+So.
+
+Speaker 1: 00:05:25
+
+That's beautiful.
+Yeah, absolutely.
+And Do you guys see with these different persona, these different archetypes, is there a path to get there different?
+Or is it the same and it doesn't matter where you're headed and you just have to go through the same path?
+
+Speaker 4: 00:05:53
+
+Maybe Adam, I'm guessing that you are the most I don't want to do the most talking though yes, they're very different paths And I think we are trying to figure out what a more clear path would be.
+So I think we don't do a lot of teaching of code.
+Like in the very beginning, You sort of have to arrive in this ecosystem understanding what code is, because this is very complicated stuff.
+And so I have seen some educational initiatives try to teach coding through Bitcoin.
+I think you sort of muddle the message.
+And so for coming into open source, like you start with very scalable things like books.
+And then you start moving down the chain on moving into things that are more personalized, including like Blockstream internships and things like that.
+For the industry, the bar is a little bit lower.
+You just need to sort of prove or at least talk during your interview, prove that you can do the job.
+And then people hire you because they need you to build virtual stuff.
+So, yeah, I think there's two different paths.
+
+Speaker 1: 00:07:13
+
+Sounds like a fake it till you make it for the industry.
+That's the official advice.
+Okay, sounds good.
+Yeah, go ahead.
+
+Speaker 3: 00:07:26
+
+I would like to add one persona, which is, I hinted at it earlier, because I think it's also important and these are PhD students or postdocs who are doing research at universities, they're developing proof of concepts or also doing research on the things that we want to eventually develop.
+And there the path often is that as PhD students they have relatively short term incentives, writing papers and publishing papers and then heading over to the next project.
+And I think that's why they don't see the value of doing research on Bitcoin at first.
+They rather would like to explore separate systems.
+And what I've experienced is that over time, sometimes naturally, because they see, okay, there have been so many things, most of them haven't worked out Bitcoin is still there It might make a lot of sense if I focus my career more on Bitcoin.
+I think this is another path that is also relatively frequent in the academic world.
+
+Speaker 4: 00:08:42
+
+Do you think that when it comes to academia, Bitcoin has the stage that it should as in aren't other projects getting more attention and mindshare?
+
+Speaker 3: 00:09:00
+
+So the thing is that academics don't immediately see the problems that we are interested in as the research problems that they should spend their time on.
+Like, I remember being at a conference one time and a professor asked Peter Weller, why are you interested in these Schnorr signatures and not like fixing Bitcoin from the ground up as they perceived it by moving to proof of stake?
+Right.
+So that's just the thing that isn't really, I mean, back then it was three years ago, but I don't think it has changed much.
+I think it is changing, but still there's this general idea that Bitcoin is kind of...
+That's it.
+It's finalized.
+There are some people who do a lot of good research on layer 2s, but I think there's also a lot of potential in this space.
+
+Speaker 1: 00:09:57
+
+Is this the path you took?
+No. Out of curiosity.
+What are some general resources, like the main resources I'm looking at?
+
+Speaker 4: 00:10:13
+
+I want to pass that to Will, because Will is working on some of those resources.
+
+Speaker 2: 00:10:19
+
+Yeah, well, as Josie alluded to in his talk yesterday, Chaincode have a whole series of fantastic residency and remote learning seminars, which people can, aspiring developers can use to boost their knowledge.
+But currently there's still a little bit of a gap perhaps between completing one of these seminars and actually getting into the Bitcoin or some of these lightning implementation code bases and understanding how they all work because they're big.
+Some parts of them are pretty monolithic still and some things have been broken out.
+And it's just about teaching these new developers how all of these pieces fit together and then from there on you know where do you where do you start what should your first pull request be how do you get involved with the community and yeah we're trying to work on some resources now specifically to fill that gap between, you know, I know about Bitcoin the protocol, I've got some level of understanding and now I want to contribute, how do I go?
+So hopefully there'll be some more resources on that soon.
+
+## PR Review Club
+
+Speaker 4: 00:11:34
+
+I guess another piece would be the PR review club, which John runs.
+It's a weekly review club.
+It's on IRC.
+Everybody reviews the code, and then they show up in IRC and talk about it.
+And he's been doing it now for two years, two and a half years.
+He's taken, I think, two weeks off.
+So yeah, it's a very reliable thing to get involved.
+It's specifically Bitcoin Core.
+I don't see that popping up with other projects.
+I'm still waiting for the SecP256K1 PR Review Club.
+Good luck.
+Working on it, sounds like.
+
+Speaker 0: 00:12:15
+
+I recently found out that there's also a Bitcoin Core Dev Wiki, which is, I guess, not very well known.
+I would also show the Bitcoin OpTec newsletter, bitcoinops.org.
+And there's some excellent podcasts out there for learning technical materials, such as the Chain Code podcast.
+Brink has a Bitcoin development podcast that was just released.
+So, I'm just going to put that out there.
+
+Speaker 1: 00:12:47
+
+With regards to the PR review club, you said, how approachable is it?
+How far within the code, within how Bitcoin works, how far should you be to be able to go there and learn something?
+
+Speaker 0: 00:13:08
+
+Well, it's designed to be accessible for anyone, so beginners.
+Typically, we write the notes such that you can have very little background and there'll be links for resources that you can use and the questions that we go through we usually go from like surface level or conceptual like deeper and deeper.
+I think the biggest, like, the best part about the PR Review Club is it's supposed to be a safe space for anyone to ask questions.
+And there's always very experienced developers in the meeting to answer those questions.
+But nobody judges anyone for not knowing things.
+So to answer your question, you don't need any background.
+But doing your homework ahead of time helps.
+
+Speaker 2: 00:14:03
+
+I would say there's new people in there almost every single week.
+So, you know, that's, you're not going to be the only new person in there if you want to just jump right in.
+And people are super friendly.
+I highly, highly recommend it as well.
+
+Speaker 4: 00:14:15
+
+But don't expect to understand everything that's happening your first meeting.
+Because it's just an unrealistic bar.
+If you've I remember my first technical meetup, my first Bitnevs in New York City, and I just didn't understand nearly anything that they were saying.
+And it just takes time.
+It's like learning a new language.
+And so that fog of understanding will lift over time but you're gonna have to keep showing up you have to do the work so can you Can you guys talk a little bit about your experience, what you've seen, what are the...
+
+Speaker 1: 00:14:51
+
+You talked today about the hero's journey, right?
+It's a tough process, so you start with an idea and you find that it's really hard and intimidating.
+What are some of the characteristics of the people that get through to the end of that journey?
+Is there an end to that journey?
+
+Speaker 4: 00:15:11
+
+I mean, they're sitting on the stage.
+They're stubborn.
+They don't give up.
+Like, you just keep showing up.
+This is really hard.
+I mean, to imagine that you're just gonna learn this the first on first pass, like it's not realistic.
+So You just have to keep showing up and eventually the fog will lift.
+The hero's journey is that you get beaten down every time you learn something new.
+Then you get back up and you go back and take another shot.
+
+Speaker 3: 00:15:46
+
+Perhaps also important to note that the Bitcoin network is a huge thing with many, many different components.
+And perhaps it's not the greatest strategy to try to understand everything at the same time very deeply, but rather focus on very specific aspects and then go deeper and deeper on that side and then broaden your things.
+But Bitcoin, even Bitcoin Core, that's such a big thing, it's so specialized already that very few people, I would say, understand most of it.
+
+Speaker 4: 00:16:28
+
+So let curiosity be your guide, like find what's something that's interesting that you can dig into and that will motivate you to come back tomorrow.
+And so yeah, you just, I think that's really good advice.
+Or, you know, in talking with Will and Gloria going through this process, like, you know, Gloria was coming out of school and had been working with C++, but you sort of have to relearn C++ or at least learn Bitcoin Core C++ in order to be, you know, a valuable contributor.
+And so you just have to chip away at it from a lot of different angles.
+She was reading, let me show Gloria for a second.
+So, you asked about a characteristic of someone who ends up getting through their hero's journey.
+And I met Gloria about two years, almost three years ago now.
+And when she decided that she was going to be a Bitcoin Core contributor, it was just before the summer had started.
+And she had gotten an internship at Google.
+So she's working on an open source project at Google.
+That's the pinnacle of a college senior Like that's that's what everybody's going for but she really wanted to work on Bitcoin core So she would wake up at 5 o'clock in the morning put in her, you know hours her her four hours or whatever it might be, and then do her regular day job, and then put in more time on Bitcoin Core, and then go to sleep, wake up, and do the same thing.
+And she'd do it on the weekends and she just wouldn't stop and you see someone with that kind of engine and you just know eventually, they're just gonna figure it out and She did and we're glad to have her we're lucky to have her and but that's what it takes It takes someone with an engine.
+
+Speaker 1: 00:18:20
+
+That's beautiful.
+What could you guys say is the success rate, I guess?
+Like people that start and show some proof of work, like they not just show up once on IRC, but they start for real and they actually complete.
+Like, whatever, how are you define complete?
+Whoever wants to jump on it.
+So that's a zero, okay.
+
+Speaker 4: 00:18:57
+
+All right, next question.
+I don't know how you measure that.
+I don't know what starting and completing looks like.
+You know, I think that this is a journey that never stops.
+I've been working with John now for three years and he's still at it.
+You're a Bitcoin Core contributor.
+You're a SECP256K contributor.
+The learning never stops.
+And that's the awesome part about all of this.
+Like you just, I mean I work with Peter Wella, like he never stops.
+It's, it's, it doesn't end And the people who are the most valuable continue to be curious about this space and continue to find problems to solve.
+And watching someone like Peter, he needs an entire team to just do the stuff that's in his head.
+And you know, I think it, that's what's so great about this, as in you will not get bored ever.
+But there's no end.
+And the start is you just decide that you're going to do it.
+And sometimes life gets in the way.
+Sometimes you're going to have your job's going to get busy, or your friend is going to need you to work on a startup and people take a break.
+But the people that end up coming out on the other side always come back.
+
+Speaker 3: 00:20:29
+
+The failure rate in terms of people who start in Bitcoin and then move to shitcoins at least is relatively low.
+Most of the time it's the other way around.
+I think that's a positive note.
+
+Speaker 1: 00:20:41
+
+Is that so?
+Is that developers that were on shitcoins coming into Bitcoin?
+
+Speaker 3: 00:20:47
+
+It happens, I guess, at least in my experience more often than from Bitcoin to shit coins.
+They're more flexible.
+
+Speaker 1: 00:20:57
+
+Is there any ritual for like repent or something like that?
+
+Speaker 3: 00:21:03
+
+I don't know.
+You don't look in the history of people, right?
+
+Speaker 1: 00:21:06
+
+Too much.
+If you dig too deep, you will always find dirt.
+Actually, this is a good jumping board.
+It's one of the last questions that I had, but I think this is a good segue.
+How do you guys feel and what would you recommend for taking in context what has happened with some guy that claims to be Satoshi and some lawsuits.
+What would you recommend with regards to protecting yourself as an individual?
+What are your thoughts with that?
+
+Speaker 2: 00:21:46
+
+I mean we're talking about being a pseudonymous developer right.
+I mean there's definitely some issues with that.
+I think for me personally it seems like a no-brainer that you probably should try to protect your identity.
+I mean those lawsuits you're talking about are particularly nasty.
+But Bitcoin and Lightning, I guess, development, as I see it, should be a meritocracy anyway.
+Who you are and what you've done before shouldn't necessarily impact whether your changes are going to likely to be merged.
+And I think that lends itself quite well to being sued anonymous or fully anonymous.
+Obviously there is a few problems with that too.
+Possibly it's more difficult to get funding or, you know, are you going to be able to get a job at another company without them knowing your details?
+That's tough.
+But some people have started to get some funding and things like that.
+So I think it is possible.
+And if more people did it, then I think that would be a good thing for me as well.
+
+Speaker 4: 00:22:56
+
+Yeah, I think it's a one-way door, right?
+So you can always start as a pseudonymous name.
+And you don't have to be you know some cat picture you could be what would be a normal name and so yeah just you can sign up for a get up account under John Smith and that works just fine So trying to think you know you can always go back like you can always go through that door if you choose to reveal who you are and I think when it comes to funding it is getting better but to work for a company like a US company they're gonna need to know who you are like that's how it goes We're not quite at a point where, you know, you just sort of ship a salary to a Bitcoin address.
+So I think it's worth trying if you're establishing yourself, because you can just walk through that door later if you choose to.
+
+Speaker 6: 00:23:55
+
+Awesome.
+
+Speaker 1: 00:23:58
+
+You've mentioned that Bitcoin core is really big.
+There are a bunch of different aspects and you don't have to know all the nuances of the mempool and everything that happens.
+So what areas of Bitcoin and of Lightning Do you guys think that companies that are hiring in this space are most interested in?
+
+Speaker 2: 00:24:25
+
+I'm not sure about that, but I did have some other thoughts that it's one of the things I would like to see is more Bitcoin first companies, you know, getting some of their developers to use part or full time improving the parts that they're interested in.
+So I don't know what they are, but you know, I think that's something that could be could be worked on.
+
+Speaker 3: 00:24:49
+
+At Blockstream I think we're interested in all the various parts that you could think of.
+Of course the first step would be someone who's really familiar with just using a wallet.
+Then there is this kind of ritual that many Bitcoin devs go through.
+You build your own wallet.
+Many people do that in various kinds.
+Some people do a wallet on some kind of obscure architecture, others build a VR wallet.
+So many people go through that.
+I think what else would perhaps other essential skills perhaps is that you just know how to at Blockstream, I would say is like the fundamentals of how does proof of work work, how could I create a transaction.
+Perhaps not so important like knowing it in detail how it works, but just look, know how to look it up.
+Also know how to look it up in the code where to search for Bitcoin core is often the reference for many things.
+Yeah, I think those are the most important things.
+
+Speaker 4: 00:25:59
+
+I think What mostly people are hiring for is people who work on wallets, people who work on trade engines and now there's like a growing economy of lightning app developers.
+But it's not a big pool of people that really understand lightning and understand how to build on top of it.
+So I think we need to sort of address what the, try to fill that funnel with more people.
+But overall, there's a lot to build.
+And people, companies are impatient, and they need to fill roles.
+And so the bar is, I think, a little lower than it should be, which is our job to attract more people, give them the training they need, and then deliver them at the doorsteps of the companies to make them easy hires.
+
+Speaker 0: 00:26:44
+
+I'm Not a company.
+It would be nice if more people come to work on Mempool.
+
+Speaker 1: 00:26:53
+
+Maybe you should do an enticing talk about it.
+Do you guys think that, because Lightning has some very distinctive properties, right?
+So we had a bunch of talks about liquidity management.
+Do you guys think that that's going to be a field that companies are going to be particularly interested in and how should developers think about it?
+
+Speaker 3: 00:27:20
+
+I think companies are interested in it.
+I think there will be a lot of specialization in this area as well because it's not that easy to do.
+It should be easy for normal people to do, liquidity management as well.
+So I think this is certainly also a very interesting and growing area and we're just at the start of this whole thing I think.
+That as far as lightning network, liquidity, routing, these things go, we're just at the start, right?
+
+Speaker 1: 00:27:56
+
+Going back to what we were talking before, what would you guys say is the most common stumbling block?
+Like, where do people get stuck?
+
+Speaker 4: 00:28:09
+
+People get stuck everywhere, because life gets in the way, and it's hard, and you feel dumb.
+Like, honestly, that's the biggest.
+If I had to make one place where people get hung up, it's that they feel dumb in front of a group and they're not willing to go through that pain.
+And so, Yeah, I think we need to do I think the PR review club is a good example.
+Like creating places where people can feel dumb together.
+And that's okay.
+And you sit up and you share a stage with, you know, a guy who's been doing this for a while and, like, understands cryptography, actually.
+And you feel dumb.
+I just sat through the federated Jami and E-cash, and I was like, I need to really learn what this is.
+So it takes some humility to be able to get through that process.
+And again, you just got to keep showing up and have faith that eventually you'll get it.
+Again, I feel like it's very similar to just learning a foreign language.
+I learned a foreign language as an adult in a different country, a different culture, and you feel dumb.
+And over time, you start understanding the vocabulary, and then you start understanding some of the context when people say idioms, and then you can actually, like, you wake up one day and someone tells a joke in that language and you get it.
+And you know, then you realize that it's just a matter of time.
+
+Speaker 3: 00:29:42
+
+You will, however, always feel dumb most of the time compared to other people and you will always have imposter syndrome.
+I mean, it's not me or anything, but many people report that who have been in the space for a long time and are actually very good developers.
+I think you just have to live with it and accept the fact that this exists.
+
+Speaker 1: 00:30:03
+
+Okay, so if you say that there is no hope for the rest of us, right?
+
+Speaker 3: 00:30:08
+
+No hope.
+That's not what I'm saying.
+I'm not saying, I'm just saying that it's not that you wake up the next day and suddenly you think, oh, I'm the best or anything and I'm the best developer and I understand everything about this particular protocol and I'm the only one and the only expert.
+This will never happen.
+There will always be people where you think that they know more about this than you do.
+
+Speaker 4: 00:30:33
+
+Yeah, I think you and you want people that have that humility working on this project because otherwise people get cocky and they make mistakes and you know you look around at the rest of you know you look around at other projects I'll say and people get cocky and stuff's gonna break and if you aren't sort of checking your own mistakes and having humility to think that you don't know everything, then you're not doing the best work.
+
+Speaker 2: 00:31:02
+
+I mean, I think one of the other areas is where do you start?
+What do you do as your first move?
+How do you get over the starting line?
+And definitely one, not the only way, but one good way to do this, which also happens to be one of the main bottlenecks in a lot of these projects, is get involved with reviewing pull requests.
+
+## Reviewing Pull Requests
+
+Speaker 2: 00:31:21
+
+Developers, I think, often have this desire to create new code, you want to write new features and get your satisfaction from implementing something, but you can learn a lot from doing reviews.
+You often gain a little bit of context into that specific area.
+Why are these changes being made?
+Why was it originally like this and why are we changing it?
+That burden of review is often cited as a sort of blocker for those experienced people to get on with doing what they want to do.
+And I just think it's a really good way to learn.
+
+Speaker 1: 00:32:00
+
+So basically, I just heard of Bitcoin, I'm here to fix it.
+Getting over there, right?
+Okay.
+So we've been talking a lot about how hard it is, how painful it is, how humbling it is.
+What can developers that are thinking about starting or have started they are in the midst of it what can they keep in their mind as their guiding star what what should they keep in mind you got it sorry You got it, Zorja.
+
+Speaker 0: 00:32:42
+
+I think you should answer this question.
+
+Speaker 3: 00:32:48
+
+I don't have a good answer to this question because I don't have anything in particular in mind when doing this.
+Perhaps one thing I have in mind is the long-term look that I mentioned, the long-term outlook on this thing.
+This is going to be around for a long time so it makes sense to invest your time in it and it changes people's lives.
+Perhaps not directly, it's a very indirect way of course to influence things but I think the chances are good that it works.
+
+Speaker 2: 00:33:24
+
+Yeah.
+Yeah, and I think coming back to what Jonah said earlier, you know, most Bitcoiners I talk to are just super interested in Bitcoin.
+Personally, they want to think about it all the time.
+You're weaving it into conversation.
+You want to work on it.
+I don't know, perhaps if you've got a desire to keep learning about it continuously then I think it'll be good.
+Like Jonah says, keep putting the work in, and you'll get there.
+
+Speaker 0: 00:33:54
+
+OK.
+I think it's about imagining the type of world that you want to live in and recognizing that it's not going to happen unless you make it happen.
+I want to live in a world where anyone can pay anyone.
+Where big banks and companies and governments cannot just arbitrarily censor people.
+Want to live in a world where when you like something that someone creates, you pay them directly with money instead of waiting for an intermediary to come in and seek rent from both of you.
+Like, I don't know, I'm not, we don't want to wait for someone to build that for us.
+
+Speaker 3: 00:34:42
+
+Perhaps another guiding principle now that I'm just thinking about it.
+At some point you will take responsibility and especially in or for example in the open source world that and also in the job of course it means doing a lot of things in your spare time for example that you probably don't want to do.
+So that's, I think, one of the key things that many developers are also really, really driven by is just the sense of duty, right?
+Because that's their part of the code, they want to improve it, they see other people's pull requests, they need to review it.
+There are a lot of things that when you start working in this space and you have this kind of idealistic outlook, perhaps, that you really want to make this work and you get this sense of duty?
+
+Speaker 4: 00:35:40
+
+I think, I mean, why did we all fly down here?
+Like, this isn't convenient to be here.
+And yet, we're all here because it's meaningful and it's impactful and we want to make big change.
+And so, the ability to contribute to that as a builder, like, is there anything better than that on the planet?
+Like is there anything to wake you to just the way that Gloria described where she wakes up every day excited to go to work and goes to sleep every day feeling like she had a meaningful day?
+Like what else could you ask for?
+
+Speaker 1: 00:36:26
+
+How do you guys think, I'm guessing most of you like myself, get like a bunch of spam from recruiters with horrible pitches.
+How do you guys think that companies in this space should, or that want to launch a project in this space, should approach developers in a way that is meaningful for them.
+
+Speaker 3: 00:36:55
+
+The Blockstream approach to this apparently is, which is apparently working, which is apparently working, which is to build this kind of image of being a cypherpunk company that is really, whose future is completely aligned with Bitcoin's future.
+And also who's investing a lot in open source projects.
+And that on the other hand attracts a lot of people who start contributing in their spare time or who see Blockstream as something that they would want to work at.
+I think this is something that really helps Blockstream right now to get applicants for the job postings?
+
+Speaker 4: 00:37:54
+
+So I actually do quite a bit of recruiting, but it's mostly for open source developers.
+Not to necessarily work at Chaincode, but just to work on the project or I think the project Bitcoin core related technology protocol stuff and so the way I reach out is mostly because someone has already shown interest As in someone has already made the first move, and you just offer help.
+Like, how can we be helpful?
+Now, chain code is a little bit different, and I think a little bit unique.
+But something I've started to do when recruiters send me emails is I take the call and then one of the first questions I ask is like what are you doing for the ecosystem?
+And I've had some actually some meaningful conversations with recruiters trying to help them understand that their approach is a waste of their time if they're actually looking for the kind of people that they want to hire and if they went about it in a way where they actually were helping the ecosystem as opposed to trying to extract from the ecosystem that they'd be more successful.
+So if you're a company and you have a budget for recruiting, you probably have a budget to work on open source or something like that.
+So take your marketing budget and put it towards something that will actually make things better, please.
+
+Speaker 1: 00:39:26
+
+One of the things that I think are very, very different is I've done a lot of open source development myself and I've worked for companies and the the way open source development works it's very different than how working in a company feels like and how the approach to everything is like.
+Can you guys talk a little bit about how someone that has worked within four companies their whole life, what to expect going into open source development?
+
+## What To Expect Going into Open Source Development
+
+Speaker 4: 00:40:17
+
+It's different in that oftentimes no one's telling you what to do.
+So that's the big change is when you work for a company, there's a hierarchy and a structure.
+You get orders from on high, business makes decisions, and then that gets filtered down through layers, and eventually it reaches the front line developer who's told it's broken up into smaller features, and they go and implement it.
+People who work in open source scratch their own itch.
+And oftentimes, there's not that kind of coordination.
+And so you go after the things that are important to you.
+You go after the things that are meaningful to you, and that can feel very scary when no one's telling you what to do because you don't know what to do.
+And so I think we actually have examples of people working in open source and deciding that they wanted to go work in a company because they didn't feel comfortable in that murkiness of feeling like they were productive.
+You know, there's no...
+The shipper's high that you get from shipping a feature and, you know, the CTO celebrating that with you, you don't really feel that in the same sort of way.
+And so it may not, Open source may not be right for you.
+That's OK.
+You can still contribute to the space in meaningful ways.
+But you may not like taking orders, too.
+And so maybe open source is a better fit for you.
+I think it comes down to your personality and comes down to your mindset.
+
+Speaker 1: 00:42:03
+
+I thought about leaving some time for questions from the audience.
+So if you guys want to talk about something before we open for questions, something we didn't touch on.
+Yeah, good.
+We don't have any more mics, right?
+
+Speaker 3: 00:42:22
+
+No.
+
+Speaker 7: 00:42:29
+
+Hello.
+Awesome panel.
+Okay.
+Two questions.
+One is for the whole group.
+What are some good milestones that people can aim for when they're onboarding both early ones and later milestones?
+
+Speaker 0: 00:42:52
+
+For me it was the day when I was wondering how something worked in Bitcoin, and instead of going on Stack Exchange or Googling, I just look for it in the code.
+And after hitting that, it's just like full speed ahead, because you never need anyone to learn.
+
+Speaker 8: 00:43:21
+
+So you talk about the hero's journey and you folks are all, you've taken the hero's journey.
+I mean, I see it and I know it.
+What about for normal people?
+You know, like, you focused on, and I'm glad you're doing it, I'm glad you're cultivating those heroes, I'm so glad you are.
+But there's a whole lot of other folks who are not going to be able to take that journey because of where they are in life, because of whatever, but we need them.
+And I don't know whether it's, I don't know whether it's like maybe we're just not the product, the ecosystem is not mature enough yet to be able to take advantage of the normal folks or is it that we need to pivot the ecosystem to make it be more accessible and so we can use us normal folks.
+Does that make sense?
+
+Speaker 4: 00:44:25
+
+That's a great question.
+Noel, go ahead.
+
+Speaker 2: 00:44:27
+
+Yeah, I mean, I think certainly for Bitcoin Core and some of the other projects, there is a bit of a, I think it's a misconception that it's all super technical and you need to be incredibly specialized and incredibly good at something to contribute, but it's not the case.
+You know, there's a ton of, there's a ton of work that needs to be done that doesn't require you to be a cryptography expert or a mempool expert.
+So I think there's stuff for everyone to jump into, really, and it's just about getting a journey started and getting involved.
+
+Speaker 4: 00:45:06
+
+Everyone's a hero.
+I don't, like, I can't, I mean, I can't code for beans.
+Like, I am not good at developing.
+And so I've chosen a different path because that's how I can contribute.
+And so you have to find what you're good at and what you're excited about and how you can position yourself to make meaningful contributions.
+And there is no hero here.
+I mean, these people are heroes.
+But I promise you, I'm no hero.
+And so How do you take advantage of that?
+You find a way that you're excited about to contribute.
+That's it.
+I'm happy to talk to you about who you are and how do you contribute.
+
+Speaker 8: 00:46:02
+
+I'm not just thinking about myself, but I'm using myself as an example.
+I mean, there are folks out there that we need that are never going to get passionate, right?
+
+Speaker 4: 00:46:13
+
+I mean, we've got...
+Oh, yeah.
+I don't want those people.
+
+Speaker 8: 00:46:16
+
+But we need them.
+
+Speaker 4: 00:46:17
+
+No, no, no.
+No, I don't think we do.
+I really disagree with you.
+I think what's exciting about my wife is calling me a lot right now.
+I'm sorry.
+I think what's exciting about this space is that we just flew thousands of miles to come to a country because they made a Bitcoin law.
+Like, that's what we need.
+Because one of those people can do 10 times the work of someone who's just clocking in.
+And so, yeah, you don't need to be a hero, you just need to be excited and you really do the work.
+
+Speaker 8: 00:46:50
+
+Are you saying that because that's where we are right now in the ecosystem, in the environment?
+Because I mean, I'm just thinking...
+
+Speaker 4: 00:46:59
+
+No I think if you take someone who, if you compromise on that, then you dilute what you're doing.
+You dilute why you're doing it.
+And it's okay.
+You can dilute it to a certain extent.
+If you're building a big company, and that's your goal is to build a big company, That's different than building a company to push Bitcoin and Lightning forward.
+And so if you're doing that, then you need to find people who care about what you're doing.
+
+Speaker 8: 00:47:27
+
+But I mean, like, I'm again thinking like traditional banking system, right?
+I mean, way back when, at some point in time, somebody was really passionate about fractional reserve banking, and they went crazy, and now it's normal, and thousands of people go to JPMorgan Chase every day and work on whatever they work on.
+I mean, don't we want Bitcoin to be like that where it's just normal?
+It's normal and that keeps it going?
+
+Speaker 4: 00:47:55
+
+I don't.
+It's OK.
+I think it's OK to want that, but I don't want that, because I don't want to work with people who aren't excited.
+I don't want to work with people who clock in.
+That's not, by the time Bitcoin gets there, hopefully nobody has to work on the planet at all.
+We've figured out how to have a society where you have so much surplus, you don't need to work.
+But like, that's not meaningful.
+That doesn't bring meaning to your life if you don't care about what you do.
+
+Speaker 8: 00:48:25
+
+No, I mean, no.
+You can have other things that you find meaningful in life and a job is a way, is a means to get income for you to do the meaningful thing in your life.
+And there's nothing wrong with that.
+I mean, that's not me.
+But there's nothing wrong with those people.
+We need those people to do the dredge work, whatever, to integrate it in with the cash registers, whatever.
+We need those people.
+I mean, that's.
+
+Speaker 4: 00:48:53
+
+I just disagree.
+It's OK.
+
+Speaker 7: 00:48:58
+
+Can I ask my second question now?
+Second question is, how can someone who didn't do a PhD get involved with the research side?
+
+Speaker 3: 00:49:12
+
+I don't have a PhD and I'm on the research side.
+How does it work?
+How did it work was basically working with the right people, right?
+You need to be in the right group and you need to learn from people.
+You need to find someone who is willing to teach you, who is willing to spend time with you.
+You need to be willing to learn and then it just takes time.
+But really, I learned all the things from other people, right, who really took in the time to do that, who knew more in this specific area than than I did.
+And especially in the field of cryptography, I didn't have the formal training that other people do, for example, to do stuff like music.
+But somehow, I was able to pick it up just from other people who were willing to teach me.
+
+Speaker 9: 00:50:09
+
+So you've been talking about onboarding.
+You obviously all care about getting more more developers into the Bitcoin and Lightning ecosystem.
+So I'd be curious for the four of you, what does success look like in two or three years time?
+What does the Bitcoin and Lightning developer ecosystem look like?
+
+Speaker 1: 00:50:28
+
+It's okay.
+
+Speaker 5: 00:50:31
+
+It's okay.
+
+Speaker 4: 00:50:45
+
+I don't have a snappy answer.
+I think we are at a point where we are just so desperately looking for people that are willing to do the work that it's, it consumes me.
+In two to three years time, I hope that, and it is happening, I think you find people who are attracted to this kind of work and they start doing it themselves.
+But success looks like that the community has taken this over and there's a flywheel effect where people who go through and someone helps them, they then help the next group and that group gets larger and larger.
+And so in success in two to three years looks like there's just a big base of teachers and mentors and a whole like decentralized onboarding path for your local community or your, you know, wherever you are, that we have filled enough gaps where We are providing Clear paths for people to onboard into this ecosystem Just to add to that I think we don't only want people who are super motivated, great developers, etc.
+
+Speaker 3: 00:52:27
+
+We also want people who are philosophically aligned.
+And I think for success this is also very important that we are able to teach the values of Bitcoin, permissionless, decentralized money for everyone, to the next generation of developers as well.
+
+Speaker 4: 00:52:49
+
+That's a better answer.
+
+Speaker 5: 00:52:52
+
+I have a question.
+Well, a suggestion first, and then I guess a question.
+I'm coming from another open source project.
+I'm into web development.
+I've been in the Drupal content management ecosystem.
+I've been there through the years and seen the transformation that's done in that project.
+One of The most important things I saw happen was one year they decided to work on what they called developer experience.
+It's how to get people to work on Drupal core and get more people from off the street, so to speak, working on it.
+One thing that they did for the PRs and the patches that we call them to core what they did they assigned them with difficulty right so so it allowed newbies to come in and say okay I'm seeing a bunch of PRs here which ones I guess are within the range of my my ability and and that helped a whole lot because it allowed people to come in and say okay I can perhaps start on these smaller ones first right so and I think it kind of adds to his point where it, it creates stair steps for, for people who are not necessarily passionate because I think passion can begin in two ways.
+There are people who come in passionate.
+You, you, you, you, you, you grew up around computers or something and you just have passion for things technical.
+Then the other people who learn passion, you do something and you realize it works, and then you do something else and you realize it works, and You kind of step up the stairs until you're really passionate about something.
+So I think improving the developer experience by creating those stair steps for new developers to come in.
+Because I was really interested in Bitcoin.
+I mean, I'm the type of guy who comes in with high passion, right?
+But even coming in with high passion, I was trying to figure out so how do I get started.
+I asked person like what what projects are there I need to get worked and I was asking on Twitter asking people and people were like well I don't know just just kind of get started right And it was kind of difficult for me, because I wanted to know what projects needed help, you know, as a newbie, where could I go and get started?
+And it was kind of difficult.
+So working on a kind of stair-stepped method to get into developer experiences is perhaps something that you can work on for the future to make it easier for people to onboard as developers.
+Secondly, just again from the Drupal ecosystem, the companies that are, you know, running Drupal in their businesses, they also contribute to the community.
+So there are a lot of bounties and things that allow people to have motivation to work on these projects.
+I'm in the Caribbean, and most of the guys around me, they're not going to work on open source projects because a lot of them just want to get food.
+The priority, they don't have the free time to go on to work and stuff right and and you just want something so you can pay your bills and whatever and after you start making good money as a developer or whatever Then you have the spare time to start working on open source projects and so on.
+But if there are bounties, bounties could be a thousand sats.
+It is just a kind of motivation to allow people to get started.
+And then there might be bigger problems with the larger bounty.
+So companies who are working and benefiting Blockstream or whoever, could perhaps set bounties on different issues.
+And tell the developer community about these issues and how they're more accountable.
+So, just two suggestions I have.
+
+Speaker 6: 00:56:49
+
+Can I maybe add to that real briefly?
+So, I wanted to pick up one of my neighbors and what they're saying about the heroes and stuff.
+And I read, onboarding Bitcoin and Lightning developers, not Bitcoin Core developers.
+And I think it's pretty dangerous to idolize the Bitcoin core and lightning and all the super hard things because there's so many super small projects where one or two people are working on and I think there does the people that work in those projects would be way more passionate to teach new people to work with them on their very small projects.
+And they're usually way lower barrier to entry.
+And I think it would be really great if there's more resources for people to find those small, smaller projects and not want to work on core or want to work on lightning.
+Because those projects are freaking hard.
+And most developers will never work on them or don't have to work on them because it's hard.
+So maybe like a mailing list or a newsletter where smaller projects can announce new things that they built or something like that where then you can look at, Yeah, smaller projects, web projects, point of sale projects, hardware projects, like smaller things.
+Lower barrier of entry.
+
+Speaker 0: 00:58:06
+
+Some of us have a personality trait where when we see something that's not quite right, there's a typo or something, We're like, I wish I could open a PR to fix that.
+Like a broken lamp or something.
+If you have this personality trait, pretty much everything in Bitcoin is open or, you know, there's a lot of open source Bitcoin projects and a lot of them are like Stephen said not Bitcoin core like not going to cause Bitcoin network to die if you make a mistake so if you have this personality trait I think you'll be surprised by how many places are welcoming contributions.
+
+Speaker 1: 00:58:56
+
+Okay.
+I think that's time.
+So if we don't have any more questions, We'll wrap it up.
+All right.
+Thanks guys.
+
+Speaker 0: 00:59:15
+
+You

--- a/adopting-bitcoin/2022/how-to-get-started-contributing-sustainably-to-bitcoin-core.md
+++ b/adopting-bitcoin/2022/how-to-get-started-contributing-sustainably-to-bitcoin-core.md
@@ -1,0 +1,620 @@
+---
+title: "How to get started contributing sustainably to Bitcoin Core"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://www.youtube.com/watch?v=Bduon80-4CE
+tags: ['bitcoin-core']
+speakers: ['Jon Atack', 'Stephan Livera']
+categories: ['conference']
+date: 2022-11-16
+---
+Speaker 0: 00:00:00
+
+Now we are going to have a panel conversation a kind of side fireside chat between Stephan Livera and John Atack and Name is how to get started contributing Sustainably to Bitcoin core so if you are a deaf and are looking to start to contribute to Bitcoin Core, this is your talk.
+
+Speaker 1: 00:00:32
+
+Okay, so thank you for having us and thank you for joining us.
+Joining me today is John Atack.
+He is a Bitcoin Core developer, contributor.
+He started about two or three years ago, roughly?
+
+Speaker 2: 00:00:47
+
+March 2019.
+Hello, everybody.
+Good to see you.
+Three and a half years now already, time goes fast.
+Yeah, right.
+We haven't seen each other since three years at the Lightning Conf in Berlin.
+October 2019.
+Yeah, we met and at that point I'd been working on Bitcoin Core since seven months.
+
+Speaker 1: 00:01:06
+
+So let's get into this today, we're gonna chat a little bit about your journey and offer some insights for people here or anyone on the stream if they are thinking about what it's like being a Bitcoin core contributor and if they want to get involved how they would do this.
+So maybe just tell us a little bit about your motivation, like why did you want to go down this pathway?
+
+Speaker 2: 00:01:27
+
+That's a great question.
+So I'd have been aware of Bitcoin since several years before I began and I had in the back of my mind the goal to that someday I would Stop taking freelance missions.
+I was a freelance software developer working for large corporations saving their ass on missions that they were in trouble with and The whole time I was thinking okay.
+I'm saving up money I'm stacking and I'm someday I'm gonna quit this and I'm going to work on Bitcoin.
+It was an idea I had a long time years beforehand and You know you something something has to happen to kind of kick you in the rear and to kick-start you into doing it and That's something for me was totally unplanned.
+It was end of February 2019 on Twitter I saw chain code labs saying last minute to apply for the summer residency at chain code labs this summer.
+In 2019, chain code labs did a very large residency program.
+It was very ambitious And at the last minute, I think 20 minutes before midnight when the applications closed, I submitted a proposal to join the seminar as a residence.
+I was not accepted.
+But this is where the story becomes interesting.
+They did take me for a first round interview.
+They said, okay, we don't know who you are.
+You haven't done anything in the space yet, but we encourage you to try and to apply later, maybe to the next residency.
+I thought, okay.
+Two weeks went by and then finally I thought, nah, I'm just gonna start now.
+And I started trying to contribute on my own, I would say half time.
+And two weeks after that, I got a call from Chainflow Labs saying, Ah, you're active on Bitcoin Core and it's interesting.
+Would you like a phone call with John Newberry to mentor you?" I said, sure.
+And we did a phone call and I was like, whoa, this is ambitious.
+He's setting the bar like up there.
+So I just kept doing what I could and I was not in the residency, but one week before the program began, Chaincode Labs called again and said, okay, you've been doing this since March and now we're late May, why don't you, would you like to come to New York?
+And so I did end up going to Chaincode Labs, even though they said no.
+
+Speaker 1: 00:03:49
+
+That's a great story.
+And I think what has happened over time, because I know part of your story is that you were working unpaid, right?
+You were doing this just because you believed in it.
+And so then there was also a journey of trying to get sponsorship or grant money or funding to sustain yourself.
+So could you explain a little bit about that process?
+Because I think listeners will be interested.
+
+Speaker 2: 00:04:17
+
+Right, so basically when I began in 2019 it was brutal.
+It was the bottom of the bear market, the previous bear market, and at that time none of the currently existing funding structures were in place.
+Your only options were to be hired by Blockstream or Chaincode Labs.
+
+Speaker 1: 00:04:40
+
+MIT DCI maybe.
+
+Speaker 2: 00:04:41
+
+Yeah, but they didn't have these grants that are very prevalent now and the situation is much better now, much easier.
+Really, you need to show proof of work.
+You need to show up and humbly, you gotta stay humble.
+You're gonna learn a lot, you're gonna fall down a lot, and you need to try to add value while respecting other people's time and being humble about it, you're gonna make lots of mistakes.
+There's so much accumulated context and experience that the long-term contributors have that a newcomer will not, but that doesn't mean you can't provide value if you're careful about it and thoughtful and take the time.
+So yeah, it took me literally back then one year to be funded.
+Thank you to Jack Dorsey who created Square Crypto, now since renamed Spiral.
+I didn't actually do anything to get a grant.
+I was just, you're just showing proof of work and you, after a while people will push grantees to, I mean I suppose nowadays you can apply for grants with a project But I never had a project My only project was to review and to contribute and to fix things that I saw my project I never had a project dropped into my lap like hey I'm going to implement this I'm going to do fed admin, or I'm going to do you know pay join or or Join market or whatever or bit 324 implementation or bit 155 implementation.
+I never had anything like that.
+All I did was review and basically do the things that no one else perhaps wanted to do, but that needed to be done, like reviewing and testing and fixing things.
+And after a while, that worked.
+It took me a long time.
+It was pretty hard.
+
+Speaker 1: 00:06:24
+
+So for the layman audience who don't understand perhaps the nuances of software development and Bitcoin Core, Can you explain the difference between writing a pull request, making some new code for Bitcoin Core and doing that other role that you was mentioning, the review, the testing?
+
+Speaker 2: 00:06:41
+
+Right, I think that gets back to what does a Bitcoin Core developer do and I think it doesn't correspond to the image that most people have of what we're actually doing.
+I would say most of the time what we're doing is reading code, reading other people's ideas and thinking and maybe testing and reviewing.
+In my case, There's very little coding.
+I was a full-time software engineer from Quite a long time before Or you basically you just churn out the code and check off the boxes as fast as you can during your current sprint before the next sprint starts Bitcoin core is is different.
+It's more you have to be more patient you have to There's more thinking going on and nuance and things don't always go quickly.
+It depends on what it is.
+So I would say the most important role in Bitcoin Core and what is most lacking is review and testing.
+It's not coding and also spending time thinking through what other people are saying, testing, verifying.
+Okay, maybe they're right.
+Maybe they're wrong.
+You need to come to these conclusions and pretty much you do it on your own.
+Well I've always worked alone.
+Some people work in large organizations, you know, some people work at Spiral, some people work at Chaincode, some people work at Blockstream.
+But even Blockstream, they only support one Bitcoin core developer, Andrew Chow, and I believe he works mostly alone unless you travel into an office.
+So a lot of it is just alone time with a code, reading things, reading the mailing list, coming to your conclusions.
+
+Speaker 1: 00:08:17
+
+So going on from that, I think it's also the, okay, so could you maybe outline as an example like somebody, like where some of the discussion takes place and then where the interaction back and forth like with other developers happens?
+
+Speaker 2: 00:08:41
+
+Well the interaction happens either on the Bitcoin Core Dev IRC channel or on the pull request on GitHub, generally, and occasionally on the mailing list.
+Those are the three areas where there's, yeah.
+Another thing that core developers do is educate.
+They don't only work on Bitcoin Core, they might review and help write for, say, Bitcoin Optics Weekly Newsletter.
+I did that for two years.
+I see Murch is in the room.
+He's currently on the Bitcoin Optics team.
+They also perhaps help run the Bitcoin Core PR Review Club, which I also did for two years.
+These are Annex activities that many core developers do in addition to working only on Bitcoin Core.
+
+Speaker 1: 00:09:24
+
+One other area that I think is interesting, and I know you mentioned this to me offline.
+So with Bitcoin Core, as I understand, most of the code is in C++ and a lot of the testing is in Python.
+But you mentioned that you actually had to learn this as part of your process.
+
+Speaker 2: 00:09:42
+
+Can you elaborate a bit?
+Correct.
+So Satoshi Nakamoto wrote in C++ And the functional test suite is in Python.
+Now, before I'd arrived, I had not coded in either one.
+I'd had C back in my college days.
+But My personal work experience was we're in completely different languages.
+Assembly and web development in Ruby and Ruby on Rails, for example.
+So, yeah, but if I can do it, I think anyone can.
+I arrived and I taught myself C++ while doing it.
+Python came quickly because it's similar to Ruby.
+But yeah, it's not impossible for you to show up and to learn these two languages and become a core developer if that is your goal.
+Note that there isn't just Bitcoin core and I think that's important to underline.
+There are many other valuable projects in the space besides Bitcoin core There are wallets miners lightning implementations lightning development specification bolts dips There are many super valuable projects It doesn't have to be Bitcoin core and even it doesn't have to be open source You could work on closed source.
+There's lots of jobs out there now for Bitcoin Developers and it doesn't just have to be a developer You could also find a place for yourself if you're a product manager a designer a writer We need people like that in the space.
+Maybe not on Bitcoin Core, which is just developers, but in other areas.
+Or you could become a startup founder.
+There are more and more VCs who are willing to fund Bitcoin and now lightning startups.
+
+Speaker 1: 00:11:18
+
+So could you elaborate a little bit in terms of non-developer contributions?
+So let's say somebody's out there, they're interested to get involved.
+Maybe they're not quite a developer, but they are, let's say, tech savvy and interested to contribute.
+What are some ways that they could do that?
+
+Speaker 2: 00:11:34
+
+Well, for example, I believe that Spiral, who was my first sponsor and still a sponsor of mine, I believe that they're quite interested in finding product managers because a good product manager can have a lot of impact by leveraging through their work through developers and designers.
+And I think they're very happy with the one or two product managers they do currently support and might be interested in more.
+I don't know if I answered your question.
+
+Speaker 1: 00:12:04
+
+Yeah, that's one example.
+And I know even some other open source projects are looking for translators as an example.
+So literally no coding, just literally someone who can translate and make that wallet or that software accessible in other languages.
+
+Speaker 2: 00:12:19
+
+There was a period of about two years when Spiral was also giving grants to a lot of designers.
+I don't know if they're doing that so much currently because we are unfortunately in a bear market, but you can always apply.
+If you research it, you'll find that there are many funding organizations now, especially compared to four years ago when I began.
+But the first step isn't to apply for a grant unless you're already well established in the space.
+The first step is to apply, I would say, to Chaincode Labs online seminar, either Bitcoin or Lightning, or Summer of Bitcoin, or a number of other excellent programs that are up and coming to educate people in space right and yesterday on the same stage we had some other organizations like Vintium, Library of Satoshi and Torogos as well.
+
+Speaker 1: 00:13:07
+
+So these are some other organizations that you can potentially...
+
+Speaker 2: 00:13:12
+
+I believe there's one that's being started by Marina Spindler, I can't remember the name, for El Salvador focused.
+
+Speaker 1: 00:13:19
+
+That's Torogos.
+
+Speaker 2: 00:13:21
+
+Right.
+DeFarm in New York, DeFarm, Desfarm maybe for Americans, DeFarm for people like me who live in France.
+In New York they're also doing mentorships.
+I helped mentor some developers, tried to at least.
+
+Speaker 1: 00:13:35
+
+And so there's a range of possible places that you could be sponsored by or directly employed with.
+So you know historical and long-standing examples like Blockstream as we've mentioned, but there are other so Blockstream, Chaincode, MIT, DCI, Spiral as you've mentioned, there's Brink, there's probably a few others that I'm missing.
+Yeah, Super Lunar is a new one and various Bitcoin and crypto exchanges.
+
+Speaker 2: 00:14:02
+
+Human Rights Foundation, also miners.
+Unfortunately, they aren't going through a good time right now, but I had a grant for one year from Compass Mining.
+Thank you to them.
+Unfortunately, they may have been falling on hard times, but in Human Rights Foundation, They receive donations like Brink does and they support people.
+And Alex Gladstein just renewed my grant for another year.
+So thanks to them.
+
+Speaker 1: 00:14:24
+
+So these are some examples, or in some cases, exchanges will directly sponsor a grant or grantee.
+So these are some of the pathways for people out there if you're interested in applying for this kind of thing.
+I think it'd be good to chat a little bit about mentorship as well.
+So I understand for yourself, it seems like you were a little more individual in your own way, but I understand for other people mentorship was very key for them So could you just explain a little bit about that?
+
+Speaker 2: 00:14:52
+
+Right?
+You're right.
+I'm pretty much a free-roaming Free roaming sort of independent person and I like to self-learn I've never found it very useful for me to learn in a classroom situation.
+I'm a self-learner alone, just pounding my head into the material.
+And again, I wouldn't be here if it wasn't for Chain Code Labs seminars.
+They're excellent.
+It's a good first step.
+If you have any doubt as to whether you would like to join the space, apply.
+Because not only will you learn as much, you will get as much back out of it as you give into it.
+I promise you that.
+But it's also, I would say, a talent scouting program disguised as an educational seminar.
+In other words, you'll become known in the space just by participating in it.
+The people who matter will see who you are and this person maybe needs support And that's how it happens.
+I didn't actually apply for any grants ever you kind of got headhunted Well, that's how it happens.
+Yeah And once you begin As long as you're doing the work, and this is all really about showing proof of work It's just like Bitcoin and once if you continue showing proof of work, people are valuable and needed in this space, and especially experienced people, context is important.
+That's one of the things that people may not realize is the longer you stay in the space, the more accumulative context and history you have in your brain.
+And that is terribly, that's a terrible loss for the space when someone stops contributing and has all that context and they leave.
+So it's important to keep long-term people so that when someone new comes up with a flashy new idea, hey, I just thought of this, what do you all think?
+You're able to say that's not bad.
+Now, someone proposed that in 2015 and here's what happened and why it didn't get adopted and then in 2018 someone else brought it up in a different format and that almost made it but I think they got discouraged and dropped their effort.
+So that's valuable.
+You can apply history and context.
+And so usually, once you get in, it's not too hard to stay in.
+
+Speaker 1: 00:17:02
+
+Yeah and I think that's a underrated point around context.
+So from every Bitcoin Core developer I've spoken to, it seems that it matters having that longer-term knowledge of what happened before and so that's obviously a very useful thing when there are experienced contributors such as yourself and others out there who are longtime contributors who can then share the context about what happened and perhaps be on the lookout for certain bugs that maybe they have a heightened awareness of.
+
+Speaker 2: 00:17:37
+
+It was Adam Jonas at Chaincode who mentioned to me the value of long-term context in history and why it's important to keep long-term contributors.
+And...
+
+Speaker 1: 00:17:55
+
+Well, a common thing is various Ideas get shared and actually that idea was on Bitcoin talk in 2011.
+You know this kind of it's like a common thing but then Where that idea went and what whether it was the right time for that idea?
+Maybe that's also a question right so people might have been speaking about payment channel ideas on BitcoinTalk, but nowadays we have the Lightning Network which is a network of payment channels and now it was the right time.
+
+Speaker 2: 00:18:23
+
+There is one paradox that will surprise maybe some of you who are considering entering the space and it might be finding it forbidding or Intimidating and that paradox is I'm going to use analogy that I pulled out of my head yesterday at a talk I gave it's a bit like the old music industry where The artists are saying man.
+I can't find a record company to sign me.
+But then at the same time, you would talk to the record companies, and they would be like, there's no good artists, we were looking for them, we can't find them.
+The point being that, if you show up to a seminar like Chain Code or some of the other ones we've mentioned.
+And you engage with the material, and you do the work, and you really show thoughtful work on it, you will stand out just because you're doing proof of work that is hard to find.
+They have trouble finding people willing to engage deeply with the material, the space, the tech, the concepts, and to struggle and engage with them and work on it.
+This is rare.
+If you're willing to do that, then give it a shot because you're more rare than you realize and they're looking for you.
+That's the paradox.
+
+Speaker 1: 00:19:35
+
+Do you have any comments on how Bitcoin Core development has shifted over time, if it has?
+
+Speaker 2: 00:19:46
+
+One thing that is striking is how fast things change.
+For a long time you feel like you're the new person who's struggling and nobody cares what you have to say and everything you say feels dumb and you regret half of the things you write.
+And then in a flick of a second, and all of a sudden people are talking to you differently and you're seen as established.
+It's very odd, and it's a bit surprising.
+Your grants renewed, and suddenly you're sort of an og or one of the most Experienced remaining contributors on the project because people drop out and leave I would say Well the event that affected me personally the most on Bitcoin core was the lead maintainer Vladimir Vanderland.
+10 years he was lead maintainer.
+I haven't said this here but he was the reason I was inspired originally to work on Bitcoin core because I really appreciated his maintainership style.
+In addition to being interested in Bitcoin, Vladimir followed me on Twitter maybe three or four years before I began working on Bitcoin Core.
+And I listened to him and read his tweets and following how he treated people on Bitcoin Core, which he was lead maintainer of for so long, he was kind, he was humble, service-oriented, he was lifting people up, and I thought that he was just the kind of leader I wanted to work with.
+And I'm honestly very, very sad.
+It was time for him to step down he needed to for himself he'd been around so long you know and everyone saw that coming since years but I think it's a great loss for the project.
+
+Speaker 1: 00:21:33
+
+In terms of I guess like dealing with you know conflict or contentious things that come up in Bitcoin, what do you have any anything you could elaborate or share on that, on how you deal with that?
+Like if, let's say, there are competing interests, if one party or people want something and the other people don't want that?
+
+Speaker 2: 00:21:55
+
+Yes, that's a good question.
+Some people have different levels of tolerance or appetite for drama.
+Some devs like to stoke drama on the social networks and others like me aren't too keen on the drama.
+I've found it helpful to adopt sort of a stoic or Taoist philosophy, at least I try to.
+It's helpful to not be the first person to get angry.
+It's helpful to read, say, meditations by Marcus Aurelius.
+And I also prefer people who say their position once without flooding over and over again and coming back and attacking anyone who disagrees with them.
+There are characters like that in space.
+That's not my cup of tea, and that's how I prefer to deal with it.
+Like, for example, the mempool full RBF recent discussions.
+There was one person who was just pretty much flooding all the threads everywhere on all the social networks and on the PR.
+My personal opinion is that's, well, maybe they got what they wanted.
+But I don't think that's the right way to have the debate.
+I think people should think carefully, respond when needed.
+But It's not always necessary to respond, especially to some sort of low kind of attack or criticism.
+If what you've thought and said is your position, that's enough.
+That's my position.
+
+Speaker 1: 00:23:28
+
+So perhaps, I mean, abstracting away from particular arguments and debates and things.
+What is the right way to reason and debate about these things?
+As I understand, there's a preference then for speaking about objective data or reasoned arguments.
+Is that the right way that people should debate things or what is the right way?
+
+Speaker 2: 00:23:51
+
+Well in theory this is about rough content consensus right a rough consensus isn't voting There's an article on it written back in the 90s by the internet standards committee back in the day, where rough consensus is humming or something like that, where basically everyone needs to feel heard.
+And I thought it was important on a process like the taproot activation one, which drew out for months and months.
+But some people got very upset about that and I wasn't upset at all because in my opinion it was necessary for all the people who had something to say to be able to say it and to feel heard.
+It's important for people to feel that validation, okay I was able to get out what I wanted to say.
+And I think that's fine.
+I mean, if people want to say something, they can.
+At the same time, there's a delicate balance.
+For example, in the recent Mempool full RBF, there's a whole bunch of people who have, say, an 80% understanding of the topic.
+Some people have a 90%, some people maybe a 95%.
+And there's maybe two or three people who I would say have a 99.9% understanding of the topic.
+The deepest, most experienced, long-term, active researchers and contributors in the space, in my opinion, is that they were shouted down, perhaps.
+People weren't listening to the most thoughtful and nuanced discussion, necessarily.
+Maybe they were.
+That's just my impression.
+My opinion is we shouldn't break things if we don't need to.
+We should be careful.
+But I'm not one of the young fiery contributors.
+I believe we should be prudent and reasonable.
+
+Speaker 1: 00:25:30
+
+I think that's a fair approach to take.
+Can we chat a little bit about some of the various ways that people skill up.
+So probably one good example would be Bitcoin Review Club.
+So can you tell us a little bit about that and why that's useful for people?
+
+Speaker 2: 00:25:47
+
+Right, Bitcoin Core PR Review Club is an excellent initiative, again by John Newberry, who's done a number of excellent initiatives.
+He also was the founder of Brink.
+I highly recommend, if you want to get involved, participating in the Review Club sessions online on IRC every Wednesday, preparing the sessions.
+The more you prepare, the more you give, the more you'll get and learn.
+And eventually, hosting some sessions.
+Because nothing is more scary than the preparation to feel you're capable and competent enough to host a session about something.
+Highly recommended.
+
+Speaker 1: 00:26:26
+
+And so that seems to be one good tool or way to skill up on things.
+I understand other people use things like Socratic seminars.
+That's another way that people try to learn by asking Socratic questioning of each other.
+And there's mailing list discussion as well and of course GitHub, the comments on the pull requests.
+So could you just elaborate a little bit on some of those methods of the discussion and learning that can take place?
+
+Speaker 2: 00:26:54
+
+First of all, you reminded me I highly recommend subscribing by email to the Bitcoin Optech newsletters.
+They're written by Dave Harding every week with a competent team of reviewers, of which I did that for two years, and wrote articles as well.
+It's a great way to keep up with developments in the space.
+Subscribe to the mailing list.
+And I've already forgotten your question.
+
+Speaker 1: 00:27:17
+
+Well.
+Yeah, if you could just elaborate a bit on that discussion.
+I think you already were and I know there's an IRC chat as well, and I think that's shifted now Definitely follow the IRC discussions in whatever project that you're working on.
+
+Speaker 2: 00:27:32
+
+There are IRC channels for L&D, Sea Lightning, Lightning Protocol Development, Bitcoin Core Dev.
+All the projects, Join Market, they all have IRC channels.
+
+Speaker 1: 00:27:45
+
+Now I know also, it can vary, but some bitcoin core Contributors have an area that they are a specialist in whether that's the wallet or whether it's You know different aspects of that Do you have an area that you you would consider yourself a specialist or do you consider yourself more like a generalist?
+
+Speaker 2: 00:28:04
+
+I'm definitely more of a generalist.
+There's not a part of the codebase that I'm not willing to try to review and to learn about.
+And it's kind of cool that moment when you open up a file that you've never looked at before, which in Bitcoin Core is easily possible for a very long time.
+Yeah, it depends on you.
+I like to roam.
+At the same time, there are certain parts of the codebase I spend much more time on than others.
+So it's just up to you.
+
+Speaker 1: 00:28:29
+
+So let's talk a little bit about that process, maybe for people who aren't as familiar.
+What does it look like then, that process of a person, let's say, contributing some kind of change, review for that, and maintainer?
+If you could just talk through that process.
+
+Speaker 2: 00:28:47
+
+Yeah, it's hard for me to know how familiar people are with that process, but if someone opens a pull request and then people review the change on a conceptual level or on a code review level, it suggests changes and the process moves forward.
+When there is enough approval by the reviewers, then it might be merged.
+Some different kind of review and different amount of review is necessary depending on the change and how critical it is if it touches consensus or not Some changes are really low risk other ones are high risk so in theory Were I a maintainer I would probably want to see much more review on a critical piece of code than on a non-critical one.
+
+Speaker 1: 00:29:34
+
+Is there anything in terms of the broader Bitcoin ecosystem that you're excited about or that you would like to see, like whether it's, I don't know, whether it's lightning or some other thing, are there any aspects of that that you are particularly interested to see?
+
+Speaker 2: 00:29:50
+
+My main goal is for Bitcoin Core to be robust because failing it being robust it's hard to build on it and it's decentralization.
+So most of my concerns are if there's some failure that we can see or some area that isn't as robust as it could be, it's the base layer, so it needs to be really solid.
+And the second key point is decentralization.
+So I'm speaking in general terms, but that's what it is I think Bitcoin might be the last one standing apart from any captured coins Thanks to its decentralization, but it's not as decentralized as it could be and I would hope for it to become more decentralized in the future and on all levels including the core development level.
+
+Speaker 1: 00:30:41
+
+And it's right to say that there's been a focus on that even amongst developers.
+I think one other area, maybe this is like an observation, that sometimes when you're talking to people who are known for let's say evangelizing Bitcoin, they will speak in this kind of, oh it's inevitable sort of sense.
+But then when you talk to somebody who's a core developer, contributor, and they're closer to the code.
+They're a lot less inevitable, let's say.
+So could you just elaborate a bit on that?
+
+Speaker 2: 00:31:09
+
+Yeah, well we see how the sausage is made, warts and all, and I mean, there's a lot of things that could be improved that no one on the outside will necessarily notice that it has been changed.
+And yet, these are, in my opinion, the most important things.
+I'm not talking about refactoring or making the code cleaner or prettier, I'm just talking about making the code base as robust as it possibly can be, and finding and fixing bugs.
+Sometimes they're not talked about.
+Sometimes they're fixed sort of in a way that people don't see.
+
+Speaker 1: 00:31:46
+
+This to me is more important than adding new features, but that's personal other people have a project This person is supposed to implement this pip this person is supposed to bring this into the project, and that's fine And generally I see my role is reviewing those things And I think it's fair to point out that there are debates even amongst the community about how much change Bitcoin should have right and it's almost it's I don't want to get too political, but it's almost like a similarity of like progressives and conservatives and you have like people who just say no just focus on the reliability and then maybe there are Other people who have let's say this big new feature that they that they want and so I suppose there are even even on Bitcoin call there are people with a different focus, right I Think I turn my mind.
+
+Speaker 2: 00:32:31
+
+Oh, it's good.
+I thought I turned my mic off.
+I'm not against new features at all.
+They're not necessarily my priority, but I'm happy to review them.
+Sometimes we break things without realizing it.
+It's easy to think something's safe and it breaks something, and it's noticed only later.
+So, what we need more than anything is review and testing.
+And even if you're not a C++ expert, you can still test.
+You can test the release.
+You can test the areas that you're interested in that you use in Bitcoin in the new release or Even in not a new release But the release you're using and report anything you find in a way that makes it possible for us to reproduce what you found So let's leave it here with a few tips and then we can maybe open up for questions.
+
+Speaker 1: 00:33:24
+
+So, if you had any closing thoughts and tips for people out there, whether they want to become a Bitcoin Core contributor themselves or whether they just want to have an awareness of the process, what are some things that you think people should know?
+
+Speaker 2: 00:33:38
+
+Well the number one thing if you want to become a developer or something else in the space, in my opinion, is to show proof of.
+It's as simple as that.
+You got to dig down and do it.
+And depending on who you know, maybe it will go faster or go slower, but proof of work is something that in the end, I think, rises to the top and is visible.
+So that's basically if you want to be a core developer or work on Bitcoin or Lightning, I highly recommend the Chaincode Lab seminars or any of the other initiatives.
+That's the best possible way to begin that I can think of.
+
+Speaker 1: 00:34:18
+
+Great, well everyone give John a round of applause.
+Thanks, Stephan.
+Thank you.
+So we've got a few minutes for questions, so we can probably take two or three questions.
+So can we just get a runner, down the back I think was first.
+
+Speaker 2: 00:34:40
+
+So yeah, we got Bitcoin core in your humble opinion should anyone even bother with BTC D or other implementations Should anyone run BTC D No, should anyone you know start contribute, you know As far as contributing to Bitcoin Core, is it worth looking at the other implementations as well?
+That's up to you.
+I don't want to tell people what to do.
+Do what you like.
+
+Speaker 1: 00:35:12
+
+Next question, anyone?
+We've got one at the second row here.
+
+Speaker 3: 00:35:20
+
+Thanks very much for your talk, it was enlightening.
+You mentioned about being funded to work on Bitcoin Core through a grant.
+I just wondered if you could say a little bit more about those grants and maybe even like what kind of level are they at?
+How does that compare to say like salaries in big tech for senior professionals?
+
+Speaker 2: 00:35:51
+
+If I understand correctly, you're asking how high are the grants?
+In terms of financial terms.
+Generally, it depends on the grant structure.
+Some offer you the ability to be paid all in Bitcoin, some all in dollars or even a choice of half and half.
+I've often had the choice of all three, USD or Bitcoin or half and half.
+I would say that it's less than a big Silicon Valley salary.
+But nothing's stopping you from applying to several sponsors to accumulate them if you so desire.
+I didn't do that at first.
+And after I did begin talking to a few others, that turned out to be a good thing to do, in my case, because at one point I had three instead of one, and now I currently have two.
+I don't worry about it as much as maybe I should because I like to stay focused on the work and not on the money Because I find that thinking about the money doesn't isn't conducive to being productive on the on the focus on the work itself But that's just me I would say that if you're young, it's very interesting financially once you begin.
+If you are a bit older with say mortgages and a family to support, it's a bit more difficult, but it's not impossible.
+It depends on what you're used to and where you live.
+For example, I don't believe that they're geo-adjusting the grants.
+For example, Spiral offers the same grant amount to everyone and then it's up to you to geo-arbitrage if you need to.
+
+Speaker 3: 00:37:30
+
+Okay, thank you.
+
+Speaker 1: 00:37:32
+
+We've got time for one more.
+
+Speaker 4: 00:37:33
+
+We've got John over there I really appreciate your comment about people wanting to be heard in the process.
+What do you think is the best way for not only users and merchants to actually be heard but also feel heard in the process while they are not actually part of core engineers or really familiar with the culture of how to interface With that community.
+What do you think is the best way for these outsiders yet still bitcoiners to be heard and feel heard?
+
+Speaker 2: 00:38:16
+
+Okay, that's an excellent question So first of all, I think it's good to remind ourselves that Bitcoin Core isn't a closed team.
+It's an open source project that anybody can provide feedback on.
+And feedback is welcomed.
+And for example, just yesterday I reported a large Bitcoin financial company has some minor issues with the upcoming release and I reported it.
+And they were like, well, why didn't they comment directly on the PR?
+Well, I understand that it can be intimidating to do so and Also, they're busy They may be not have the time to go in and review and say something that they're not afraid that they're unafraid to say On the pull request it's intimidating.
+I get that But it's open to everyone I encourage businesses and merchants to get involved.
+As we recently saw with the Moon Wallet and Dario and others on the mailing list and on pull requests, There is a productive and less productive way to be giving feedback, so I would suggest giving feedback, but doing so productively, in a positive way, but yes, please do give feedback.
+People want to see that.
+We shouldn't be in our own little ivory tower, breaking things downstream for people without even realizing it.
+We need that feedback.
+I think it's very important to keep the core devs' feet on the ground, and I say that to myself.
+I want to keep my feet on the ground.
+And it is an issue because there is a tendency to say, give high respect to people who are just really deep in the code, but who actually maybe, you know, it works in theory, but not necessarily in practice.
+So please do provide feedback, and do so in a conducive and constructive way.
+It's very helpful.
+Thanks.
+And you certainly can.
+Anyone is welcome to.
+Last 30 seconds.
+
+Speaker 1: 00:40:17
+
+One up the back there.
+Got to keep it quick, though, or we might run over.
+
+Speaker 2: 00:40:25
+
+What would you say is the main reason that people leave?
+
+Speaker 1: 00:40:29
+
+What would you say is the main reason people leave?
+I believe Bitcoin Core, is that what you're saying?
+
+Speaker 2: 00:40:34
+
+That's a great question, why do people leave?
+Working on Bitcoin Core is particularly frustrating, I believe.
+It can take you years to have changes merged or even never merged.
+You can work a lot and hard on something that takes a lot of your time, only to at the last minute have it not worked out because someone finds a really good reason why it shouldn't take place.
+The review can be brutal.
+Also some aspects are not necessarily fun.
+Like, you know, it's a little bit like high school.
+In some ways it feels like there's popularity comes into question.
+And all these things sort of combine to burn people out.
+And there's also the high stakes.
+For example, you know, the discussion on the social media really burns people out I've had feedback from people who've left recently that you know all the talk about Bitcoin fixes the world or Bitcoin boils the oceans or why didn't you stand up to CSW and assassinate him yourself like you're some kind of ninja and not just the developer.
+You know people have these really crazy expectations of core devs like we're just humans We're just developers and we need to focus on our work.
+And we're not necessarily here to argue with every single person and spar debate with them online about whether Bitcoin is boiling the oceans and whether it's fixes the wars and whether it does this and whether it does that.
+We're just trying to do our work.
+And so this gets to people.
+It gets under their skin even if it shouldn't.
+And of course the Craig Wright things really burn people out because you're a potential target.
+We're all one lawsuit away from deep stress.
+So, yeah.
+These things sort of do eat you, at you for a while over time.
+And as much as you try to push them aside and focus just on working on Bitcoin Core, they do get under your skin after.
+
+Speaker 1: 00:42:33
+
+Yeah.
+Well, all right, everybody, put your hands together for John.
+Thank you, John.
+Woo, woo, woo, woo, woo,
+
+Speaker 0: 00:42:40
+
+woo.
+Yes, yes, yes.
+
+Speaker 2: 00:42:42
+
+Thanks everybody.
+
+Speaker 0: 00:42:45
+
+All right.
+So, let's keep it going and remember to share your pictures tweets memes or anything that you want to share in social media using the adopting BTC hashtag so people could join and see all the experience that we already have in here in adopting.

--- a/bitcoin-design/learning-bitcoin-and-design/_index.md
+++ b/bitcoin-design/learning-bitcoin-and-design/_index.md
@@ -1,0 +1,6 @@
+---
+title: Learning Bitcoin and Design
+source: https://www.youtube.com/playlist?list=PLpV0KfVOMojZiB7ZRExyU8ETFDmjq8BNw
+---
+
+{{< childpages >}}

--- a/bitcoin-design/learning-bitcoin-and-design/covenants-part-2.md
+++ b/bitcoin-design/learning-bitcoin-and-design/covenants-part-2.md
@@ -1,0 +1,819 @@
+---
+title: "Covenants Part 2"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://www.youtube.com/watch?v=zk_EEKeAFuY
+tags: ['covenants', 'ux']
+speakers: ['Christoph Ono', 'Michael Haase']
+categories: []
+date: 2024-02-02
+summary: "Continuing our discussion from our first call, we dove into how covenants might play out in scenarios around chaining transactions, payment pools, and cold lightning channels. We made good progress, but also still have questions."
+---
+Speaker 0: 00:00:01
+
+All right, welcome to our second learning Bitcoin and design call about covenants.
+So today, I think the idea was to go deeper into covenants use cases, right?
+Last time, the first call was more about just generally what it is and what it does.
+And then now we wanted to go deeper.
+And I think on the web, on the GitHub issue, there was one request about congestion control.
+And then the, but the other big one was scaling I think so but how's everyone how are you feeling about covenants today maybe we should just pick up I don't know wherever our brains are well so I'm feeling bullish on covenants okay no but it's it's that I would personally probably want to have a look at.
+
+Speaker 1: 00:01:04
+
+I think it opens up a they open up a kind of fascinating capabilities that I would personally probably want but in terms of whether what the let's say the technical soundness or the security implications there's nothing I can contribute and but in general I'm kind of more probably interested in these kind of bolting or kind of scripting stuff than scaling.
+But that's just the nature of what I'm working on currently.
+So that's not at all some kind of judgment or so.
+But it's just in terms of the scaling question I'm not sure how valid any of the things that I'm gonna say or I have to say or think is relevant But it's really interesting and what stuck from the last call was I think Owen said you can, in terms of scaling, You can transfer ownership without on-chain transactions and have the same assurances.
+So that's definitely something interesting.
+
+Speaker 0: 00:02:45
+
+So, yeah.
+So Owen's threads here, he has three threads.
+They're really awesome.
+I tried to earlier, I tried to sit down and actually understand that specific part.
+I tried to understand how does this enable any sort of scaling and how do you transfer ownership off chain?
+And there's this one thread here that talks about, I don't think it's this one actually, where it's something, on the one hand, it kind of makes sense, but I was missing, there was something I was missing from it too and let me maybe I'll maybe I'll try to explain and try to get there there was one thread with an example that I thought was pretty good.
+So here's kind of what I came up with, which kind of helps maybe with the scaling stuff.
+So, and I tried to create a very simple example of this.
+So there are three people, Alice, Robert, and Charles, right?
+Robert owes Alice 1.01 Bitcoin and Charles owes Robert 0.2 Bitcoin.
+So what they would do right now is Robert sends Alice 1.01 Bitcoin and Charles sends Robert 0.2 Bitcoin.
+Two transactions done.
+Cool.
+Now let's make this way more complicated.
+So, but Alice gives Robert the address, like Alice's address one.
+Cool.
+So Robert could technically now just send her zero point Bitcoin and be done, But he makes it more difficult.
+So he creates his own address because he's expecting money from Charles.
+I think this needs to be Charles, right?
+Charles needs to send him money.
+So Robert creates an address, Robert's address one, and that one has rules baked into.
+So any funds that go into this address, 0.1 of that has to go to Alice's address, right?
+So when he receives zero, whatever he receives, 0.1 is reserved for Alice and no one will ever be able to change that.
+That's just how it is.
+It cannot be used anywhere else.
+And then rule number two is that another 0.1 should go towards a lightning channel with Dan.
+So those are rules baked into, right?
+And then in this address, then Robert gives this address to Charles.
+Charles puts the 0.2 Bitcoin in.
+Now we have this Robert's address with 0.2 Bitcoin.
+And those address cannot be freely spent right.
+0.1 has to go to Alice and 0.1 has to go to this lightning journal with Dan.
+That's it.
+So but only Robert knows this because he baked this into the address.
+No one else knows about this, right?
+On the blockchain, it's like, hey, there's an address with 0.2 Bitcoin.
+Cool.
+That's it.
+But so Roberts tells Alice, hey, look at this address.
+There's a rule baked into into this one.
+So Alice looks at the address and she's like, cool, that is true.
+There's 0.1 Bitcoin in your address.
+But at some point, they can only be spent to me.
+So, right, you, Robert still has them.
+But the only thing that can be done with them is to give them to me.
+Is that as good as me having them?
+You could say yes.
+Like there's a promise in there that cannot be broken.
+So Alice now says, cool, they're not technically in my address, but they kind of have to go there.
+So it's like they're mine, but they're not really, you know, they are and they aren't, Schrodinger's cat or whatever.
+And then Robert tells, shows Dan the address and the rule number two and then you can open up a lightning channel with them and because even right because there's this promise that cannot be changed so in a way we've like there's was one transaction that happened.
+So Charles sends those 0.2 Bitcoin.
+But actually we did three, we accomplished three things at the same time.
+So literally on the blockchain 0.2 were sent from Charles to Robert.
+So that debt is kind of settled.
+And then there are these baked in promises that 0.1 will go to Alice and another 0.1 will go to the lightning channel with Robert and Deb.
+So without covenants, it would be three different things with convenance they're one.
+
+Speaker 1: 00:07:35
+
+Plus Alice since Alice probably gave I mean it depends on what kind of address Alice gave to Robert.
+
+Speaker 2: 00:07:56
+
+So if that's a normal kind of address, she can then spend this point zero one, point one freely as well.
+
+Speaker 1: 00:08:10
+
+Right.
+So yeah, basically, basically you can then you could basically change transactions on onto this.
+
+Speaker 0: 00:08:19
+
+Yeah.
+You're basically unwinding a bunch of stuff then like you're winding up things right or you bake in all these promises.
+But then, then you can build promises and promises and promises and promises.
+But then the question is then and that's something Owen also wrote in his thread.
+It's like can you do that forever or does at some point this whole thing just kind of have to you know unwind.
+
+Speaker 1: 00:08:43
+
+I think this is what he meant with the trees of trees of trees right with this kind of layers of trees.
+It always depends what the next hop is going to do.
+
+Speaker 0: 00:08:56
+
+And your point was this Alice's address it could also hold promises to other people.
+Exactly.
+Maybe she wanted to...
+
+Speaker 1: 00:09:05
+
+Exactly.
+And that's also something that nobody else knows.
+
+Speaker 0: 00:09:10
+
+Yeah.
+So I think it's like if, but the thing is, if Robert forgets the rules, then no one can recover them.
+No one will know them.
+Right.
+Because they're not saved anywhere on chain it's they only exist because he baked them in and if he forgets them then it doesn't share then they're gone.
+So I guess that's where I have a whole bunch of questions about how can all of this fall apart if someone forgets something, right?
+And then all this stuff gets locked or is there always a way out to unwind it where anyone can just back out of this whole system, screw it, I don't like these shenanigans.
+And if let's say you do that three times in a row and I want to, I'm secretly paying Mo and I'm like yeah you know these Bitcoin they're actually yours but really they're in Michael's address and you have with this rule but then they're in Loic's address in this rule and he paid me before and with that rule and then they're actually Bitcoin that my mom sent four years ago with that other rule and then it came over there.
+It's like do I need to do all that stuff or do I not or like how do I prove them that and will you accept it when you're like this is way too complicated for me just give me my money.
+
+Speaker 1: 00:10:35
+
+Well the way that I understood it is the I mean all of these checks are automated in the background right so the address that I give you is only spendable by my rules or if you receive something into this address then I have the assurance that I can spend it the way I want to spend them.
+And that's all of these rule checking that you just described.
+And that's how I understood it, that it works.
+
+Speaker 3: 00:11:15
+
+No, when we speak about use cases, and I'm just thinking about the scenario that Christophe presented.
+I personally would never enter into such a scenario because there's just too much of he said, she said, I promise you promise he promises they promise.
+If I would think of a very practical use case, I would just think of a family using it between three people, the husband and then the wife and then the kid.
+The kid has their own Bitcoin savings for their university or whatever they want to study for and then the couple has an account and it's a joint Bitcoin account and both of them are in Bitcoin and every time money comes in they both agree that there's a rule that 5% of that goes to the kids university fund.
+It's a covenant between them.
+And then it's safe.
+It's trusted.
+It's the husband and the wife.
+There's no more.
+There's not too many people making promises.
+And then maybe between the husband and wife, they have their own covenant, which is like, OK, certain percentages, 10% goes for a holiday and then that is that own covenant.
+I mean, I'm just trying to think of a very practical use case in a situation which I think would practically work.
+But I think the more people you add on to this I promise he promises she promised a problem.
+
+Speaker 0: 00:12:37
+
+But so the trick is you might not even know because on chain these addresses look like regular addresses there might be all kinds of stuff in but you just can't see it.
+
+Speaker 1: 00:12:47
+
+So that's the part which part of this construct is conscious and which not, right?
+Because I just want to send you money and the only thing that I have to know and you have to know is that I can spend that money and it goes to you and then you can spend it freely afterwards.
+So that means consciously we don't even need to know it.
+It doesn't concern us.
+This huge construct doesn't concern us.
+The only thing that we need to know is that we can spend that money.
+And So this is not a kind of an attempt to set up this big construct because nobody has a use case like that.
+It's just that we need to have the assurances that whatever we want to do with the money can be done.
+So I think we have to separate the part that is kind of for each person in that line of succession.
+The only thing they need to know is they can spend the way they want to spend.
+Yeah, it's true.
+Automated basically, nobody at the beginning, if I'm in the middle of this of this whole sequence I don't need to know what's before it and I also don't need to know what's after it right so I just need to know that that whatever comes into this address can be spent the way I want.
+That's it.
+
+Speaker 0: 00:14:39
+
+Yeah.
+And it's true, Mo, you define your own rules because it's your address.
+So no one can force rules on you really.
+
+Speaker 1: 00:14:49
+
+So you're not part of some kind of bigger scheme, but you're just receiving and sending.
+Everything that we talked about is basically happening in the background and it shouldn't even really...
+
+Speaker 3: 00:15:06
+
+Right, the protocol is making sure that all of those conditions are met.
+
+Speaker 1: 00:15:10
+
+Exactly, but you should be able to say okay now I received like this 0.1 Bitcoin and then I want, because these are mine and I want to spend them I want to automatically put I don't know I want to put 10% of that into my savings wallet yeah And the rest I just send to people.
+So these are then your rules, right?
+So that and everything, it's basically one up after that.
+And the question that Christoph raises, does it break at some point?
+Right?
+Or is it the can you do this forever?
+
+Speaker 3: 00:15:55
+
+Good question.
+
+Speaker 0: 00:15:58
+
+I guess you know I'm not to continue on that thought I'm not sure what I said was actually right that no one can force things on you.
+So here, you know, Robert shares tells Alice, hey, look at this address.
+There are funds in there for you.
+But they're not detect that.
+How can she already sent them to someone else?
+
+Speaker 1: 00:16:25
+
+No, I mean that the point is it has to be funds have to be sent to the address that Alice gave him.
+So, and then Alice has enough assurances because she constructed the address and the address contains the spending conditions or the policy.
+So that means once the funds hit her address, she knows that she can spend them.
+
+Speaker 0: 00:16:59
+
+So I think that the way that Owen put it was there's like a PSPT in there.
+So, Robert really doesn't have to pay any fees there, but eventually Alice will have to.
+So, let's say fees are 200 bucks, right?
+And I'm like, check Alice, you're at the 100 bucks I'm supposed to send you.
+They're right there.
+You can grab them.
+But, you know, then she has to pay the fees instead of he being the sender who puts it in her address for paying the fees.
+He kind of gets around the fees and kind of puts that on her in a way right because it's almost like she has to withdraw them Or is it if it's a PSPT?
+I don't know if it's a fully signed transaction baked in, then I guess it's still on him.
+Or is it on?
+I guess who pays the fees then in that regard?
+How does that trickle back?
+
+Speaker 3: 00:18:04
+
+I'm trying to see what Bitcoin technical search is going to provide.
+I actually said, how do fees with covenants work?
+I'm just reading through whatever's coming up here.
+
+Speaker 0: 00:18:13
+
+Maybe no one even knows.
+
+Speaker 3: 00:18:15
+
+There is no direct article about it.
+
+Speaker 0: 00:18:20
+
+So here's another one if you're cool with looking at something else.
+I was trying to figure out how payment pools work, which are also supposed to be this technique.
+So basically, Robert, Alice and Charles, we want to create a payment pool.
+So we we collaboratively create an address that has some rules that we put stuff in.
+So on chain, there's an address with funds in it.
+That's all people see.
+But baked into this, there are a few rules.
+So Robert puts 0.1 Bitcoin in Alice 0.2 and Charles 0.3. And then the rules that say this is how much everyone else.
+So each of those, there are rules that each of them can exit this arrangement and they just get the 0.1 back.
+Then there's another rule that if all of them agree the funds can be split up differently.
+So Robert can get it all and Alice nothing or Alice can get 0.4 and the others 0.1 whatever it is like they can they can exit with a different arrangement.
+So that basically means between the three of them there's now these funds.
+It's a little bit like lightning, lightning, right?
+You have these funds locked up between the three of them and then it's just like split wise one day one person pays for lunch they're like okay cool I'm keeping track that you know I owe you this much and then they do something else and then at some point they can just settle the whole thing and collapse it into one on chain transaction.
+It's a bit like split wise and all that.
+So yeah they pay Jill a bunch of times one year later Alex says screw you guys I'm done with this let's settle.
+So cool so that's It seems like an overly complicated way of doing things for three friends that can just talk to each other and actually use splitwise.
+Right.
+Why go through all these shenanigans.
+So that's why I put this thing here.
+Well, where is this useful?
+Is it useful in, let's say there are three companies or banks across countries that need to settle between them regularly or where there's not such a trusted scenario.
+Then the other thing in the examples was that, well, someone can exit from a pool and the others can continue in the same pool or they can spend and split up and go into another pool.
+And then it's like, awesome, cool.
+But what do you, like, that was one of the things that I read it's like you can have pools and pools and pools and they're all linked and I thought I don't get it what's the like what are you actually achieving here that doesn't seem and then who tracks all of this stuff right so I don't know that was my it was so hard my insight into payment pools and I don't I feel like I'm missing something still, but I also didn't spend a ton of time on it.
+So I don't know.
+
+Speaker 3: 00:21:30
+
+So is there, there's, this is a protocol layer thing that makes it that make sure that these agreements are met and then it makes sure that everything goes on agreement underneath the hood.
+So it isn't, it is a protocol layer that will continuously be worked on so that the rules are constantly updated according to the needs of the network.
+I mean, this is just the thing that I'm trying to understand as well.
+Like, is there one dedicated developer now working on Covenants or how is it like?
+
+Speaker 0: 00:22:04
+
+I gotcha.
+So, you know, what all of this stuff, both examples here, they're based on the same thing, that you can bake rules into addresses that no one can change.
+And then everyone has to follow that it's it's actually a somewhat simple idea right just how those what can be done with the Bitcoin in in the in that are deposit put in this address and this as far as I know this idea has been around for a very long time.
+And there are, if you go to what's the covenants info, let me switch over real quick.
+
+Speaker 3: 00:22:44
+
+Yeah, 2016.
+I see one of the first talks given about it.
+
+Speaker 0: 00:22:49
+
+Yeah, coming inside info.
+So there are 123456789 different.
+Hey, working there nine different proposals around there.
+And from the Stefan Levere podcast, they had their their have various different technical complexities.
+So generally people want the simplest version because there's the lowest risk that anything can break.
+It's easiest to reason about.
+And each technique solution has kind of, it allows you to do things slightly differently, right?
+And it's important to think through how these differences could play out over time and what they could lead to.
+So yeah, that's why nothing's been...
+And then there are these different use cases and stuff.
+And some is more, you know, not spectacular.
+What is it called?
+Speculative than others.
+So yeah, no one's decided on anything.
+It does feel like a whole bunch of people really want this to happen and others say well there's no real urgent need we have other problems and other things to figure out so yeah and there's also seems to be some confusion right now about how you actually make change to Bitcoin.
+
+Speaker 2: 00:24:14
+
+Yeah so from And I think that's also why Owen focused on CTV, which is one version of implementation, version of what Christoph just mentioned, Because that seems to be the most widely kind of accepted one and best studied.
+
+Speaker 1: 00:24:40
+
+But yeah, I mean, every, any kind of assessment of viability is far beyond my.
+
+Speaker 0: 00:24:52
+
+And so the, Are you there, Michael?
+
+Speaker 1: 00:24:56
+
+I'm here.
+Okay.
+
+Speaker 0: 00:24:58
+
+Yeah.
+Sorry, it just froze for me for a little bit.
+One extra thing was that, you know, it's not like these things are just get discussed and then someone decides and then they get implemented.
+Some of these things have been implemented on test net or rec test or maybe even on other chains.
+So you can kind of see in practice how they pan out.
+I feel like liquid even had something like that for some.
+So there are these practical explorations that take you to a certain point.
+But the other bar is just really, really high for any of this.
+
+Speaker 1: 00:25:34
+
+Yeah.
+And you, and then you have the concern or people, I mean, if you, let's say, if we say, if we take this scaling example, what kind of impact does this have on miners who actually secure the network?
+It could collapse their income basically.
+What's the kind of the impacts of that?
+I don't know because if you can collapse 10 transactions into one, then obviously there is an economic impact.
+So that's why it's also maybe taking apart from the security concerns that's another thing to consider.
+
+Speaker 0: 00:26:17
+
+You know, maybe the Bitcoin network in the future, all of the actual transactions will just be really cheap.
+And we just live off of the money from art collectors and all the JPEGs. It's just art funding.
+Yeah.
+
+Speaker 3: 00:26:35
+
+So apparently there's also some people also write white papers, well not white papers, but they write there's something called vaults and covenants as well.
+And in this paper we examine how they might be implemented.
+Okay, that new approach is presented, which avoids pitfalls of general covenant proposals.
+So as Christoph said, there's many different covenant proposals.
+And then each proposal has its own pitfalls.
+
+Speaker 0: 00:27:03
+
+And vaults, I don't know, I feel like vaults are more of an implementation or a use case for covenants.
+
+Speaker 1: 00:27:10
+
+Exactly.
+A use case for covenants.
+Yeah.
+Like scaling is a use case.
+And that's why, or one of the one of the things that kind of because covenants take so long.
+That's why in recent in the last maybe 12 months, the interest in Miniscript picked up, or 18 months, picked up significantly because you can actually program similar or not quite as sophisticated stuff like with governance but you can achieve some kind of programmability with miniscript already, right, with what we have now.
+And so that's kind of the dynamic.
+Basically, Covenants would take that programmability to the next level, definitely.
+
+Speaker 3: 00:28:17
+
+So chat PDF to the rescue.
+I downloaded that white paper.
+It's called Vaults and Covenants.
+It's 13 pages, published 9 January 2023.
+And I uploaded the chat PDF and I asked how how vaults are related to covenants and basically it's a storage mechanism so it's something yeah it's more for more security but yeah there's a 13 page article on vaults and covenants if you'd like to read it.
+Vaults are a technique for substantially reducing the risk of Bitcoin theft.
+They are a form of covenant that give Bitcoin users operational simplicity but heightened security.
+
+Speaker 1: 00:29:03
+
+I mean this definition of a vault, I mean it really depends on what you, this is a technical description of the implementation of vaults but you can also understand a vault just as an applicant you can You can create a vault from a different type of covenant proposal, right?
+So it's, I have a hard time to actually, I see a vault as an object and not as an implementation.
+A feature.
+A feature, exactly.
+A feature or a use case.
+Yeah.
+Vault is a use case, but for me, and I'm a technical layman, but I have the feeling it's more helpful to think of Vaults as the feature or the thing that you want to achieve rather than the way of achieving it.
+
+Speaker 0: 00:30:17
+
+By the way, did you see Owen's Figma prototype?
+No. Do you want to look at that one or do you want to continue with the vault?
+
+Speaker 3: 00:30:27
+
+No, let's see the prototype.
+I mean, I'm keen on seeing it.
+If anyone else is open to as well.
+
+Speaker 0: 00:30:35
+
+I'll share that link.
+I think my link here.
+So he he he mocked up the idea of cold channels.
+So that's what what earlier in the example I think what is it Alice, Robert, whoever said well part of this deposit is dedicated to a lightning channel, right?
+So that lightning channel is not technically active.
+There are no nodes talking to each other and stuff but the funds are dedicated to it right it's just kind of like secretly committed to this lightning channel and so typically you do need to create a new on-chain transaction to get funds into that state but here you kind of have that automatically.
+So it saves you a transaction and you kind of have this secret what he calls cold channels or in this case reserves.
+So let's say you're in Phoenix here and someone sent you 0.1 Bitcoin or whatever and you've created an on-chain address with this cold channel option.
+So then that would go into what he calls reserves.
+So here you would in this example the balance is 433,000 sets plus 1.3 million in reserves.
+So that means if he ever runs low on liquidity, he could activate his reserves, activate these cold channels for free, I think.
+So what can I click here?
+So I can receive.
+Now here, let me get my head out of the way.
+So here you can see that I can choose between regular addresses or what he calls simple address and cold channel addresses.
+So it looks pretty much like a regular address, but anything received to that has the cold channel option.
+And then I want more liquidity and then I can see, you know, here are all these different deposits that I can activate.
+And then I activate one, I confirm it, cool, sweet.
+I have now 300,000 more sets that I can spend on lightning basically for free and right an instant I think I think the there just needs to be this connection needs to be established with the other node.
+But because on-chain transactions taken care of already, you save those 10 minutes or that block confirmation.
+Yeah.
+How does that sound?
+
+Speaker 2: 00:33:49
+
+It's saving just a transaction fee in the future.
+
+Speaker 0: 00:33:58
+
+Sorry, what was the first thing that you read?
+I didn't quite catch where that came from.
+
+Speaker 2: 00:34:02
+
+Oh, it's it was the final page in this little prototype.
+
+Speaker 0: 00:34:06
+
+Oh, OK.
+Let me let me take a look at that one.
+Where is it?
+Under receive or how do I get there?
+
+Speaker 2: 00:34:15
+
+Oh, just keep clicking.
+Oh, it's.
+After it says activate this reserve, activate now one page back after that.
+Oh,
+
+Speaker 0: 00:34:30
+
+okay.
+Here at the bottom.
+
+Speaker 2: 00:34:31
+
+Yeah.
+Yeah.
+Oh no, not that page.
+One, try going one more.
+
+Speaker 0: 00:34:40
+
+Oops.
+Maybe back.
+Back.
+There's no back here anymore.
+
+Speaker 2: 00:34:50
+
+OK, well, sorry, let me see maybe under receive.
+It was activate reserves.
+It was starting out 1234.
+It was the fourth screen.
+Oh, I was just clicking on clicking along the bottom navigator.
+I wasn't using the prototyping.
+
+Speaker 0: 00:35:15
+
+Oh, okay.
+
+Speaker 2: 00:35:16
+
+Yeah, sorry.
+
+Speaker 0: 00:35:18
+
+Oh, this one the receive with the payment tree leaf.
+Yeah, that's a that's a whole different thing.
+That's not the cold.
+
+Speaker 2: 00:35:27
+
+No, no, it wasn't.
+That's fine.
+I'm, it was just a general definition of what was going on and I was just trying to get my head around the what exactly was going on.
+
+Speaker 0: 00:35:39
+
+Yeah I mean so the way it typically works is that you receive funds in your address and then when you want to open a lightning channel that is another transaction.
+
+Speaker 2: 00:35:48
+
+Right.
+
+Speaker 0: 00:35:48
+
+That takes 10 minutes to confirm.
+And yeah, that's basically you have to pay another fee takes 10 minutes.
+But with with you can kind of collapse this into one using covenants.
+So you have you get these funds and it's like they're they're just primed for a lightning channel.
+They're not the light channel is not active, but it's all ready for it.
+It's all set up.
+So you don't need to wait another 10 minutes you don't need to pay the extra fee so you just need to say let's go and the channels right there but you don't know you don't have to write it's like an option a free option to have a lightning channel right and that's through governance yeah so it's kind of cool you could also just You could just also send it as a normal on-chain transaction.
+You can either use it as a regular on-chain transaction or as a Lightning channel.
+It's up to you.
+There may or may not be a delay in there.
+That's something that I wasn't quite clear on.
+Because if let's say I promise that I think channel on the one hand, and then I have the option to spend it in another way.
+You know, how, how is that?
+How do I prevent, you know, some scamming there, if there's not a time lock or some other mechanism that people can hold me accountable for it.
+That's one thing I wasn't quite sure on.
+But then this is the basic idea.
+And I really liked how Owen mocked this up.
+It's very, very in your face.
+It explains a lot.
+I don't know if we need all that in the future.
+But I think that's a really good way to start this.
+To put it in a UI.
+Okay, well, what are your questions?
+
+Speaker 3: 00:37:38
+
+Now I was clicking around on the prototype and just trying to actually understand.
+So we discussed a bit of how it works, like what a covenant is.
+So I'm trying to click through the UI and try to get this theory that I have in my brain and see how that's making sense on the actual design.
+So these sort of, if I'm understanding correctly, the reserves are actually the agreements or rather the covenants that I have with other people is that correct?
+Or?
+Yeah.
+
+Speaker 0: 00:38:15
+
+So you are?
+
+Speaker 3: 00:38:17
+
+That's how I'm understanding it.
+
+Speaker 0: 00:38:23
+
+So you're Robert here.
+You created an address.
+And there was a rule baked in there that some of this can go to a lightning channel with a specific person.
+But you made this commitment.
+So that's baked into the address.
+And that's why other people can trust, right?
+You're good for this.
+You've committed your funds.
+
+Speaker 3: 00:38:49
+
+Yeah.
+And that's the fund that's called the reserve in this UI, in this design that we, like this one here, this is that reserve bit, is this bit here, that's this, like I have an agreement between me and John that he gives me 1% and you can count on this 1% it's here and then I have another agreement with Mary and this is the agreement I have with her.
+So if I want to, I can use this because it is my stats.
+I just activate it and then I can use it in my transactions.
+
+Speaker 0: 00:39:30
+
+Yeah, you just activated a channel, a channel that was very well prepared, but was not quite active.
+And,
+you know, you, the terminology, of course, is something that that may or may not change.
+He uses the term cold channels in here, and reserves.
+And, you know, but then the it's obviously a new term.
+So no one knows really what it means unless you actually worked on it.
+So that all of this stuff is usual, you know, communication stuff.
+
+Speaker 1: 00:40:01
+
+Yes.
+So in this case, all of these code channels together are the reserves, right?
+Yeah.
+And the covenant is just basically a rule or a smart contract or kind of it's a I mean even even a normal single SIG or a multi-SIG address are a covenant or a type of covenant because they define how funds can be spent from that address.
+So it's a bit kind of confusing discussion because it's just it's kind of the concept of covenants it's just about enhancing the programmability of the existing system right And you can do that in a bunch of different ways.
+And all these covenant proposals are each a different way of enhancing or implementing this.
+But a covenant is just a bunch of rules.
+
+Speaker 3: 00:41:27
+
+If I understand this correctly, then I actually entered into, would you say, so then I entered into a covenant with this person over here on the 12th of July and now I'm trying to activate this covenant but this person set a rule, well this is not a rule, this is that because the channel partners are responsive but this could be like a notification that would pop up to say that this this person who you entered into a covenant with yeah this these this is only available in four weeks or something like this.
+Does that make sense what I just said?
+
+Speaker 0: 00:42:04
+
+Yeah.
+So the way it works here is that this other person doesn't even know that you want to have this channel with them.
+You haven't revealed that yet.
+So you banked into your address.
+You said, I want to have the option for these funds to have a lightning channel with Michael but I'm not gonna tell him right I'm just gonna bake that in and then at some point when you say well I want to I want to get that finally it's time I want this lightning channel with Michael.
+But maybe Michael's notice just not online right now.
+Then you just can't make that connection.
+But he's just not his phone, his computer, his notes down, whatever.
+Maybe he got a new wallet or changed his notes or whatever it is.
+If you wait it like six months, then maybe it's just not that connection cannot be made anymore.
+So and that's why that's why this might might fail.
+But you always have the option to just okay, cool, leave the funds there or just put it onto another address and you know, that just that's just not going to happen that lightning channel.
+
+Speaker 3: 00:43:09
+
+Interesting.
+I'm just from the from the UI here as well.
+It's like, I don't know what I clicked on enter on enter an on chain address receive the withdrawn funds.
+So now it's working that the technical problem doesn't exist now.
+
+Speaker 0: 00:43:23
+
+No, no, no, it is exist.
+You're just taking the other route.
+You're kind of giving up on this channel with Michael and you're just putting the funds somewhere else because you just don't want that.
+That reserve is useless to you.
+Michael's just, it's not going to work out.
+You give up.
+So you're just like, okay, I'm going to put the funds in my cold wallet or I'm going to pay rent or something.
+Just going to do something else with it.
+
+Speaker 3: 00:43:45
+
+Okay.
+Okay.
+All right.
+Wow.
+
+Speaker 1: 00:43:49
+
+You know, if you think that lightning channels, this is like, whoa, whoa, whoa, you know, goodness, from a from a from a UX perspective is actually I don't do much different than I do today.
+All these kind of discussions are about the logic that happens in the background.
+So once you give me an address and I send funds to that address, whether it be an on-chain transaction or kind of like a covenant enabled promise, then you know you can spend and you can do whatever you want.
+You don't even know about all of these things.
+So, yeah, you might just pay or not pay a transaction fee.
+And that was one of the questions.
+But what idea or in general, you don't even actually touch these concepts as a user.
+
+Speaker 0: 00:45:03
+
+Ideally.
+And that's why we need wallets to be really smart for people.
+So wallets can just notify people and says, hey, there are some old reserves that are we just can't make a connection anymore or a liquidity is low.
+I prepared something for you.
+If you want to, you can just enable that real quick and you're good to go.
+You know, all of this stuff is ideally automated and intelligent.
+And we are here to design this and implement it and make it happen, work with the developers and all that.
+
+Speaker 1: 00:45:35
+
+Yeah.
+One of these use cases that I thought about that we didn't discuss yet is, or something like it is kind of an escrow address or an escrow wallet where all the parties have to preemptively inspect the address whether it actually matches what they agreed on.
+I mean so far we talk whether I can spend something or not but this would be something where I would have to know beforehand if funds are deposited into that address if that still works as intended per our agreement.
+And that's probably for another call since we have like five minutes left.
+
+Speaker 0: 00:46:30
+
+Yeah, I think it would be cool to as a follow ups to these understand calls, just to a bunch of jam sessions and just design these UIs. And just just feel out what this could would actually be like and what we need.
+When I generate an address, do I need this whole rule builder thing now?
+When I paste in an address, do I need to have an option?
+It's like someone gave me a rule for this address.
+Can you just verify?
+And then what does that look like?
+And if I have my transaction list and it's like, I don't know, it feels like that's why I think would be really interesting to figure out how you would actually interact with this stuff.
+
+Speaker 1: 00:47:19
+
+Some kind of visualizer.
+I was thinking about this with manuscript descriptors, wallet descriptors, because they are like this long, right?
+If you have like, you have a two or three, after six months, it's a one or three, after another six months, a fourth key gets activated and you need some actually somebody would need to visually see not just the string of like 9,000 characters to, but they would need to kind of visualize that in to actually reason about it.
+
+Speaker 2: 00:47:55
+
+So it's something I'm a little late to the party.
+I'm sorry.
+But as that's what happens as time increases more can you get added to it?
+
+Speaker 1: 00:48:07
+
+No that's just that's a it's a different discussion from from from covenants but in order to be you can do this with manuscript wallets already, but you can say, so I say I have a two or three multi-sig, but after six months, I want to have this to be the threshold to be lowered to one of three.
+
+Speaker 2: 00:48:32
+
+You set that up in advance?
+
+Speaker 1: 00:48:34
+
+You set that up in advance and you set up while you set up the wallet.
+But then when you import it somewhere else, you want to you want to verify that it actually does what I think it does.
+And currently the only way to do that is you have a string of text.
+There's no way for normal people to actually know what it does.
+And kind of a visualizer or visualization pattern templates tool for these kinds of things.
+It's probably might be even more needed for something like escrow addresses and escrow wallets because you want to inspect the contract before you enter into it or deposit money into it.
+
+Speaker 0: 00:49:22
+
+Design huddle of Covenants.
+My brain is getting pretty fried here.
+
+Speaker 1: 00:49:31
+
+I think it's a good time to call it a covenant day and continue next week or a week after that.
+I mean,
+
+Speaker 0: 00:49:45
+
+do you feel like we need another learning session on this one or do you feel like we've kind of tapped out a good amount of the use cases and ideas?
+
+Speaker 1: 00:49:56
+
+We could maybe do an iteration with Owen based on this call where we basically were guessing on our own and maybe take this one of these use cases and go through just with one thing.
+
+Speaker 0: 00:50:16
+
+Do you know that saying that the best way to get something validated is or the best way to find out how to do something is to do it wrong and show it to people.
+There's something like that.
+Just curious if you should just design a bunch of stuff where we're like, it's probably something like that.
+And then you know, that will trigger some responses quickly.
+
+Speaker 1: 00:50:44
+
+Yeah, that was that was basically that's describing my entire high school and academic career.
+Yeah, let's do it.
+
+Speaker 2: 00:50:57
+
+Real quick, I know everybody's brain fried, but is the oracles, is there any oracles on Bitcoin?
+And the oracles, do they dovetail with covenants at all?
+
+Speaker 0: 00:51:10
+
+How much do you know about oracles?
+
+Speaker 2: 00:51:12
+
+I mean just they're kind of, you know, receive data from the real world and then link to the blockchain somehow.
+
+Speaker 0: 00:51:21
+
+Yeah.
+So my understanding is just exactly that.
+It's like a connection between the real world and the blockchain.
+If something gets evaluated, how do you get the current price of a euro how do you get the temperature how do you get you know like if there's a betting thing how do you get the end result of some soccer game or something how do you get that in there So I feel like it's just basically just a fancy word for an API call.
+Right.
+So I guess a price API and you just at some point you're like, okay, API, what's the what's the price or value?
+Yeah, right.
+Thanks for joining.
+
+Speaker 2: 00:52:01
+
+The trusted nature of it, I guess, becomes like a sticking point, I guess.
+
+Speaker 0: 00:52:05
+
+Yeah.
+Yeah.
+So I don't know I feel like there's there's no such thing as an on chain Oracle and all of this stuff and I feel like some of it is just kind of a big hype and whatnot.
+So I don't know.
+That's that's my understanding.
+So it's a source of data.
+You have to trust it and make sure you can rely on it.
+
+Speaker 2: 00:52:30
+
+Right.
+Now, the only reason I brought it up was there's this thing called a Tongue Teen I think where people join a group and then whoever's the last person that died gets the money.
+So that's always what came to mind when I was thinking about Oracle.
+So I think it's from an old Simpsons episode.
+
+Speaker 0: 00:52:55
+
+Yeah.
+Yeah.
+Especially with betting and some of this stuff.
+People seem to love betting markets.
+It seems to be just kind of thing a lot of people like that's where that always comes in.
+Or also these price feeds for like, let's say, actually for stabilizing Bitcoin value that page if you want to have some synthetic dollar or euro or so you at some point you kind of need to know what that value is.
+That's where you need an oracle.
+But it's I mean, it sounds like magical and stuff, but it's just like a data feed.
+
+Speaker 2: 00:53:31
+
+Right?
+Right.
+
+Speaker 0: 00:53:37
+
+Cool.
+My brain's fine.
+
+Speaker 3: 00:53:41
+
+I was out for a bit I was continuing with my design design because I'm just done.
+
+Speaker 0: 00:53:47
+
+Cool let's stop the recording then if anyone watching thanks for tuning in.
+
+Speaker 3: 00:53:51
+
+Thank you.

--- a/bitcoin-design/learning-bitcoin-and-design/covenants.md
+++ b/bitcoin-design/learning-bitcoin-and-design/covenants.md
@@ -1,0 +1,920 @@
+---
+title: "Covenants"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://www.youtube.com/watch?v=rCQKqe2XCqI
+tags: ['covenants', 'ux']
+speakers: ['Christoph Ono', 'Michael Haase']
+categories: []
+date: 2024-01-19
+summary: "We dig into what covenants are, how they work, and the different use cases."
+---
+Speaker 0: 00:00:01
+
+Welcome to our first learning Bitcoin and design call of 2024.
+We haven't had one of these in a while, but we're picking them back up again.
+And the first topic is a really tough one, I think at least, it's Covenant.
+And the reason, one of the reasons why this came up is because someone, Dan, let me see, I don't even have this in my background here.
+So Here on the Bitcoin design, we have this new design challenge.
+We have a page with design challenges that are meant to be kind of take home challenges.
+If you want to challenge yourself to assign something, there's something you can do.
+And Dan added covenants for scale because someone tweeted about it.
+Someone called Leishman, who is CEO of some Bitcoin company that I just forgot.
+
+Speaker 1: 00:00:58
+
+But the...
+River.
+River?
+
+Speaker 2: 00:01:00
+
+I think River.
+
+Speaker 0: 00:01:01
+
+Okay, cool.
+And that post basically said, hey, we really need people to dig into this Covenant stuff from a design perspective.
+So that kind of kicked that off a little bit.
+And then we decided to create this learning call.
+And I don't know how about how everyone else is on this topic.
+Until a month ago or so, I basically heard about that it exists and that there were a bunch of technical proposals called CTV and whatever that basically make no sense if you hear them and you're not familiar with anything.
+The term covenant didn't really tell, say anything.
+Like I put alien covenant in the background because literally that's the only time in my life I think that I've ever heard the term covenant.
+Couldn't even figure out what that's supposed to do.
+I did listen to some podcasts recently by Stefan Levera that were extremely helpful that have this great overview.
+And I don't think it's actually that difficult after listening to those podcasts.
+But then we're here in this call now that we can kind of shed some light on this stuff.
+And then hopefully we can work towards maybe some of these design explorations and figure out how this technical mumbo jumbo can actually make Bitcoin more useful for more people and maybe address scaling.
+I don't know, what is everyone else bringing into this conversation here?
+
+Speaker 1: 00:02:30
+
+Yeah, so I came across Covenant relatively early during or after my grant started because it's, I mean, it can help to improve the programmability of Bitcoin, of wallets, of transactions.
+So in terms of kind of, let's say, automated inheritance or vaulting features that might be helpful.
+But then I focus more on Miniscript, which is, can do something or something that exists today and can do something limited, similar, something similar.
+So yeah.
+And then components are like that on steroids with, kind of, yeah, on steroids basically.
+So you can do much more advanced stuff with it.
+But I didn't know about the scaling enigma thing at the time.
+Just read that this week.
+
+Speaker 2: 00:03:42
+
+Yeah.
+Hey everyone.
+Nice to see you guys.
+I think my journey on this one has been pretty I think similar to Christoph's because it's like so many abbreviations, so much like arcane stuff, like it seems so difficult to understand APOC TV CSFS.
+I mean the abbreviations go longer and longer like they're like you know what's happening.
+I think it's all very technical like it looks like there is there is a class of people mostly devs who are like interested in the in the digital money programmability side of Bitcoin.
+And so they want to make it more technically useful, and you should be able to do different things, and all of that.
+And basically, as Michael was saying about spending it in different ways and things like that and I think that's like a lot of the motivation like covenant so I think the original use case was voids so basically being able to specify different types of conditions that UTXO can be spent in and all of that stuff.
+And this thing, I think, was pretty old.
+This is from three, four years back, but in the last few months, I think it has picked up steam again with so many devs coming in.
+My perspective on this is like, this is too technical and I love understanding all this stuff, but like as a designer, I'm trying to think what are the use cases, what are the features that will help people and more like thinking not from the programmability point of view, but like scaling and privacy and those things, I think that is like something that we require nowadays, like in 2023, 2024.
+And I think I'm excited to see how it can help.
+
+Speaker 0: 00:06:04
+
+I think it would be helpful if we take a step all the way back.
+Because like you said, there's this programmability stuff and the dev conversations.
+These all seem to be pretty much already sold in.
+They're not even talking about what this thing is for.
+They're just talking about how it can work.
+And I'm actually really glad Owen is here and also raising his hand.
+Because I think just earlier I came across his two threads here, which I think you posted on GitHub or somewhere.
+And those are really good explanations of what this stuff actually does.
+So, and you just raised your hand, Owen, go ahead.
+Yeah.
+
+Speaker 3: 00:06:43
+
+Hi, I was asked to join this call.
+I haven't joined a Bitcoin design call before, but it's good to get involved.
+As you can see with those threads, I put a lot of thought recently into trying to visualize how this stuff works, because it's very difficult for people to wrap their heads around how these functions work and then what you can go on to do with them.
+And it's not actually that alien or strange, it's just different to how we do things today.
+But I started off with CTV because it's the most simple and sort of easy to rationalize about how it works and what you can do with it.
+And then other forms of covenant are more flexible versions of that that I think might be wise to put to one side for the purposes of design stuff.
+For now, the way you can think of CTV is a bit like.
+It's it's quite similar to PSBT to having a pre-signed transaction where I could technically pay you by signing a transaction to spend my coins to your address and then just giving it to you rather than broadcasting it to the blockchain.
+However, you still have to trust that I'm not going to spend those coins differently first before you get it.
+So you can't consider that PSPT a payment, right?
+Because I could spend them any other way before you broadcast it and they're not your coins anymore.
+So today we're using only the chain itself to log ownership changes.
+And what covenants allow us to do are ownership changes off-chain as long as you can plan them in advance.
+So there's a couple of use cases in those threads I gave.
+If you haven't read them already, I highly recommend starting there.
+And what, in the second thread, I got onto the actual use cases.
+And the more I've looked at this stuff, the more I've realized there's kind of two basic principles that covenants are useful for here, you end up with these kind of meta primitives.
+So technically speaking, it's what I said a minute ago about having a pre-signed transaction that I can't spend differently, so you can consider yourself paid as soon as you have it.
+But the use cases tend to be vault type structures, which are kind of using the chain to trigger a time lock because in Bitcoin's technical design at the moment, we don't have ways where like a key expires in a multi-sig or something.
+You can only make it more easy to spend.
+You can't make it less easy to spend.
+So vault type structures kind of allow you to trigger the start of the time lock, which is very useful.
+And then the other one, which is where everyone's brain starts to melt are tree type structures, which is where you're kind of, you could think of it as aggregating lots of transactions together or like a zip file of lots of transactions that only represent on chain as one.
+And it is difficult to think about this stuff, but these are the areas, particularly the tree stuff, that's where we can start doing scaling.
+And that's what I think Alex was asking people to start thinking about the UX for, because it's just very different to how we do Bitcoin today.
+But I don't think it's impossible.
+I started to think about this stuff before I even got invited to this meeting.
+And I have some ideas already, but I haven't had a chance to start working on them yet.
+Maybe I'll stop talking for a minute and let someone else speak.
+
+Speaker 0: 00:09:54
+
+Awesome, thanks.
+
+Speaker 2: 00:09:57
+
+Sorry Christophe, I just wanted to say thanks Owen for joining in.
+Those two Twitter threads are super duper useful.
+I am happy that I've gone through at least the first one a couple of times and I'm still not completely there.
+I think I have to read it again and try to do more research, but it was super, super, duper useful, man.
+And thanks for joining.
+I mean, I love that.
+Thanks.
+
+Speaker 3: 00:10:25
+
+Yeah, no problem.
+And it felt like an area I could add some value to the conversation, because I recognized there was a lot of technical people that got hurt worked, and a lot of like us normal people who just can't understand how this stuff is useful at all yet.
+And I spent, you know, the last six months or so, just gradually learning and learning about use cases and things.
+So I could start visualizing how you can actually use this and explain it to people or we're never going to get anywhere with it.
+
+Speaker 0: 00:10:50
+
+You know, we actually in the Bitcoin design guide, we have a whole section called how it works and it's very similar to what you put together there.
+It's, you know, private key management, like here's a whole thing about how multi-key, you know, systems work.
+Some of them have illustrations similar to yours, others don't.
+Here's one about custom spending conditions with recovery paths, but it's the same idea what you did.
+Just take these kind of complex things and translate them in our case for designers within the idea that then they can take that and then build products on top of them.
+So maybe we could turn this into an AI workspace too.
+Twitter threads kind of get forgotten at some point, if you'd be open to that.
+
+Speaker 3: 00:11:40
+
+Yeah, sure.
+I mean, take whatever you think is useful from it.
+I'm happy to comment if you want as well.
+
+Speaker 0: 00:11:47
+
+Awesome.
+I wanted to take one step further back.
+So as I said earlier, I didn't figure out what the word covenant means, but it's basically a promise to engage in some type of activity.
+And I found that helpful in the Stefan Levera podcast where they basically said that with Brandon Black, I think, where they said, in Bitcoin, every coin has a restriction on how it can be spent.
+But right now, it's basically you need to have the private key, right?
+There's one rule how you can spend it.
+It's the private key.
+If you have that, you can spend it, right?
+That's kind of the default that everyone knows.
+Then the second one that Michael has been looking into a lot is the time locks.
+You can spend it after a certain amount of time if you have a key.
+And then the covenants, the idea there is to just really open that door much, much further, that you can have all kinds of complex predefined rules about how this can be spent by multiple people with different scenarios.
+So I found that a pretty good starting point.
+And then the other thing that I learned that was interesting is that the CTV and all of these abbreviations and all this stuff, they're all kind of trying to do the same thing technically, and they take different approaches that end up with slightly like some of them have like some are a little bit more complex, some a little bit easier.
+Some of them have a little bit more flexibility, others are a little bit more rigid, but they're all kind of trying to do the same thing.
+And then as you dig through those, and you probably end up with different use cases.
+And one thing I found interesting, too, is that there seems to be a tendency, because the more complex proposals, they enable more, but they are more risky in terms of things that can go wrong, unforeseen circumstances and all of that.
+So there seems to be more to it, tendency towards to the simpler ones get enabled.
+So there were some takeaways that I found interesting that I wanted to add as well.
+
+Speaker 3: 00:13:53
+
+Yeah, I think that's a fair characterization and the simplicity.
+This is why I started with CTV because it's the easiest to think about and it's the most tightly constrained, but it still unlocks a huge possibility space of interesting things we can do.
+I use the word constructs because just a CTV by itself isn't that interesting but the stuff it allows you to do is more.
+Then a lot of the developers I speak to are thinking, okay, we'll start with this, we can build a ton of useful stuff already, and then as we learn more familiarity with how to use these covenant type structures and so on, we can start to realize where we need a little bit more power and a little bit more flexibility and maybe add those in later on with another fork down the road.
+But lots of people are very wary about, you know, opening Pandora's box and doing something really complicated on day one because there's, I mean, none of this stuff is going to break Bitcoin, but some of the stuff is just too complex to rationalize about what its limitations are, whereas CTV is quite tightly scoped and also very well studied.
+It's been around many years now at this point.
+
+Speaker 0: 00:14:56
+
+So a question there around the two use cases that you found.
+So the multi-sig fall vault, I find that pretty easy and that seems like it's a user-facing thing.
+You can just say, well, you know, these coins here, yeah, they can be spent, but before there, there's like a delay, basically, before they can be spent.
+So if someone else tries to spend them, then they either can't do it or they have to wait.
+So I'm going to notice it.
+I'm going to get them into safety because everyone else has to wait.
+So that's kind of user facing that's kind of easy to understand.
+Then the scaling thing, that almost seems like it's something that users might never even see that could potentially be happened behind the scenes, right?
+
+Speaker 3: 00:15:42
+
+Yeah, so this is where it starts to get complicated.
+And I think it might be useful to think of it from the two different directions.
+On the one hand, users might build these trees themselves.
+That's if you've got a number of payments you want to make to several different people for different reasons, but maybe not all of them right now, but you know, and I'm gonna pay rent next month and the month after and the month after.
+So maybe next time I get my salary arrive, I could construct a tree myself and that turns into just a regular receive address that I could give to the payroll company.
+They pay to that address.
+And I know I've actually got my rent payments for the next six months kind of locked into the chain ready to go.
+I don't need to make another on-chain transaction just by giving them that one address.
+So that's an example of a user wanting to construct a tree.
+And I can kind of picture in my head what a UX for that might roughly look like.
+I don't think it's that difficult.
+That's somewhat interesting.
+But the interesting ones are where the tree structure is built by someone else, and it allows you to be paid inside that tree.
+That's the really tricky one and that's where work needs to be applied.
+
+Speaker 0: 00:16:50
+
+Gotcha.
+So, in the first thing, so let's say I want to, right now, if I want to do six months of rent payments, I can basically make six different transactions and batch them.
+But with this CTV, then I could basically bundle them all, compress them into like a single address or so, and then they would automatically be executed as time goes by.
+
+Speaker 3: 00:17:13
+
+That's one way of doing it.
+It's more, you see this stuff is difficult to even explain, even having written the thread about it.
+Yeah, you can think of it as a compression thing.
+And that address will contain, if you've built it this way, will contain rules that, you know, I can only spend this many coins once per month or something like that.
+And so I can make my rent payments by giving the pre-signed transaction to my landlord, basically, rather than having to actually send on chain, I can just give him this transaction and that is enough information for me to look at my address I created and see that he now has all the information necessary to spend that one month's rent worth of coins from it and I can't spend them anywhere else.
+So what I'm doing is I'm just revealing some information to him and then he's able to claim them whenever he wants and he knows that I can't spend them any other way either.
+So that's how it's useful for scaling because you're moving the ownership changes off-chain.
+You're changing it from needing to stamp a transaction onto the blockchain to needing to just reveal some information to the counterparty that they didn't know before.
+Once they receive that information, they know that they have all the information necessary to claim it and that I can't spend them in a different way.
+
+Speaker 4: 00:18:32
+
+I have a question.
+So, sorry, my name is Mo from the Bitcoin design community.
+I'm the UX researcher here.
+Very random jumping into the question.
+I was just thinking for a very long time trying to piece everything together.
+You said, so this code that they share allows the transaction to happen completely off chain.
+So let's say I'm the owner of the code, and then I hand that code over to you, and then we enter into an agreement for X amount of Bitcoin and then what is preventing you from actually spending, you gave that to me but how do I know that that amount of Bitcoin actually exists and that you don't just go spend it?
+
+Speaker 3: 00:19:18
+
+So the address is encode the spending conditions for coins that end up there.
+So at the moment, all the addresses you generate with your regular today's wallet will say, you're not allowed to spend these coins unless you present a signature from this private key, right?
+That's what we're all used to.
+In a world where we're using CTV, the address that you generate will say, you're not allowed to spend these coins unless you present a signature from this private key, right?
+
+Speaker 1: 00:19:39
+
+That's what we're all used to.
+In a world where we're using CTV,
+
+Speaker 3: 00:19:39
+
+the address that you generate will say you're not allowed to spend these coins unless the spending transaction looks exactly like this that I've predefined.
+And so to the rest of the world on chain it just looks like some coins going to some address, but as soon as I show someone the spending transaction which would be you know sending coins to the landlord or whatever, then he is able to verify that that transaction, that spending transaction, is the only spending condition for that address.
+So if he's not able to verify that, because maybe you've got some secondary spending condition where Mikey can still spend it after two weeks or something, where you can try and rug pull.
+If he's not satisfied that that spending transaction is the only way to spend those coins, which he can calculate for himself as soon as he had said information, then he should not consider himself paid.
+So Maybe it might be easier to have a look at another example, which is the cold channel example, because that's a much more immediately visualizable, useful thing.
+I mean, we can't read it in the background, Christoph, but Maybe you can scroll up a little bit, because that's easy to understand.
+So the cold channel construct is something useful for lightning.
+So at the moment, when you want to open a lightning channel, you need to deposit coins into the multisig address with the channel partner, and there's normally actually several stages of on-chain hops before then because you know you're getting paid your salary or something you're not going to have that sent straight to the lightning address because you and the channel partner need to negotiate in advance what the balance is going to be and get everyone to pre-sign all the revocation transactions, all that stuff.
+So you don't tend to deposit straight into the Lightning Channel address today.
+You tend to, maybe it goes to your cold storage first and then later on you decide you want to have some more liquidity and lightning, so you send it.
+And then all the node packages tend to want you to send it into the nodes single custody first, so it can then do the negotiating stuff with the channel partner.
+And then you want to when the negotiation stuff is agreed, do you then deposit coins into the channel address and then you can start using it.
+But that's using several on-chain transactions just to get this off-chain transacting started.
+With CTV, we can do this thing called a cold channel where using a couple of different spending routes, which are in one of the other slides, you can create an address that is a Lightning Channel already, but the counterparty doesn't know about it yet.
+To everyone else in the world, it just looks like a regular deposit address.
+Then you can leave it there for months, years.
+No one else knows there's any way to spend it apart from it just looks like a regular signature address.
+But when you decide you want to start spending those, you can reach out to that counterparty and say, hey, by the way, this address here, this was actually a Lightning channel between us the whole time.
+And if they're responsive, then you can start using it like a regular channel without any more on-chain transactions happening at all.
+So you don't need to move funds from that address into a channel address or anything.
+It's already a channel address and All that needs to happen is you give a little piece of extra information to the channel partner and now he has everything necessary to start operating it as a regular channel with you.
+So why that is interesting is not only does it cut out several on-chain transactions, but it also means that you can treat this as cold storage basically.
+So you might as well receive all of your salary payments into these cold channels because you get like a free option to start using it as Lightning immediately at any time that you so wish without a security trade-off.
+Whereas today, your channel partner knows all the channels that you have together, and that means that they have the opportunity to try and steal from you, because Lightning is this sort of like cooperative, but also adversarial protocol.
+So you remove the adversarial element until you reveal the information to them.
+So that, and that works because when you, when you give the counterparty the information about all the CTV structure, he can see that the only ways to spend this coin are either through Lightning, which is just two or two multi-sig, or through the secondary path you can take is the justice transaction route.
+And he now knows that when you go that route, he will see a transaction on chain that starts a time lock where he can spend it immediately, but you can't.
+So you can, all the parties can have enough information to just start treating that existing address as a channel without doing anything more on chain.
+So you save a couple of transactions, but you also flip the incentives around.
+And that's why it's really interesting.
+Maybe there's questions?
+
+Speaker 2: 00:24:27
+
+Yeah.
+Oh, and So I think what you said, it made a lot of sense.
+I think it saves cost, and there is safety, and all of that stuff.
+How do you think existing user flows will change if we deployed cold channels?
+That's the first question.
+The second is, are there any new user flows that are enabled by this and like of course the first question was how does it change the existing user flows like you know for example in Phoenix we have deposited on chain and then there is like you know like so there is that kind of a user flow where you have to deposit funds first.
+But then the way that the Moon Wallet does it is that it like does these submarine swaps and kind of avoids it all together.
+And so it seems like around, around the channel stuff, there are a bunch of like user flows, how would you say like CTV impacts those or improves those?
+
+Speaker 3: 00:25:32
+
+So how I think it would look is first of all, you construct this cold channel by yourself without needing anyone else's cooperation.
+You just need the channel partners, public key or something like that.
+Something that they publish that isn't, isn't risky to them.
+So this would probably be like an LSP and they would probably publicize that they do this because it gets them more liquidity.
+So what I imagine the UX sort of flow would look like is you need to construct this address first of all, because you're going to give it to your payroll process, or your exchange or whoever to do the withdrawal to, so you would need to pick who the, who the channel partner is going to be, which LSP, which probably seems like a dropdown or something, you know, like Async or Zeus or whoever.
+And then it seems like the wallet in the background would do all of the CTV construction stuff, because the user doesn't even need to see or care about any of that.
+It's like a standard template that you would just deploy.
+And then the outcome of that would just be an address that you just give to payroll or whoever, and it gets paid to.
+And I think you would need to, in the sort of the wallet balance area of the app, I think you would need to keep these in a segregated spot because they need to be almost like unsealed or something to start using them on Lightning.
+So you wouldn't want to just dump it into the regular like Lightning balance because you can't start spending them right now.
+You need to, a step needs to happen between the receiving and the spending.
+It's just that that step is, does not require a non-chain transaction, just requires communications with the LSP.
+So it seems to me like you naturally end up with like a, like a cash account or something, which is your actual lightning available sats right now.
+And then maybe like checking account or something, which is like sats that are available on lightning, but you need to unseal them first, or we need to come up with a term, you know, that makes sense to people, but They're ready to go, but you need to complete the communications loop first.
+So they're sort of like reserves or something like that.
+But the unsealing seems like it could just be a regular button or something that starts a communications loop with the LSP and you ping them and say hello are you awake and they go yeah we're still here everything's fine and then you go bang here you go this was actually a cold challenge with you the whole time you're happy to start spending it and they go yeah sure whatever and then you can move it into the available funds you know.
+
+Speaker 2: 00:28:01
+
+So like would it like mean that wallets and even users might not have to think about an on-chain balance and a lightning balance as two separate things and they can just like start thinking about them as the one and the same thing?
+
+Speaker 3: 00:28:24
+
+I'm trying not to put my personal...
+
+Speaker 1: 00:28:27
+
+I think you would still have to basically top up this kind of, let's say, lightning balance.
+It wouldn't just, it would just be immediate.
+It would not be, you wouldn't need to deposit, but you would still have probably two different, let's say, buckets or balances.
+
+Speaker 3: 00:28:47
+
+Yeah, I wonder whether these might actually replace the whole on-chain balance thing because that's not awfully useful in Lightning at the moment, right, because you need to go and make another $5 transaction to start actually using it.
+Maybe these would just supersede the on-chain balance stuff.
+
+Speaker 2: 00:29:02
+
+Right, because I think right now like in the Phoenix wallet, you like try to you know, make some transactions.
+And like from the user perspective, it seems like at some random time, the wallet will tell you that no, now you like, like, you need to pay this $5 or something, and then we don't know that, like what's happening in the background is that the channel is being made larger and all of these things.
+And what it seems like you might be saying is that we don't even have like the users will never have to think about that again.
+And it will simplify like all of those all of those things those mechanics.
+
+Speaker 3: 00:29:42
+
+Yeah in an ideal world I think so.
+I mean there is still a trade-off to make So what we didn't talk about already is in the case where you've got one of these cold channels, you deposit some funds there, and then you call the LSP that it's a channel with and say, I'd like to start using it please, and they don't respond for whatever reason, then you need to basically move from that address to another one because as part of the assurances that you need to provide to the LSP that you're not going to rug them, that means that you, the only routes to spending the cold channel are the cooperative case, which is the multi-sig like now, or the like something's gone wrong and I need to move on case, which adds a time lock, which is how he's got an assurance that you can't rug pull him.
+So if he doesn't respond, you do need to make an on-chain transaction and move to another address.
+So we will still have to kind of factor that in.
+But hopefully with a professional SP, this is a very rare occurrence like in the Phoenix situation.
+You know, Phoenix is so tightly integrated with async, they're not ever going to be offline.
+It shouldn't really ever be an issue, but you do need to have that in the back pocket somewhere like how you would resolve that.
+But it should be quite rare and you know it's kind of no worse than today where you have an on-chain balance that you still can't use without spending some money on another transaction anyway.
+
+Speaker 2: 00:30:59
+
+So like these funds I would still be able to spend them for some other purpose, but I would have to do something else.
+
+Speaker 3: 00:31:09
+
+Yes, you need to make an on-chain transaction to kind of move out of the cold channel construct and into another address, which could be a different cold channel with a different LSP, like in one swoop.
+It doesn't have to be moved out to like a regular private key address and then moved on again.
+Like you can chain these things together because they're all just addresses on chain that don't need negotiation first.
+Negotiation first.
+
+Speaker 0: 00:31:38
+
+Sounds like we have two potential user flows we could mock up here.
+One, the vault and then the cold channel one.
+I'd be really interesting to see some UI explorations on those, on exactly what we just talked about.
+
+Speaker 3: 00:31:51
+
+I think that's a good starting point as well.
+The really important work to do later is the tree stuff.
+But it kind of makes sense to start small, because trees are ultimately tend to be made of these like, I mean a cull channel is basically a vault structure on top of with a multi-sig as well, it's just with different, you reshuffled who the parties are, but everything is basically either starting time locks or using keys to spend a different way.
+So it might make sense to come back to the tree stuff later on because it's like just a bigger version of all the stuff that we're covering already.
+
+Speaker 0: 00:32:31
+
+Yeah, I tried to understand the tree stuff.
+There's a point where I just didn't get through it.
+Especially once everyone's in their trees, how you have any assurances of anything in there.
+But I don't know, how's everyone else doing with the tree stuff?
+
+Speaker 4: 00:32:53
+
+Yeah, I'm going to sit in the tree right now and enjoy the view.
+That's where I'm feeling the trees right now.
+
+Speaker 0: 00:33:00
+
+But what questions do you have?
+What can we clarify, or what would you like to?
+
+Speaker 4: 00:33:06
+
+I think if I would, if it's, or I should plug in my laptop charger as well.
+I think if it's explained in a more, like the way that you have an example, if someone gets paid, I would be more able to understand it if it's an actual mock-up in a user flow, it would make a bit more sense to me.
+I'm not, it's just not quite there.
+
+Speaker 0: 00:33:28
+
+Which part?
+
+Speaker 5: 00:33:31
+
+I'm sorry, I'm gonna agree with what you just said, Morgan, and ask if someone could just step through a narrative.
+Just tell the story of how this thing works with the rent.
+Like the example, if I think, okay, I want to post-date a bunch of rent.
+Is that a good place to start?
+Like I've talked with my landlord and I'm going to stay in this apartment for a year but then all of a sudden the water heater goes and I have to move okay how would I how would I run that scenario at month six, even though I gave him a bunch of post-dated checks, how do I stop from month six to month 12 and move and not pay him until he fixes the water heater?
+
+Speaker 3: 00:34:30
+
+Yeah, so I think the rent example was not a good place to start actually, and why I wanted to move to the cold channels, because I think once you understand that a cold channel is just an address, the same as any other address, but it has lightning like optional functionality, then you can start to see how that is a very useful thing for everyone to have for like every payment they receive from anything basically, because Lightning payments are just better if you can make it work.
+And the main hurdle is that you need to get the SATs into Lightning in the first place.
+And we're kind of removing that concern.
+So rather than the landlord rent example, if you think of it as like, next time I make a withdrawal from an exchange, I'm gonna, you know, I can only give them one address.
+And let's say they're a dumb exchange that doesn't do lightning or anything yet.
+They just do boring old on-chain transactions to one address and they're going to charge me 50 bucks to withdraw or something.
+What I could do is withdraw to an address that is actually a tree of my own of which one branch is a big cold channel right now.
+Another one is like my backup cold channel that I might start using in a couple of months or something, you know, just reserves.
+And then another one is to my vault and that's like 50% of the withdrawal or something.
+You can do all those three things in one go with one address that the exchange doesn't need to cooperate with at all or know anything about.
+They don't care.
+They just send SATs to an address and you're done.
+So it's the lack of needing cooperation I think is what's very useful about these.
+That you don't need them to know or understand what you're doing at all you're just all the clever stuff is happening on Bitcoin itself and this the person spending to you the payer just sees an address So this is complicated as you want.
+
+Speaker 5: 00:36:18
+
+This would be more like, okay, I got paid and I have a checking account and three savings accounts.
+
+Speaker 3: 00:36:24
+
+Yeah, you could easily structure it that way.
+
+Speaker 1: 00:36:30
+
+And you could probably even say that at the beginning of the, or when the payment comes in, it goes into the, into the checking account.
+And from there, at the end of the month, whatever is left or a certain amount goes into, into a vault.
+Two payments go to your children for their, I don't know, chocolate and stuff like that.
+
+Speaker 5: 00:37:00
+
+But if my child has been bad and they don't deserve the chocolate, can I reverse?
+Can I switch it off?
+This is the whole, we're getting at the essence of the covenant, the promise, and the promise being broken.
+
+Speaker 3: 00:37:15
+
+Yeah, so one way you can think about that is you can have multiple different spend paths, which is true today.
+You know, you think of a multi-sig, you could have a multi-sig that requires two or three to sign today, anytime, or one key, but I have to wait six months before I can spend it that way.
+That's an example everyone's fairly familiar with.
+You can do the same thing and have a CTV spend which is you must use the exact template transaction which is some goes to the kids, some goes to the landlord or whatever.
+Or the alternative is maybe a multi-sig where the landlord and the kids and me.
+That's maybe isn't a great example.
+The point is you can, you can fuse these two things of like, you can have a templated path Or you can have a multi-sig path, and that multi-sig, you can think of that as like everyone having a veto vote, basically.
+You know, we all have to agree.
+If we all agree, then we can spend this pot of sats, however the hell we want.
+Or if we don't agree, then we can all trust the template path because that's locked in and committed already.
+
+Speaker 5: 00:38:20
+
+I see.
+Yeah, yeah.
+So, again, I'm staying with the narrative here.
+So, my child did not do their homework, so they don't get the chocolate.
+And my wife and I are on the multi-sig and we both agree, okay, no, he can't get the chocolate.
+
+Speaker 3: 00:38:41
+
+Yes, it would work like that, but I don't think it's a great example and there's maybe more confusing than that.
+
+Speaker 2: 00:38:47
+
+So, Owen, like I feel like with these covenants and like how it means like to make a promise and all of that stuff, like sometimes you might want to break like you know, like you want to be careful before you make a promise and so if you like do like this this something of this like a transaction structure and then you want to like don't want to do that So is it possible in like scenarios like this to like have this like to commit to something that I will do this, this and this but then have the option to say no I don't want to do it.
+
+Speaker 3: 00:39:31
+
+Only if you've built it that way.
+So remember, the address encodes the spending conditions.
+So you've decided what conditions should apply for you to be able to move those coins.
+And the covenant is almost more useful as a way to prove to someone else that I can't spin it any other way.
+So maybe another example, and this is still a little bit abstract, it's not that useful by itself, but we can use it for payments between three people.
+So we've already covered the compression thing.
+We can give this one address to the exchange and it has many different things inside it.
+Imagine that there are three branches and they are each branch is owned by one particular person.
+Alice, Bob, Charlie.
+Let's say we set it up so that the template route is, you know, exactly one third goes to each member, but there's also a multi-sig route that must be three of three.
+And that multi-sig route, you can spend to anywhere that you want.
+So We can all fall back on the everyone gets exactly one third equally, because we know that that can't be removed unless we all agree.
+But if we do agree, we can spend it any way we want.
+So if Alice needs to pay Bob for something, and Bob needs to pay Charlie for something, and Charlie does something else for Alice, whatever, we can change the amounts.
+It doesn't have to be one third to everyone.
+It could be 90% to Alice and 10% to Bob and nothing to Charlie, as long as we all agree on that.
+And if we all agree, we can sign a transaction to spend from that initial address we gave.
+And then it moves on to spend to wherever we want, because we all agreed.
+So, you know, that's not really that useful in the real world, but as a principle, maybe that explains better, like how this stuff can work.
+
+Speaker 2: 00:41:15
+
+Yeah.
+Yeah.
+Like I, I just heard, like your example in detail, I think you're like absolutely right.
+Like that's not exactly giving the picture of what CTV can do like it seems like in this case it would be CTV plus like some of the other taproot things and all of that and combine them to get this use case.
+Like this flexibility, I think that's the point here.
+Yeah?
+
+Speaker 3: 00:41:41
+
+Yeah, it's not that useful by itself, but it's very powerful primitive when we combine it with other things that we have.
+
+Speaker 2: 00:41:50
+
+Right.
+Right, so I was thinking, trying to think about it in the lens of something that you mentioned earlier.
+It's like, what are the new new use cases it enables?
+How does it improve some of the existing use cases?
+And like, what is like, you know, like, maybe it can do the exact same use case, but with improved privacy, or lower costs, or things like that.
+So can we try to think about the use cases and CTV like in these three categories, just to be able to understand it and the applications in a more concrete way.
+
+Speaker 3: 00:42:40
+
+Okay, so that example I just gave with the three people, that's a very small example of what's called a payment pool, or I kind of use the word tree sometimes because that's more like how it's actually structured.
+But these can be scaled up to whatever size.
+I mean, the limit is basically how large do you think you can reliably collaborate between people.
+You know, like three sounds probably pretty easy, especially if you've got no time constraints.
+10, probably fine.
+Theoretically, hundreds, I guess, if you're like not in a rush, maybe.
+But also remember that those inside the tree structures, inside the CTV, they're just payments to addresses, and addresses can also be CTVs. So each of those can be like, each branch can be another tree in itself that you don't even need to know about or care about.
+Like that payment to Alice might actually have had, you know, 500 branches coming off of it.
+Some of them were vaults and some were cold channels and some were all sorts of other stuff.
+So why this is powerful is because this allows us to scale Bitcoin significantly by pushing all this transacting off-chain but with on-chain level of assurances still.
+And there have been some papers even demonstrating that, I mean, things get a little bit unwieldy for sure, but in theory you can do global scale with this stuff if you can have a tree with a million people in, which is done by using some timeouts and things to force roll over the particular time so that everyone can rely on stuff without having to get those million people to actually collaborate on everything.
+So this is the scope of what we're talking about here.
+
+Speaker 2: 00:44:17
+
+But we need to start small with things we can design right now for sure.
+Yeah, yeah.
+But it's like, I hear what you just said and I think, yeah, so this is like scalability and it improves privacy.
+Like these use cases could be like, so if it's just like one UTXO shared by a dozen people, and then there is like a spend from that, you don't know who was the owner of the previous one and who's the owner of a new one and things like that.
+
+Speaker 3: 00:44:47
+
+So right.
+So with what you can surveil on chain, you're just seeing one UTXO and it we're all kind of familiar with it with lightning already where it's one UTXO on chain but it's owned by two people but the SATs in it you know when we when we broadcast the closed channel state and I have you know 5,000 fewer SATs you know that I've paid them to the channel partner,
+but you don't know where he sent them onto because I've routed it through the whole Lightning network.
+So that, you know, the privacy improves significantly.
+And a simple way to think about it is that you have that effect but with more than two people inside that UTXO.
+And you actually don't even know how many people are inside that UTXO.
+So it could be two or it could be a million.
+And there's kind of no real way to know.
+So you kind of get a lot of privacy for free.
+Not perfect, sure, but better.
+You get the payments kind of flexibility stuff in the same way as we do with Lightning.
+But I think that the most compelling case for CTV was the scaling stuff, which is what a lot of people didn't really understand until about six to 12 months ago, just because it's very abstract and hard to think about.
+
+Speaker 1: 00:45:52
+
+It doesn't have the picture mode.
+Like the movie Inception, you can have a dream in a dream in a dream, right?
+That's the forest for the trees.
+Dream in a dream.
+So that's, I found it actually a pretty, a pretty good visual in the tweet thread.
+Yeah, I'm going to definitely next week work on the vault thing because it's basically what I, in the hackathon, like a year and a half ago, worked on for the inheritance topics where you have a dead man's switch that keeps transactions from happening.
+But you have to have previously kind of on-chain transactions for everything.
+And you couldn't have something like really these time locks where you have, let's say two weeks or a month before to reclaim the funds.
+So to an emergency address.
+So that's definitely something that I'm gonna work on.
+But I had a question.
+Can I already say if I have, let's say, one Bitcoin and if create a transaction or have a kind of a setup where if I spend less than 0.1 Bitcoin, then I need only one signature?
+If I want to spend more, I need two or three.
+So Is this something that, I mean, that would be also a use case for these kinds of things, no?
+
+Speaker 3: 00:47:37
+
+Yes, so you can't do that today, but you could do that in a Covenants world.
+That would look like having several different possible spend paths, one of which was a template of the spend must be 0.1 BTC to address A with key A and path 2 might be you need keys A and B and it goes to address C for 0.2 BTC or whatever.
+You get the gist.
+
+Speaker 1: 00:48:01
+
+Exactly.
+So we have a reference design crystal right for for exactly this use case I think it's in one of the In the shared world.
+So somewhere we have exactly that where you have The condition that if it's less than something, only one signature is enough.
+But these are, I mean, these are the practical use cases, I'd say.
+
+Speaker 0: 00:48:28
+
+No, that's a different, that's assisted custody one, where you have an auto signer that signs transactions below a certain amount to facilitate low amount payments.
+And then for larger amounts that you're not comfortable with being automatically approved, that's where you need to get your extra keys out but it's the same key configuration there's just the software kind of enforces them.
+
+Speaker 3: 00:48:54
+
+So in that example you're kind of trusting the signer software or the custody partner or whatever to not sign if they don't meet your terms But this is what CTV kind of does is it allows us to take things that were previously trusted and make the chain be the only trusted thing instead, which is obviously an improvement for many things.
+
+Speaker 0: 00:49:15
+
+Yeah, so I feel like I get some of this stuff, right?
+So if I was just trying to diagram a few things here, I made lots of other diagrams here earlier today for explaining fiat over lightning with synthetic, you know, fiat and all of this stuff.
+So I'm just reusing those.
+So, so here's my understanding.
+So Alice comes up with a bunch of rules, right?
+Like I can spend these Bitcoin after one, after two Bitcoin after one year.
+But Charles, he can take, spend one of those Bitcoin after one month, and he can spend another one Bitcoin after two months, whatever the rules may be, right.
+And then I kind of compress them and turn them into this address.
+And then, you know, I tell Bob, Robert, who is my employer, So I give him this address, it looks like general address, like no one can just looks like an address.
+And they're like, okay, here's your salary.
+And then that means these Bitcoin here will be locked to the conditions saved in this address.
+So now we have rules and we have bitcoins tied to them.
+And from then on, all interactions with these Bitcoin are governed by these rules.
+So but no one knows about those rules, only Alice does, right?
+So my landlord, which is this guy here, Charles, I have to tell him about those rules, right?
+So I have to give him an address.
+And it's like, here's my address, there are two Bitcoin in there.
+And here's a rule that I baked into this address, and Charles can verify from the address like that, that's actually accurate.
+And there are no other rules, which are where Alice can secretly take things away.
+And he's like, okay, cool, I can spend one of those Bitcoin next month and then another one in two months, right?
+But that's it.
+Like no one can change these rules anymore.
+And we're all kind of tied to them.
+And that's kind of it.
+So that's my understanding.
+How do we get here from trees and trees and billions of scale?
+Maybe it needs another 400 diagrams.
+
+Speaker 4: 00:51:16
+
+This makes sense.
+This makes a lot of sense.
+
+Speaker 1: 00:51:19
+
+And another call probably.
+
+Speaker 2: 00:51:22
+
+But does this one require CTV, Owen?
+
+Speaker 3: 00:51:27
+
+Yes, because CTV is What's being used to say, you know, you can only spend one Bitcoin.
+Today, you can do time locks, sure, but you can't constrain how much.
+All you can do is completely unlock the address or not have it be spendable.
+Whereas with CTV, you can say how it can be spent, which includes, well, in CTV is a specific type of covenant that is all the terms of the spending transaction are built in already.
+So it's how much and where to.
+But with some of the more flexible covenant ones, you can pick and choose which bits of the transaction you want to constrain.
+But it's easier to think about if you're using CTV as a starting point, where it's just like, this is exactly how it must be spent and nothing else.
+
+Speaker 0: 00:52:09
+
+I had one question on here, and that wasn't clear to me.
+So Alice can say, here are the rules, right?
+But what is the unique thing that only allows Charles to spend them?
+Why cannot Alice not spend through those reels?
+There has to be some secret that only Charles has where Alice can't give everyone else.
+
+Speaker 3: 00:52:30
+
+It's actually, it's not that Charles can spend it.
+It's that one Bitcoin can go to Charles's address after one month Okay,
+so anyone who has this information can just broadcast it straight away.
+Think of it like a PSP T that can't be spent differently The rule is the Bitcoin has to go to Charles's address.
+
+Speaker 0: 00:52:47
+
+So Alice has to know Charles's address in advance when she comes up with those rules?
+
+Speaker 3: 00:52:52
+
+Yes.
+So that's one of the kind of useful limiting factors of CTV because you can only bake as much in as you can kind of coordinate in advance.
+That's what stops things from going completely off the rails.
+
+Speaker 0: 00:53:03
+
+Okay, so we need a thing here, like, where Alice talks to Charles and says, give me some addresses.
+And then she can bake those in the oven.
+
+Speaker 1: 00:53:24
+
+Okay, I'll have to.
+
+Speaker 3: 00:53:25
+
+And who knows what the addresses of the trousers are.
+They might be just vault addresses or they might be regular keys, or they might be trees or they might be vaults or they might be cold channels or God only knows what he's doing with them.
+But as far as you're concerned, it's just an address.
+
+Speaker 1: 00:53:39
+
+Okay.
+
+Speaker 2: 00:53:42
+
+Yeah.
+Owen, I think we spent the whole hour like talking only about the CPU, and there are like a dozen more proposals and stuff.
+
+Speaker 3: 00:54:03
+
+I lost the tail end of that question.
+
+Speaker 2: 00:54:05
+
+Oh, sorry.
+I was asking about like, what about some of the other proposals like this is just all about CTP just about but what about LHANS and OPFALT and CSFS and there are so many of these, I don't even know what that is.
+
+Speaker 1: 00:54:28
+
+You have to wait for the next tweet, Brad.
+
+Speaker 3: 00:54:32
+
+LHANS packages CTV plus CSFS and something else to kind of make a suite of soft forks bundled into one that are particularly very useful for Lightning.
+CSFS, just a way to think of it holistically is that CTV is the most constrained version because you specify everything, every element of the spending transaction in advance.
+And CSFS and other proposals allow you to say, you know, maybe I constrain the amount, but not the destination, or vice versa.
+But you're generally making it more flexible.
+And then there's other technical differences, like exactly how they go about that inside the code, and which bit gets hashed when, and which bytes are used for that, whatever, and so on, which is way beyond me.
+But from an object level, as far as we in the UX world are concerned, CTV is like everything must be defined in advance about how this gets spent, and other covenant proposals are, you can choose which elements you want to constrain and how.
+But that makes a design space even larger.
+So I haven't even started thinking about those yet.
+
+Speaker 1: 00:55:42
+
+One of these things I seem to remember, and I hope I remember it correctly, is that you could leave out which UTXOs should be bent.
+Because you don't know in advance.
+
+Speaker 3: 00:55:56
+
+And that's any PrevOut I think APO.
+
+Speaker 1: 00:55:58
+
+Yeah, probably.
+Yeah.
+Yeah.
+It's a, it's a big design space.
+
+Speaker 3: 00:56:07
+
+Yeah.
+So I can't advise awfully much on anything else besides CTP at the moment, just because it's just even larger to think about.
+I know any PrevOut is particularly useful for lightning because it allows you to, you don't need to keep holding on to all these old channel states just in case someone broadcasts a really, really old one.
+You can just keep hold of the latest one in the case that the channel goes wrong and you have to force close it suddenly somehow.
+The latest one is enough.
+You can forget about everything else.
+But I don't know how that is used in, you know, other more interesting covenant constructs yet.
+
+Speaker 1: 00:56:41
+
+Right.
+Yeah, probably you would, I mean, actually we would probably need to know what we want to do before we, and then only then can we say, okay, is CTV enough or do we need something else?
+Or is, so probably reverse the reasoning there a bit because, Yeah.
+
+Speaker 3: 00:57:04
+
+That's one of the arguments that gets made and why there's a lot of kind of discourse about this stuff, because some people want the really expressive forms, some people want the really limited forms of covenants, and I'm in the camp of the really limited form Because there's already a lot of very interesting stuff we can build with it.
+And we don't, we also know it's about as safe as you can get in terms of soft fork upgrade, because it's so limited in scope and well studied.
+And then as we build more things with it, we can start to see where it doesn't quite do enough and then we have more confidence about what extra things we need to add without breaking stuff.
+
+Speaker 1: 00:57:41
+
+Yeah, this was super helpful.
+I really learned a ton today and from the threads.
+It was really, really helpful.
+
+Speaker 0: 00:57:51
+
+Yeah, for sure.
+We should really throw some, we could do a design huddle where we actually just collaboratively just try to design some flows for it.
+I mean, I'm thinking about basic stuff where, you know, you look at your, you look at your coins in there.
+I mean, you're going to have to look at your balance or your transactions.
+And there has to be a little thing that says this one has extra rules attached.
+And then you'd have to somehow see those extra rules.
+And then you would have to think of the whole backup flow that this, because this is off-chain data that it doesn't get lost.
+Yeah.
+Yeah.
+
+Speaker 1: 00:58:27
+
+We could also in a design huddle have these kind of real world use cases like the one with the rent and the one with something else and say and then we give that to Owen and he says we have a he makes the table with all the different government proposals and he said okay you can do that with any product or with all these different things.
+So we can compare them.
+
+Speaker 0: 00:58:58
+
+Okay, and here in my background to wrap things up are some AI generated trees made of Bitcoin addresses.
+At least that's what Mitrani thinks it looks like.
+Looks more like broccoli.
+But that can be our next topic.
+
+Speaker 3: 00:59:14
+
+Hey, That's cool.
+
+Speaker 6: 00:59:21
+
+Yeah, I had a question and I got to know the idea of it, but I have a small question.
+I know that all of this is off-chain, and how will he spend it?
+Like the last, when the owner or whoever gets the amount.
+And he can spend it like that, or he needs to go and convert it into on-chain, and then he can spend it.
+
+Speaker 3: 00:59:50
+
+Yeah, that's the million dollar question.
+So this is where a lot of people get stuck, including like really smart developers and things because it's hard to visualize.
+So you will eventually think of all the stuff you do with the covenants, the CTVs or whatever, as being able to, how far you can organize things in advance by collaborating and working together.
+So, You know, I won't give an example, that's more confusing.
+So there's only so far ahead that we can plan and collaborate and things can actually work.
+So once you reach the end of that and you need to change the structure altogether or something, you will need to go on chain, but it doesn't have to be that every single member of the shared UTXO have to all exit out of the chain and then all start again.
+You can work together and say, if you're doing a payment pull structure, and Bob wants to leave or something, Bob needs to do something he can't possibly do inside this structure anymore.
+The rest of us can be like well I'm fine still staying in here I don't need to get my own new TXO on chain and then organize pooling together again in another one.
+Why don't the five of the rest of us will all just hop across at the same time that Bob exits and start another pool or join an existing pool somewhere else.
+So it's like, it's just the way we use Bitcoin today is kind of quite crude and simplistic and we need to start realizing that the Chain is for like logging commitments that you can't go back from, basically, rather than ownership transfers, because we can now achieve ownership transfers off chain, but there just comes a point where we will need to do something that we can't do off chain and we can capture that change in a non-chain transaction, but it doesn't have to be splintering it into a million pieces and starting from scratch.
+We can still collaborate to move from one tree to another.
+But this is the stuff that's super hard to visualize, so I may not have explained anything at all.
+
+Speaker 6: 01:01:50
+
+Yeah.
+Okay.
+And one more question.
+In the start, it was, you said that it's necessary that they respond back.
+What was that about?
+
+Speaker 3: 01:02:03
+
+It's necessary that there's what, sorry?
+
+Speaker 6: 01:02:07
+
+Like when there will be the, like Alice has the rules, set up the rules, and there's a landlord.
+So when it goes to him, he'll have to respond back, something like that.
+Is that, I didn't get that idea.
+
+Speaker 1: 01:02:30
+
+Or I just like it.
+
+Speaker 3: 01:02:31
+
+I'm not sure I like, I wish I'd never said this landlord example because I think it's more confusing.
+Okay.
+Christoph is showing some stuff on the screen.
+Was it about that?
+What's on the screen right now?
+
+Speaker 0: 01:02:43
+
+I think the idea, I think the question is like, what does Alice actually give him?
+And it's, I mean, the understanding is she basically gives him a ready to broadcast transaction almost.
+It's like, hey, here's information that you can broadcast, but it's not and, but you don't have to do it now.
+And it's not valid right now.
+But in a month, you can do so.
+And then the landlord, Charles here, he just has to keep that transaction or that piece of information and then months later just plug it into his Bitcoin wallet and say hey you're broadcasted I want this to be executed and then the Bitcoin will be transferred.
+
+Speaker 6: 01:03:24
+
+Okay so he has to reply back to Alice that I want to use it?
+
+Speaker 3: 01:03:29
+
+No she she will give him this little chunk of information.
+So think of it as if we were doing it with PSBT, with signed transactions.
+You know, she could, if we weren't using covenants, she could give him a pre-signed transaction and say, look, here's everything you need to withdraw some coins from my address and send them to yourself, signed by me.
+But he can't trust that because she could spend the coin differently before he broadcasts it, so he has to broadcast it now and get it mined for it to be sure that it's his.
+But in a world of covenants, she can say, here is that same PSPT, but you can also see that the address they're in, I can't spend them any different way than by broadcasting this transaction that sends them to you.
+So you're using the transaction as the key that opens the lock now, rather than just a regular key.
+By doing that, he may not even need to bother broadcasting them at all until he needs to go and buy a car next year or something, because he knows they can't go anywhere.
+They're effectively, they are his.
+They're not able to be moved by anyone apart from him.
+So although they're not in his address yet, he can consider them his because there's nowhere else they can go.
+
+Speaker 0: 01:04:36
+
+Yeah, I guess the one addition is that it's tied to that piece of information.
+It's not an address generated by his wallet.
+So he would have to make sure to keep that piece of extra information, because if he loses it, then he cannot get it back.
+Yes.
+
+Speaker 3: 01:04:53
+
+But I also think that's a huge deal, because you already need to preserve a blob of information.
+You know, the user doesn't even see the key anymore.
+And the wallet software is holding on to that key for dear life because if it loses it, it can't sign anything anymore.
+So this is just in an abstract sense, I think it's just a different blob of information the wallet needs to hold on to and make sure it backs up to the cloud or whatever.
+It doesn't even matter if you keep it in iCloud or anything because it's not sensitive, it can't be abused by anyone, it can only send the funds to you.
+
+Speaker 1: 01:05:26
+
+One design challenge that I think will be for the recipient to, they have to be able to inspect this address, right?
+Or what it does somehow.
+
+Speaker 3: 01:05:42
+
+Yes.
+
+Speaker 1: 01:05:43
+
+So that means I would kind of, wallet software would need to kind of surface this information in some kind of usable way.
+Yeah.
+
+Speaker 2: 01:06:00
+
+I think about it like a bit like a joint, just like one set, cause like that also involves the PSPTs and all that stuff.
+So maybe they could like construct.
+So basically Charles could construct the transaction or like construct something, send it to Alice and then she does her stuff, adds her keys or signatures or like whatever.
+And then she sends it back.
+And that's like the transaction that's like ready to broadcast.
+Is that the right way to think about it at all?
+
+Speaker 3: 01:06:35
+
+I'm not 100% sure.
+What we can say is that when Bob receives the spending transaction that we haven't broadcast yet, he could even himself go and reconstruct the address.

--- a/bitcoin-design/learning-bitcoin-and-design/fedimint.md
+++ b/bitcoin-design/learning-bitcoin-and-design/fedimint.md
@@ -1,0 +1,815 @@
+---
+title: "FediMint"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://www.youtube.com/watch?v=lQ0dETyS28o
+tags: ['ecash', 'ux']
+speakers: ['Stephen DeLorme', 'Justin Sun']
+categories: []
+date: 2022-07-29
+---
+## Introduction
+
+Speaker 0: 00:00:02
+
+Recording is on.
+
+Speaker 1: 00:00:04
+
+All right.
+Welcome, everybody.
+This is the Learning Bitcoin and Design Call.
+It's July 26, 2022.
+And our topic this week is Fediment.
+And we have Justin Moon here with us and several designers and product folks in the room here that are interested in learning about this.
+So I've got a FigJam open here where we can toss images, ideas, text, links, whatever we want to consolidate during the call.
+And anyone on the call right now can find that in the Jitsi chat if you want to jump in there with me.
+But without further ado, I'll just turn it over to Justin and I'll let you kind of take this wherever you want to take it.
+If you want to center this around specific questions, we can do that.
+Or if you just want to take it away and give us an overview of Fediment, that's cool too.
+
+Speaker 2: 00:01:00
+
+Yeah.
+So Fediment is kind of hard to explain.
+
+## Justin introduces FediMint
+
+Speaker 2: 00:01:03
+
+It's a little bit like Bitcoin and there are sort of different facets to it.
+So, let me think how to best explain it.
+So I guess one way I'll start from just like the obvious thing.
+So one thing that it's a layer two technology basically or you know whatever you layer two layer three whatever you want to call it.
+And it it works really well with the layer two technologies like with Bitcoin and then with lightning.
+So that's kind of how to think of it.
+It's a layer two technology.
+And so what is it used for?
+Like One thing that it's very good for is scalability.
+
+## Scalability
+
+Speaker 2: 00:01:50
+
+So it's basically like you set up, it's kind of like a, think of it like a side chain, like Liquid or something like that, that allows people to transact without having to go on Bitcoin.
+So a lot of new people, for example, one FedeMint Federation can run on a couple of Raspberry Pis and it can do about as many transactions as Bitcoin.
+So if you can think of a world where like there's 10,000 of these out there, then you just increase the amount of transactions that Bitcoin can support by 10,000 times, something like that.
+So that's one thing that it's a way of moving transactions off of bit coin.
+So it helps bit coin scale.
+It also helps lightning scale.
+One problem with lightning is that it's kind of difficult to run a lightning node just because it's not just a UX problem, there's UX problems, but it's just a complicated protocol and there's, you know, so you have to manage liquidity, you have to manage channels, you have to stay online all the time.
+There's all kinds of difficulty in terms of being able to send a payment across a bunch of routes and have every single peer really online and everything.
+It's difficult for a mobile phone to be able to do this, for example.
+And also it's capital intensive.
+You have to lock money into a channel, right?
+And so, FedEment also helps scale Liquid because you could have a lot of users share one Lightning channel, for example.
+And so, it allows for a little more specialization there too.
+So for example, you can have one really expert lightning node operator serve like, let's say, a thousand people in the FedInventor, 10,000 people.
+So it's a little more specialization there and that these lightning node operators can compete based on how good they are at completing lightning payments.
+And so usually when you have these trade-offs for scalability, for outsourcing stuff like running a lightning node, usually the privacy is terrible.
+Usually that's the trade-off.
+It's more convenient, but the privacy is terrible.
+
+## Privacy
+
+Speaker 2: 00:03:51
+
+And so one of the things that's very interesting about Fediment is that while it helps with the scalability, while it helps with a simpler user experience, the privacy is actually better than with Lightning or with Bitcoin.
+And I won't give, you don't need to know too much about it, but I'll give just like a simple example.
+So how FedEvent works is users deposit money into it and can withdraw from it.
+So it's custodial.
+And when you deposit money into it, you get an IOU.
+And the IOUs have an interesting property where any two IOUs, once they're issued, let's say I'm issued an IOU, I deposit and I get an IOU.
+Steven deposits and gets an IOU.
+When Steven goes to redeem that IOU, the Mint can't tell if it was him or me.
+So every one of these IOUs looks exactly the same.
+And so that's where the privacy comes from, is that you get these little IOUs and everyone looks the same.
+And this is why it has to be kind of a custodial system because it's IOU based.
+And So yeah, you can think of it that way.
+It's very good for custody or it's very good for scalability and it's also very good for privacy and And so now let's talk a little bit about the custody side so you have to deposit into a mint.
+
+## Custody with a federated mint
+
+Speaker 2: 00:05:13
+
+What is a mint?
+So usually when you deposit into something it's like one entity, right?
+There's one entity that runs it and if that entity decides to treat you poorly, you're just out of luck.
+And so how Fetiment works is it's something called a federation.
+And a federation just means that instead of one entity running it, there's multiple entities.
+And one example of this is Liquid.
+Liquid is a federation, right?
+So it's a second layer blockchain that has a bunch of features that don't exist on Bitcoin.
+For example, confidential transactions.
+These are transactions where the amount is hidden or confidential assets.
+These are, I think you can't even see what the asset is and you can't see the amount either.
+And so, Fetiment works similarly underneath and why is that useful?
+Well, if you have a custodial thing that adds a bunch of, that has great privacy features, maybe it's a target of tax, for example.
+And so if you spread out who runs it it might be a little harder to shut down for example and so and I guess so one last interesting thing about this.
+So, yeah, Federation is basically, it's like a multi-sig.
+It's a multi-sig.
+Each one of these servers, there's like, let's say me, Steven, and Christophe are running Fetiment, right?
+We'll each have a server and the server just runs one program, Fediment, a little, very simple, relatively simple program.
+And so underneath me, my server, Steven's server,
+
+Speaker 3: 00:06:41
+
+and Christophe's server all have one key and a two of three multi-sequence site.
+
+Speaker 2: 00:06:46
+
+And so we just have, and then the server itself has a bunch of logic for what to do with that custody of Bitcoin, right?
+Like whether to accept the deposit, whether to issue a withdrawal, whether to issue these e-cash tokens, and lastly, whether to use these e-cash tokens to basically incentivize a Lightning node to do payments for them.
+And so the federation is the multi-sig and then there's some logic inside that my server, Steven's server, and Christophe's server need to agree on that allows basically smart contracting.
+So it's kind of like underneath, it's kind of like a smart contract as well.
+And the smart contracting so far is very blunt, but one of the, they can only do a couple of very specific things.
+But I think one of the promises over time is that all the smart contracts and that exists on we'll call them altcoins could exist here in a federation.
+And when you really think about it, most of these altcoins are basically federations, right?
+They're not terribly decentralized.
+There's a handful of entities that basically control what the rules are and you know they they pretend to be something very distributed and organic like Bitcoin but we know that most of them, all of them besides Bitcoin really aren't this way, especially, you know, and some of them aren't even close.
+And so, you know, if you had like a let's say you had a federation with 100 servers, that's probably more distributed than Ethereum is.
+You know, that's probably more, there's probably less centralized trust there.
+And so if, if, if smart contracting is a good idea, like if there are a lot of use cases, potentially it could happen on a system like Fediment that's a federation and it would work just as well as on Ethereum and plus there aren't, it's all trust-based.
+So you have to trust who runs the servers.
+That's an important thing.
+To use it, you need to trust me and Christophe and Steven, right?
+And you basically trust that no two of us conspire to steal the money from everyone else.
+Right.
+So it's a trust based system.
+So the security comes from trust and not from proof of work or proof of stake or any of these other consensus mechanisms.
+And from my point of view, that would be completely inappropriate for like a global money like Bitcoin.
+But like, I don't know, one example we talk about the land registry, right.
+A way to register land titles and like a local area not global just a local area this would probably a lot better than a proof of work mind blockchain or something it's just simpler and clearly trust based so yeah so these are kind of some of the different angles of pediment and just to sort of summarize this Like, you know, what the hell is this used for?
+
+## Community banking use case
+
+Speaker 2: 00:09:23
+
+We think it could be really interesting thing for like community banking kind of like Galoy Has been used so far.
+So, you know last week there was a company announced FDI.
+We're not going to talk about that in the call but that's just an example of like the use case there will be community banking to try to actually deploy these in areas that are under, that really a lot of these places just don't really have much of a financial infrastructure like we have in the West.
+I have in the West for example.
+And yeah, they also have a lot stronger trust relationships in their local communities.
+It's less institutionalized in the West for example, but on the other side, the trust relationships at a local level are much stronger in the US.
+For example, a lot of people don't trust their neighbors at all, which is kind of sad.
+So yeah, with that, I'll pause and kick it back to Steven and Chris.
+
+Speaker 1: 00:10:19
+
+That's awesome and I'll go ahead and say if anybody has any questions feel free to you know chime in throughout this call.
+These are usually pretty open.
+I can think of one but maybe before I ask one does anybody else in the room have any questions like for Justin having having heard that overview of what Fedimate does?
+Cool, well I'll jump in with one.
+
+## Where is the FediMint project right now?
+
+Speaker 1: 00:10:50
+
+Oh sorry go ahead Christoph.
+
+Speaker 4: 00:10:51
+
+I was just gonna ask where is the project right now?
+Is this a very new idea that's just kind of starting to take shape or how far is the development of their first alpha version.
+
+Speaker 2: 00:11:05
+
+Yeah great question.
+Yes it's kind of a it's it's been a research project for like kind of like a couple of years.
+Eric Syrian the creator had this idea a few years ago and then there's a lot of cryptography and stuff that he needed to develop before it would actually be usable.
+So he's working with Blockstream at the time so he got a lot of valuable basically mentorship from people like Tim Ruffing, some of the other cryptographers that, let me know if this is too windy by the way, if it's making a bunch of noise.
+So, you know, so that was kind of going on for like the last two years or so and so now it's at a point where it's starting to become usable like so you can you can run it on your computer and you can run like a lightning node to lightning nodes and you can have you know you can do lightning payments with it running on one computer over there I could bring it later on we have a stack of four Raspberry Pis that are our first like federation so we've deployed it on one it's still like testing but it like one actual thing where the each one is running on a different server and that works and so we're currently basically trying to set up the first one that we have a prototype mobile app that can just send and receive lightning.
+And so we're currently in the process of trying to get our first deployment that can send and receive with fake Bitcoin, like RegTest or Signet, something like that, Bitcoin.
+So it's getting to the point where it's usable, but definitely not on main net.
+And so hopefully, we're hoping like maybe three months from now, four months from now, kind of like October timeframe, really, we could start having our first testing on main net of the Federation.
+So it's kind of like alpha, pre-alpha.
+But the foundation is really strong.
+That's a really great thing about this from the software point of view, is that the software is extraordinarily high quality from my point of view.
+So while it's not quite ready, like the foundation is really strong.
+So hopefully, you know, the testing will be successful.
+We won't have to go back to the drawing board very much.
+
+## Self-custody vs. Community-custody
+
+Speaker 1: 00:13:21
+
+So it's curious to know, how do you think about the custodial nature of FedEmit because I think you know for a lot of people in open source you know we think about you know you know self custodying the seed phrase or having you know a channel backup of your lightning node or something like that and this this project is interesting because it's actually being like no we are custodial we're just custodial in a different way so you can tell us your thoughts a little bit about how you think about that.
+
+Speaker 2: 00:13:47
+
+Yeah.
+So I mean I love self custody.
+I have a very paranoid multi-sig personally.
+So we're pro you know we're pro self custody.
+And on the other hand almost everybody uses custodial heavily centralized custodial services today And many of them indirectly steal from you by selling you fake Bitcoin as if it's the real thing.
+And so I don't know.
+This is one of the you know, when we see in the kind of the community discussions, like there's a lot of discussion about importance of self custody, but there's a little bit of a blindness to the fact that all the normal people use heavily centralized custodial third parties that are not your friend.
+So a lot of the idea with Fetiment is to try to find something between hardcore self-custody and not just hardcore but like self-custody and these super centralized third-party custodians.
+So that's one aspect and there's another aspect of it too.
+Like, you know, I have self custody.
+I've done it for a long time, a while, and I'm comfortable with it.
+But I would still like to use this because I don't really care so much about self custody for my lightning node for payments.
+What I want for my Lightning node for Lightning is I want the payment to work every single time.
+I want it to never fail.
+I want it to work quickly.
+I don't want to have to maintain anything.
+I don't have to think.
+And I would like it to be private.
+That's what, so like I would personally love to use this for a spending wallet for Lightning in addition to multi-sig gold storage.
+And I don't know, you see this on, you know, there's, if you ever had like the taco truck at a Bitcoin conference and look at the wallets people are using, you'll notice that a lot of people's lightning wallets who are hardcore, you know, self custody maxis are, you know, they're using custodial lightning wallets.
+So, yeah, so I think it's Yeah, those are two angles.
+
+Speaker 1: 00:15:52
+
+Yeah, that makes sense.
+And, you know, another another kind of thing I've been you know I'm not sure if anybody else on the call has been like kind of following up with like all the Fed emit podcasts and stuff but one other angle I thought was interesting is just the idea that like if you're going to have a custodian it might as well be like someone you trust in your community.
+That's a great point.
+Yeah.
+And I guess what I.
+
+Speaker 2: 00:16:18
+
+There's an Uncle Jim aspect of it too, right?
+Like we've talked about this Uncle Jim idea of having, you know, there's a big question, how are normal people going to access Bitcoin?
+Right?
+And currently, the answer is finance, right?
+Like that's the if we're being honest, that's the answer currently is like, is finance coinbase FTX.
+That's what people are using.
+And So it'd be nice if we could have something where it's like you know Stephen's neighbor accesses it through Stephen because Stephen's an expert right.
+Christoph's landlord access it to Christoph and you know people in their community who are like the experts that would be like an interesting point of that would be an that would be an improvement right and we have to be realistic about you know how you know whether how much effort people need to be spending on their Bitcoin stuff, right?
+Like ideally, we shouldn't all be spending a part-time job just to use Bitcoin properly, right?
+Like that's a lot of it is like, can we create like good default, default privacy, right?
+Like, cause you can get really good privacy today, but it takes a lot of effort.
+And it would be nice if we had a little bit more like default privacy that doesn't require any effort.
+Yeah.
+
+## Are mints interoperable? How chaumian mints work
+
+Speaker 1: 00:17:30
+
+I have a question.
+
+Speaker 2: 00:17:32
+
+Go for it.
+
+Speaker 4: 00:17:33
+
+Okay.
+So two questions, actually.
+One is, are mints interchangeable?
+Can I take an IOU from Steven's mint and redeem it at your mint?
+Or is it bound to a specific mint and is it possible to find out like here's an IOU it belongs to Stephen or someone else?
+
+Speaker 2: 00:17:54
+
+Yeah that's a great question.
+So basically what a token is, so like underneath, So this is like the idea here of so Feddy Mint, right?
+It's a it's a I need to learn this word It's it's concatenated two words Feddy for Federation and mint for Chami and mint Chami and mint is I described Federation I haven't described Chami and mint yet.
+So it's a very interesting idea from the 1980s from 1982 I think was when the original is a paper and this is the idea of this remember when I was saying like me and Steven would have an IOU and the Mint could not tell from whom the IOU like when we go to redeem it they can't tell whether it's mine or Stephen's right that was this guy David Chom invented this idea and so so yeah what the IOU actually is is it's it's just like a little piece of data you know it's a couple hundred characters long and so if I run a let's say I am a chameleon mint and Steven is a chameleon mint and we don't know each other if a user presents a token from my charm in mint to Steven, he would just be like, well, I don't, it's even if it's the same format, the token is exactly the same format.
+He would look at it and be like, well, I have no, I don't know of this token.
+I have never, I've never issued this myself.
+I know that I did not issue it's actually the token with the signature, right?
+So the signature would be wrong.
+And so the answer to the question is our mints wouldn't be able to interoperate at all.
+And this is a big problem with this idea historically is that it wouldn't really, it would struggle to plug you into like the broader commercial world.
+And so that's where lightning comes in.
+It's you can think of these these mints as like kind of little enclaves.
+Right.
+But they're connected by like a road that is lightning.
+Right.
+So lightning is like the instant settlement layer between these mints.
+So if I'm in like, let's say if I'm in mint A and Steven is in mint B, then I can generate an invoice that will, when paid, I will receive tokens in my mint and he can pay that invoice using tokens from his mint and you know, it's not, you know, between the mints, it's just a normal lightning payment.
+So in a sense, you can think of it as kind of like an extension to lightning where like the first or last hops on a route don't actually happen in lightning at all.
+They actually happen between a mint and a lightning node operator.
+And like, this is really cool because it like it's not trying to compete with lightning or anything it's trying to add something you know it's kind of like tarot for example right like tarot is and to introduce this idea of like assets and stable coins into Bitcoin and so it's a good thing about it is building on top of lightning So if it works it'll make lightning bigger and more liquid.
+I think the same thing is true of of of impediments as well.
+Like if it works it'll just make liquid it will make lightning better.
+So in a way someone's dropping in.
+
+Speaker 5: 00:21:05
+
+I was just saying in a way it's settling like, like strike advertisers.
+Well, for Bitcoin, basically, and then like settle backs into another token.
+
+Speaker 2: 00:21:16
+
+Yeah, basically.
+Yeah, exactly.
+
+Speaker 1: 00:21:22
+
+So I'm curious to dig into this graphic that somebody dropped in here.
+
+## Connecting mints over lightning
+
+Speaker 1: 00:21:27
+
+User one requests lightning invoice A from LSP three and then two.
+So this is what user one meant to That's the LSP right there.
+
+Speaker 2: 00:21:36
+
+It's a very detailed.
+It's a great.
+
+Speaker 3: 00:21:42
+
+It's a great complex tool.
+
+Speaker 2: 00:21:43
+
+Yeah.
+It's kind of like how it works.
+But yeah, it's a great, it's a great, I mean, it illustrates how like, see the three, like this mint A and mint B, those are Federation mints.
+LN merchant, it doesn't know anything about Federation, doesn't even know they exist.
+The cool thing is you can still, Mint A and Mint B can interoperate, or Mint 1 and 2.
+And Mint 1 and Ellen Merchant can also interoperate, because like, Lightning is the lingua franca.
+
+Speaker 1: 00:22:13
+
+And so I guess, you know, we've got this LSP over here, and let's say like someone in that one decides that they want to pay somebody over here and met two.
+Yeah.
+Well, you would end up with is this lightning transaction between these two LSPs here.
+And so this Mint would lose some of its Bitcoin.
+This Mint would gain some Bitcoin and then in response to gaining that Bitcoin they're Mint.
+They then have to Mint eCash tokens to represent those.
+
+Speaker 2: 00:22:43
+
+So actually it's a good try but that's not exactly how it works.
+One interesting thing about Fetty Mint is that it's it the idea is that the mint in order to do anything useful the mint has to custody Bitcoin.
+So it all starts with a deposit.
+Someone deposits some Bitcoin in and then tokens are issued.
+And one of the important things is the amount of all issued tokens and the amount custody should always match each other.
+And this is actually one of the limitations of Fediment is that since it's so private, it's kind of the same problem that like Mero has, for example.
+And this is probably one of the reasons why Bitcoin will never have really strong on-chain privacy, is that if you add a ton of privacy and you make it's not everything public, then it becomes difficult.
+It basically becomes like you can, a FedEman can do a proof of reserves.
+It can prove the reserves they have, but it can't prove the liabilities because they would have to basically de-anonymize all their users, right?
+They would have to like, there's just not really a good way, like it can't prove its liabilities, but internally in the system, it always tries to make the, like if the system is running as expected right if no one is tinkering with it and trying to make it work incorrectly the assets and the liabilities would be equal at all times And that's like we do a lot of work to ensure that.
+And so to the question of how does a payment between Mint one and Mint two work.
+So Stephen was saying like oh well one of the mints loses Bitcoin and one of them gains Bitcoin.
+And that could work if the Mint itself actually ran a Lightning Node.
+But actually, the Mint itself does not run a Lightning Node.
+The Mint custodies Bitcoin and it has like a little smart contract system.
+And a Lightning Node operator, LSP1 or LSP2, they basically like serve at the...
+We envision like a free competition for these LSPs to be able to go and serve federations.
+And so what does that mean?
+So the LSP has to trust the federation because they'll have to hold a balance of these IOU tokens, right?
+And so if the Federation is a bunch of liars and they issue fraudulent tokens that they don't redeem later, then the Lightning Gateway would lose money, right?
+So the Lightning Gateway has to trust the Federation, but the federation does not have to trust the lightning gateway which is which is very nice because it kind of hopefully it will allow like a healthy competitive environment where you know the LSP's compete to serve federations in terms of how good they are at competing Lightning payments.
+And this is how you might get like very, very reliable quick transactions.
+And so, yeah, the LSPs have to hold a balance of tokens.
+And so the way the transactions actually work is like, let's say there's a user in Mint 1 and he's trying to pay a user in Mint 2.
+What will happen is his tokens in Mint 1, the user in Mint 1's tokens will be sent to the LSP attached to Mint 1.
+Does that make sense?
+So LSP 1 will get a little bit of tokens.
+Like, OK, just because this is a little complicated, but it's worth seeing.
+There's a user in Mint 1.
+He wants to pay a user in Mint 2, right?
+So some of the user in Mint 1's tokens will go to LSP 1.
+LSP 1 now owns a little more tokens.
+Now LSP 1 will send some Lightning to LSP 3.
+So now he has, he's, he's gained, or she's gained in eCash tokens and lost Lightning.
+And probably there's a, they probably gained a little total to represent a small fee right and so now LSP3 has a little bit more Lightning balance and so what they'll do now is they'll give a little bit of their eCash an equal amount of their eCash balance to the user inside Mint2 right so that's the way it works like The LSPs are kind of like a money changer between the token, the IOU token, and Lightning Network itself.
+And so the way it works is it's basically an escrow underneath.
+And the agent, it's an escrow between the user and the gateway, the LSP and the user, and the federation basically judges whether the transaction worked by basically checking whether pre-images are correct.
+So it's very simple.
+It's just the gate, it's an escrow and the gateway is the judge or the sorry the federation is the judge.
+It's not important to understand like that aspect of it but just like the you know you know the flow of funds is kind of interesting.
+
+Speaker 1: 00:27:15
+
+Got it that makes sense that when you said that the LSP needs to trust the Federation but the Federation doesn't necessarily need to trust the LSP because the Federation is going to be the judge of like whether the users receive the money or not.
+
+Speaker 2: 00:27:34
+
+Yeah.
+So one thing that also one thing in addition to the the you know the idea of like a competition between lightning nodes that do it for like a profit incentive.
+You know the alternative is also like somebody in the mint just wants their friends and family to have like a nice lighting node and so they'll run and they won't charge any fees maybe you know they want they could be running it without a profit motive which is also kind of cool.
+
+Speaker 1: 00:28:00
+
+So it's almost like the node operator, there has to be like some kind of software plugin or something that they can hook up to their lightning node that basically allows them to hold this token balance in addition to sending out the light, you know, ordinary lightning transactions and lighting messages that they usually do.
+
+Speaker 2: 00:28:18
+
+Yeah, So the way this works is we only support core lightning so far.
+Formerly known as C lightning.
+And so basically all it is, there's just one file.
+So core lightning has this thing called plugins.
+If you want to add extra functionality core lightning, you run a plugin.
+What is a plugin?
+It's just one little file, a little computer program.
+And you stick in a folder that you tell core lightning here This is the folder with all my plugins right and some plugins are for rebalancing channels other plugins are for you know doing stuff like that and so we just have a little plugin that allows that teaches the gateway how to hold an e-cash balance and and you know a couple other details with you know when a when a payment comes in that might be a Federman payment like what to do with that and how a user can tell the gateway like here I'd like to do an outgoing payment right but it's basically just you copy one file into a folder and rerun C lightning which is so it's really really simple and LND will work roughly the same way they have this thing called an HTLC interceptor.
+It's just like one little file you got to run.
+And so hopefully this could be something very, very simple if you're doing on the command line as command line go command line can get very complicated.
+Just run one little file and and hopefully in you know, hopefully eventually there will be integrations and stuff like voltage, some of these node offerings, maybe VTC pay, some of these things that have like, or maybe umbral, some of these things that build UIs for your lightning node.
+They could just have a couple buttons like, hey, would you like to become a gateway okay what what is the config file for the federation you want to serve right and that just has the addresses like the you know the URLs for the federation servers right and so you just like paste that in or scan a QR code and now you're a gateway and you just have to decide how much e-cash tokens you want to hold and there's probably, someday there will probably be options for, you know, like auto, automatic rebalancing between the two, but that's just a dream at this point.
+
+## Backups for FediMint users
+
+Speaker 1: 00:30:20
+
+So I thought it was interesting you said about your you mentioned with the core lightning thing the balance of e-cash tokens.
+And so it gets me thinking that the data structure of this is much different than what a lot of us are traditionally used to.
+We're used to thinking of a Bitcoin wallet as being a seed phrase.
+And as long as I have the seed phrase and two or three other pieces of information, I can regenerate the whole wallet.
+If I have lightning wallet I need that plus some kind of channel backup and I can regenerate the whole node or sweep those force close, sweep the funds on chain.
+But the whole backup recovery process seems like this would be very, uses much different data in the federated model.
+
+Speaker 2: 00:31:07
+
+Totally.
+So the way these eCash tokens, these tokens work, these IOUs, eCash tokens means these like anonymous, like private IOUs, you know, they're indistinguishable IOUs. And so like first off the user, hopefully the user, like this is kind of an implementation detail.
+Most users in the future I don't think will necessarily even know this is happening.
+Kind of like a channel.
+Like someday I don't think most users will even know what the channel is potentially or like a UTXO you know you might be a Bitcoin user you might have a Bitcoin you know wallet but you might not actually know what a UTXO is that terminology isn't hopefully we could get to a future where you don't need to know all this terminology.
+Okay so so yeah the the token the is a little piece of data and you'll actually have a lot of tokens.
+So basically the tokens have to have a fixed amount.
+This is kind of a little in the weeds, but it's interesting to think about.
+They have to have a fixed amount because your anonymity set comes from all the people that have the token of the same denomination.
+So if you encoded an amount in there, your anonymity set would probably just be you unless you were using a very standard amount.
+And so you end up with tiers, right?
+Like there's a one sat token, a 10 sat token, a hundred sat.
+And these are combined to make payments, to express an arbitrary amount.
+Someday I think we'll be able to use fancy cryptography to encode the amount like in a zero knowledge proof but that doesn't exist yet.
+So we don't we wouldn't need these denominations.
+So inside the wallet you have a bunch of these little tokens kind of like dollar like like quarters and dimes and nickels in the US you know.
+And so and importantly these are you know these are bearer instruments IOUs. And so if you lose them, you can't prove that you should have had, you should, you actually own them, right?
+And that's where the privacy comes from.
+And so if you lose them currently as it exists now your money's gone big big UX hurdle right and so one one thing that we will eventually do is implement recovery schemes and So how that would work is that the some of the data inside the token could be represented with like a seed, right?
+And so it's a little weird to think about this because like the whole idea was, you know, it's a custodial system, but now we have a seed again what's going on here right I think there's some really interesting things we can do because we have this federation of trusted servers right so like one one one option is you could seed and you just store it like you and any other wallet but it's a little weird because you lose some self-sovereignty in terms of self custody but you gain a lot of privacy.
+So personally, as someone who knows how to deal with seed, I might like that.
+I might use that.
+But most users we envision using that, this is not a great option for them.
+So one thing you could do is you could shard the seed into pieces and send one to each server and have them store it for you, right?
+And then so you would need some way to go to this federation each of these servers later.
+Hopefully in this scenario run by people who would know you in some manner.
+So if you lost your phone, lost all your tokens, you could go to these things and say like, hey, I'd like to recover.
+Maybe you could message them, something like that.
+This is kind of like, there's all kinds of scenarios we could think of how this might work in concretely.
+But basically you convince them, hey, I'm me and you have my shard of my seed and I'd like it back.
+And so if they say yes to that, then they can send it back to your wallet and you can reconstitute the seed and go discover all your tokens again.
+So potentially we can leverage this like local trust architecture eventually and to make like nice recovery schemes.
+But this is kind of still like a research topic.
+I think there's a lot of really interesting options, but it's like a fundamental trade-off that you get where like, you know, if you end up with a seed, it is a little weird, but I think there's a lot of interesting backup potentials due to these trusted servers.
+Because again, the whole point revolves around the fact that you trust the people running the servers.
+That's the whole foundation here.
+But that would be, this would be like, in terms of like, like where designers could contribute.
+I think this would be a really fascinating thing to just think of all the different ways that this, you know, these, these recovery schemes might work.
+There was an interesting proposal in our discord today, chat.fedMint.org if you want to go to where the developers are.
+I try to come pop by the Slack, design Slack every once in a while, but I'm just on the discord a lot more.
+If you want to think about, there was an interesting discussion of using biometrics as a, you know, like have some biometric information, encrypt it and store it with the federations.
+Like that's kind of an interesting idea.
+There's downsides to that.
+You know, you could, yeah, there's kind of a lot of interesting things and you know you could combine two of them or something.
+I was just talking with Tankred today about Photon maybe using something like Photon to store the secret in the cloud.
+There's a bunch of options for that.
+But I think the leveraging the trust in the servers is probably the, it's the novel one, right?
+Like it's different from normal key management.
+
+Speaker 1: 00:36:40
+
+Yeah, I think that, oh, sorry, go ahead.
+
+Speaker 5: 00:36:43
+
+No, you go ahead first.
+
+Speaker 1: 00:36:45
+
+I was just making a comment that I think that this is a powerful idea that you know I think that that'll be very appealing idea to a lot of people just the one of the most common things I'm talking to people about Bitcoin is when they learn about a recovery phrase or whatever they're like the first thing they say is there should be a forgot password request.
+
+Speaker 2: 00:37:09
+
+Yeah.
+So that's that's kind of like ideally over the long term we could have a forgot password a flow like a forgot password.
+Like, you know, there's a thousand details there.
+Maybe we'll never achieve it.
+But I think on paper we could get to, we could get not only to something like that, but hopefully many different options.
+And that's, that's interesting about Fediment is that it's like, it's technically, it's very module based.
+And so like, like this is a difference between Fediment and Liquid, right?
+Liquid is like a one federation deployment.
+That's very, it's exactly what they want and you can't tweak anything.
+There's one federation and it works like Blockstream says it works, right?
+Which is great because you know, they're, they do a good job.
+But if two different groups of people would like different features, they just have to hope that the features they want get in.
+And if they're conflicting, you know, they might not.
+So, FedMets is very modular.
+So some deployments might use, you know, recovery method A, some other deployments might use recovery method B.
+And then from an ecosystem point of view, I think it would be very interesting to see a diversity of deployments and then in the wild, discover what are the best ways of using it, you know, through testing, you know, with small amounts of money and in different places, like, you know, you can actually figure out through testing what people like rather than, you know, having to just guess and build your one system and hope it's right.
+
+## Backing up other user wallet metadata
+
+Speaker 0: 00:38:44
+
+Tristan, you had a comment.
+
+Speaker 5: 00:38:47
+
+I just didn't have a comment.
+Yes, so I was wondering if with this architecture there would be any kind of like data store.
+And I guess like as I say that I realized that there might be some privacy drawbacks of doing so and the reason that I'm asking about data storage because there's some additional kind of information that a wallet may need to store, for example, labels and contact data and whatever within the Mint.
+And that could even be stored on, as you mentioned, something like Google Cloud or iCloud if it's using something like Photon, but yeah, there's just like a mass amount of like arbitrary data that someone's wallet within the Mint might want to store.
+Settings, for example, different configurations.
+Is something like that being considered or is it just going to be like left for like a plugin based system?
+
+Speaker 2: 00:40:01
+
+Yeah so I mean on the server side like each server has a database And that's what basically the what the federation member, the servers send messages back and forth is basically to just ensure they have exactly synchronized database.
+And so with the, these recovery ideas, like sending a shard of your seed to one of these servers, it would just go on their database.
+Right.
+And so there's like, that's kind of the interesting thing is like it already has a database.
+And so for certain things like this, you know, backing up of pieces of a seed, right.
+Like you have this new design constraint, like, oh, we could stick it in that database that we've been carefully curating, right?
+And so the, yeah, the, there's that.
+And so, but on the client side, on the actual, like the end user app, for example, there's not as much, like, there's not that much data required, you know, like you have to store these tokens, but every token is like, you know, a couple hundred bytes, like 100 bytes or something.
+And so there's, you know, and you might have like a couple hundred, you might have a hundred tokens at any given time just to be able to represent different amounts.
+It's the data storage on the actual phone is very, very minimal, which is a nice.
+Go ahead.
+
+Speaker 5: 00:41:15
+
+Yeah.
+Like the question isn't so much like like the capacity needed to storage capacity needed on the device but more like you know if I'm migrating to a different device I want to have like some metadata about my transactions you know and that's something that Bitcoin applications like really feel on or I want at least for my my configurations to be the same and then we could extend that even further with some kind of like messaging system.
+As you said, there's already some mechanism in there for that where I want to be able to through a contact be able to request a payment to someone else who I could identify within the Mint.
+
+Speaker 2: 00:41:59
+
+Yeah, no, these are these are all great ideas.
+I mean, these are totally unexplored at this point, but in order to get this in the wild, we'll need solutions for these things.
+So yeah, these are things that we'll have, apps being built on FedEvent we'll have to solve kind of similar to any other system.
+I mean, there could be interesting ways to have the Federation servers be able to relay messages, being able to store metadata.
+It's an interesting option.
+It's like you can kind of think of the servers as like your own private cloud in a sense as long as you can you know there might be some system in order to like request that you can do that but it's it's the federations are like a private cloud you just can't store too much in there right Because you have to have redundant copies and it's a bit of a tragedy of the commons, right?
+You don't want to be uploading videos, but that is a new constraint that you could design stuff around.
+But yeah, no plans for that so far.
+
+Speaker 5: 00:42:58
+
+All right.
+Thank you.
+
+Speaker 2: 00:43:00
+
+It is a great observation though.
+Bitcoin walls do really suck it.
+
+## Checking the status of the mint or proof-of-funds
+
+Speaker 4: 00:43:04
+
+You set a new one up it's like oh there's nothing in here you know I have a question it seems like a lot of user interactions between the users and the Mint managers to figure out.
+And I was wondering if there's, I would assume users also want to know, like, is this Mint still running?
+Are they doing a good job?
+Do they have all the funds?
+Is there a way to, I don't know, to provide some insight into what's going on.
+I don't know exactly what to say there, but it's kind of like a proof of funds or I don't know.
+
+Speaker 2: 00:43:39
+
+Yeah.
+So you'll be able to see if it's running very easily.
+Like it'll just check whether, you know, the phone will just send a message and it can see whether servers are offline.
+In terms of whether it's doing a good job, I guess you could see whether a critical number of servers are offline or something like that.
+Although I don't know how much of that information like the user would actually want to know maybe some kind of health indicator or something.
+And the tricky thing is in terms of like you can't ever really know whether a Mint is properly collateralized or not, right?
+Like the software, if running correctly should never allow, like basically if it discovers that anything was created or destroyed, Like if stuff doesn't add up to zero in any given epoch like a block, it will just stop.
+Right.
+So but you could have something that looks like federation servers, but some malicious person modified the code to print tokens out of thin air, for example.
+And so, yeah, that's like a fundamental problem that we can't like, there's no way to prove that the mint is properly collateralized just because like, you can't see the liabilities because that's where the privacy comes from.
+One solution here is something like automated bank runs.
+Just like every once in a while I'll see like, hey, let's just everyone try to exit and re-enter the Mint, for example.
+Something like that would be kind of interesting.
+You know like that lightning gate with the LSP for example could could you know could attempt that just like can I get my money in and out and publish for proof that they did?
+I don't know.
+There's probably other options here, but yeah, that's like one of the drawbacks here is you can't really, you basically trust that the Federation is not screwing you over.
+It's a trust system that they're not, that they're not under collateralized.
+
+Speaker 1: 00:45:45
+
+That just the idea of the automated bank run is really wild that just the idea of like having this like what if you have some kind of like third-party lightning node that's like trying to hold the mint accountable for the community It's like constantly like they have enough, you know, Bitcoin in the lightning nodes so that they can constantly like at random times try to like make obscenely large redemptions just to kind of keep them honest.
+
+Speaker 2: 00:46:15
+
+Yeah.
+I mean, this is like one.
+Yeah, there's a lot of thinking there, but it's kind of one of these ideas where everyone's like, oh, inflation is bad, right?
+They all think inflation is bad.
+They get into Bitcoin.
+It's like, oh, wait, maybe inflation isn't bad.
+It's kind of one of those ideas.
+Well, maybe a bank run is actually a good thing, right?
+Like frequent bank runs are good.
+It just proves that it proves solvency, right?
+Like that's the real way you can prove solvency.
+Everyone can get out and get back in.
+Right.
+Maybe it's maybe this is not a priori bad thing.
+
+Speaker 1: 00:46:43
+
+Reminds me of the first chapter of Cryptonomicon, the book takes place in some small town in China.
+And it's like as the book is opening up, it's like Friday afternoon.
+And every Friday in this town, all the banks perform a bank run.
+And they send people all around town carrying boxes of cash just to see if they can get their gold out and all the banks do it to each other.
+
+Speaker 2: 00:47:04
+
+It's a sign of an advanced civilization.
+You can get your gold out.
+Right.
+
+## Hypothetical: remove some privacy features and add more proof-of-liabilities
+
+Speaker 2: 00:47:08
+
+No, but I mean, as I should mention also that like Fetiment is interesting.
+Like if you didn't have the private, like if you were, if you removed some of the privacy features, you could do much more.
+You could, you could make a better attempt at proving liabilities as well.
+And so like, that's something that will be fun to experiment right like could you do just a purely kind of custody optimized thing like like optimized for holding as opposed to spending right and so like you could kind of have a savings you could have a fed amount with a savings account and checking account, right?
+The savings account has, or the checking account has blinded IOUs where they're indistinguishable.
+Maybe the checking account or the savings account does not have blinded IOUs. It's just plain text IOUs. And so these could be published at any time.
+You could check whether the Mint is publishing.
+Every wallet could check whether the Mint is publishing their IOUs. So like all the clients would keep that Mint honest.
+Like they tried to publish a proof of liabilities and that user's liability wasn't in there.
+They could, you know, send a message around to all the other users being like, Hey, we're being cheated, something like that.
+Then, you know, this is like a theoretical feature, but like, this is that that would be doable.
+
+Speaker 1: 00:48:46
+
+Yes sir we're getting pretty close to the hour here.
+This has been a fascinating conversation.
+I want to just kind of open it up to the room again and just kind of see, you know, I mean, I could probably talk about this all day, but I just want to see if there's any kind of like, you know, designer level questions about like what, what, you know, how this, you know, what kinds of work needs to be done on Fedament or how certain things might work.
+Any other questions from the room here?
+
+## What should the initial setup of a FediMint server look like?
+
+Speaker 2: 00:49:17
+
+Well, I will mention one other thing just based on my experience where like, I was saying, Oh, this would be a good problem for designer is like, what should the initial setup be when you run the server?
+Right?
+Like, you know, just to get because I wanted to if you think of be put be negative here it's like how would this fail well one reason this would fail is because it's an awful lot of running the servers right which people aren't good at right like people aren't good at passwords people aren't good at servers and so making the server setup here is like there's a technical component we're trying to solve.
+We're trying to make the software like really easy to run, but there's a design problem too because you know you need to run the software and a little web page will show up and it'd be like, OK, who else?
+Where you know what are the addresses in the public keys of the other servers, right?
+Like there's a big life customer lifecycle there and then OK, once the server is up and running, what's the first step?
+Like what's the first like win you get, you know, you want your user to have like a win, right?
+So like how do you get to the point where they can send their first lightning payment, right?
+Or receive their first, you know, something like that, deposit the first, you know, like that sort of life, customer life, lifecycle, whatever you call it, is like some design thinking would go a long ways there, because it's currently just developers thinking about it, mostly.
+
+Speaker 5: 00:50:32
+
+Is it going to just rely on AWS at that point?
+
+Speaker 2: 00:50:35
+
+I mean, I don't know if you remember this old tools like fantastical and cPanel where you would like one click install WordPress or some yeah I think it'll be diversity right like I think there will be really easy setup hopefully we can get to it like having really easy setups in stuff like umbral, Raspi Blitz, some of these things where people are already running.
+It's helpful for people who are already running one but it's also like if you want to have like your own self-hosted server it's probably like your own hardware it's probably easier to set that up from scratch and try to attempt it yourself so that's one option another option is like I think it's been very a BC space had a lot of success with like Luna node, right?
+So they built a little series of configuration forms.
+You'd set up a VPN or VPC and then it would fire up a little configure or no, there was like a couple of forms you'd fill out and that would actually fire up the VPC, like the cloud server for you.
+And then, you know, like 10 minutes later, you'd see a little web form at that URL that would be like, okay, initial block downloads happening.
+Right.
+I think something like that would be very successful.
+And it's also nice.
+It's not like there are benefits to not being on AWS for this because you know like a lot of these like Luna node you can just pay with Bitcoin right like you don't have to go through a whole you know maybe it's harder to be censored on something like that some of these niche ones and you know something like AWS and some of these are good too, because it's, you know, people are really familiar with it.
+So I think some federations could have a mix, right?
+Hopefully, someday it can be like people's own hardware, but that's just we don't live in that world quite yet.
+But I think, you know, some of these Bitcoin companies like Start9, Umbral, they're helping us get to that future.
+
+## There can be many FediMints and each can try different design patterns
+
+Speaker 3: 00:52:22
+
+I think on that point I'll just add something from sitting in the telegram group and trying to ask, like answer a lot of questions on this.
+Like one of the common misconceptions people have when they come into this is that it's called FedeMin so there is a FedeMin when the actual fact is there's probably going to be thousands to hundreds of thousands of these things and they're all going to vary depending on the particular group that you've set it up for.
+So there's quite a large design space for looking at all of these different problems and how you might actually go through them.
+So there's those questions earlier about a guy who's setting up masts in villages in Tanzania to blanket the local area with network connectivity, you know, how would that work and what are the different failure modes that come to that.
+It's pretty interesting from a design point of view to look at the many variations of, you know, like backups for instance.
+There's not necessarily going to be one answer to that there could be the backup for your mum versus the backup for your friends versus the backup for your local community might just be quite different so there could be like a good recipe list of stuff that can be developed.
+
+Speaker 2: 00:53:34
+
+Yeah.
+From like a high level, you can think that like Bitcoin and Lightning are kind of haunted by this problem where like everyone has to agree on a change, right?
+Like more or less, right?
+Everyone has to agree on a Bitcoin software.
+Basically everyone has to agree on like a big lightning protocol thing like bolt 12 or something right because everything has to be interoperable.
+Fetamints don't have to be interoperable on their own.
+They can use lightning to interoperate right so like the different fetamints can be very very diverse as long as they can speak lightning for whatever things are expressible in terms of send and receive or maybe other lightning features eventually.
+Those things can be interoperable between mints, but like you can have a lot of diversity between them, which is really exciting from a design point of view.
+Also from a developer point of view, right?
+Like Bitcoin core lightning developers sometimes aren't the happiest folks because you know, it's so slow to get your stuff accepted.
+
+Speaker 1: 00:54:27
+
+It's almost like the farther away you get from the main protocol, the more wild and experimental you can get.
+Bitcoin development has to be very, very conservative and it has to be very slow because you're talking about the world's money supply.
+And then when you move a layer up on Lightning, you can be a little bit more reckless there because you don't have to worry about if you try some experimental new technique for a channel and mess something up, it only hurts you and your channel partner, doesn't hurt the rest of the network.
+And then you could take that even, I know you also consider a fedimental layer too.
+In my mind, I keep thinking of it as kind of a third layer, just because I think of the Fed is using lightning, that may not be technically accurate.
+But if you think about moving layer above that with Fed, each federation could just completely do its own thing.
+And then they can interoperable be interoperable because of lightning.
+
+Speaker 2: 00:55:18
+
+Yeah, I guess I mean the terminology never really goes anywhere, you know, there's an endless bike shed, but I think it's kind of a peer to lightning, right?
+Like they can talk to each other, but they also both access Bitcoin directly.
+And yeah, I think it's just a compliment to lightning, right?
+The things that, yeah, it's very complimentary, which is exciting.
+
+Speaker 4: 00:55:45
+
+It seems like from a design, from a UX perspective, it might make sense to just focus on one good the most what what likely is the most common use case and just try to think through that so I think otherwise it gets a bit bit hard to come up with a specific experience.
+
+Speaker 2: 00:56:04
+
+Totally.
+I think I mean one thing that every single federation will need is they'll need the ability to set up servers.
+Right.
+And so that's like even before like that from a design perspective that would be that flow of how to get the server up and running and how to get it so they're talking to each other.
+And then also how to do the first deposit because in almost every one of these systems, you're going to need to get some Bitcoin in and there's some steps there.
+That would be a really interesting thing to get some design feedback on, because it would be shared by every single thing.
+And I also believe just one simple use case is also desirable.
+
+## Different types of users for FediMints
+
+Speaker 1: 00:56:43
+
+So it's almost like you're kind of considering two different types of users here.
+So one is the actual federation operators and trying to make their life a little bit easier, trying to help them actually get the federation set up so they can get up and running with it.
+And then you've got this other class of user which is the actual federation like the I guess what we normally think of as being the end user the person who has the wallet app on their phone who's actually trading e-cash with their neighbors for goods and services.
+
+Speaker 2: 00:57:15
+
+Yep.
+So from that point of view you know it's like a little I mean it's like lightning right Like you need the actual node running first.
+And then, you know, the people, you know, it's, it's complicated.
+It's a, it's a potential failure.
+If it's hard to set up servers, then no one ever gets to the privacy benefits, right?
+Or not enough people.
+
+Speaker 1: 00:57:32
+
+And it seems like there's almost a couple of different ways that this user could get get their first Feddy wallet.
+Like, you know, it could be someone who already holds Bitcoin.
+They're like, oh, I want to deposit some of this with the Mint and get this kind of privacy shield, get my eCash tokens, where somebody else could be starting from absolute zero.
+Someone could say, you know, hey, I want to pay you.
+I want to pay you in eCash.
+Is that cool?
+Download this wallet.
+And they're starting from completely zero.
+Maybe they've never even touched Bitcoin or lightning before in their entire life.
+Maybe maybe they've used, you know, Venmo or something like that.
+Or maybe this is their first experience with any kind of digital interaction around money to begin with.
+
+Speaker 2: 00:58:16
+
+Yeah, I know there's an interesting point of view, you know, like the, we think where does a circular economy come from?
+Well, it's probably not going to be people buying the money.
+You know, they're probably going to get their hands on the money in a different way.
+They're probably going to earn it.
+They're probably going to, maybe it's remittances.
+Maybe it's something else.
+Right.
+But it's probably not going to be buying it.
+It's not like really a, I think the circular economies will emerge through actual usage probably.
+And so that's like an interesting thing about this too, is like, if you can get, since it's kind of like naturally like a community local thing like it might you know if you can get the buy-in to actually run one of these keep it up and you know have the interaction between all these people maybe that actually helps form a circular economy as well you know no one's no one's really succeeded there yet so it'll be interesting to see well this has been so awesome thank you so much Justin I want to I think we're a little past the hour here.
+
+## Closing
+
+Speaker 1: 00:59:13
+
+So I want to be respectful of Justin's time and kind of formally end this.
+Just yes, that he feels free to go.
+But if people want to hang out and keep chatting in the channel, please feel free to do so.
+But we'll go ahead and consider this the formal end here.
+And thank you so much, Justin, for taking time to share all this with us.
+
+Speaker 2: 00:59:36
+
+Yeah thanks it's fun to talk to you guys you know it's fun to have the designer point of view and everything you know it's just like a different I get code brain right now so I just think of everything in terms of how it works and then you know It's really nice to see the diversity of opinion.
+
+Speaker 1: 00:59:51
+
+And so if anybody's interested in Fediment, just go join the Fediment discord.
+I think this is the Fediment.org website.
+And there should be, I'm assuming there's a discord link on there somewhere.
+
+Speaker 2: 01:00:02
+
+Yeah, chat.fediment.org.
+We should probably feature it a little more.
+
+Speaker 1: 01:00:08
+
+So that's where you'll go if you want to.
+
+Speaker 2: 01:00:10
+
+Yeah.
+I'll also try to get a couple more people from over there to hang out in the design discord too because you know it's a lot or the design slack because there's I see a lot of interest here so we'll try it out be a little more responsive I show up there like once a week so I'll try to show up a little more frequently.
+
+Speaker 1: 01:00:27
+
+Awesome.
+Well, thanks Justin and yeah, Christophe, could you go ahead and cut it off here.

--- a/bitcoin-design/learning-bitcoin-and-design/silent-payments.md
+++ b/bitcoin-design/learning-bitcoin-and-design/silent-payments.md
@@ -1,0 +1,714 @@
+---
+title: "Silent Payments"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://www.youtube.com/watch?v=Cqmk2cZ2IjM
+tags: ['silent-payments']
+speakers: ['Christoph Ono', 'Josibake']
+categories: []
+date: 2024-02-08
+summary: "Josi gave us a great introduction to silent payments in this conversation. We talked about the history of similar efforts, benefits and drawbacks, how it works, status of the project, adoption path, and lots more."
+---
+Speaker 0: 00:00:02
+
+So welcome everyone.
+Super excited to have this call here today.
+And we are in learning Bitcoin and design call number 16.
+Hilariously, we had number 17 this morning, because we move things around time wise.
+But this is number 16 about silent payments.
+And we have the super expert Josie here, who is willing to talk us through what silent payments are and how they work.
+And so I'll just hand it over to Josie to kick us off and we can just organically, kind of feel out where we should take this conversation.
+And so feel free to kick us off if you'd like to, You can just talk to us for 20 minutes, give an overview, or if you prefer a more conversational format that works as well.
+And hopefully we have lots of time for everyone to ask questions and get those answered too.
+
+Speaker 1: 00:01:01
+
+Yeah, for me personally, first I'll preface, you guys got the bait and switch.
+I'm not the super expert.
+That's Ruben Thompson, who isn't here with us today.
+Ruben Thompson was the original author of the silent payment scheme.
+I am the super expert sidekick.
+I am someone who got really excited about silent payments when I heard about it and then started helping Ruben out.
+So how I've been helping is co-authoring the BIP with him.
+So we've been working on that for a while now, just formalizing the spec, coming up with test vectors for wallet implementations.
+And then I've also been working on a silent payments implementation for Bitcoin Core.
+And then also just on the side as well, looking for other ways with different libraries to help out.
+In terms of the format, I much prefer a conversational, more informal way of doing things.
+So I'll launch into an overview, but I would encourage anybody who has questions, just feel free to jump in and ask questions.
+If I say something that you don't understand, don't wait for later, just interrupt me, because then I feel like we're all using each other's time really efficiently, and make sure that we clear up any gray areas.
+But I'll launch in with like a high-level overview, But like I said, raise your hand or stop me if something doesn't make sense.
+But I guess to start, silent payments is kind of the nth iteration of a pretty old idea in Bitcoin, which is stealth addresses.
+And then maybe something that you might have seen you know in other places you'll see people like in Ethereum for example they have a static address which is an account and you rather than go through this flow of always handing someone a fresh address, there's these concepts in other cryptocurrencies and other projects of this static payment identifier.
+So The original idea I think goes way back to like 2012 or 2014, somewhere around that era, where people were talking about stealth addresses.
+And the idea of a stealth address is you have a static code and people can send Bitcoin to you using that static code and they can use it over and over and over again.
+So it becomes more like a routing number.
+Like if you're a bank, you have a routing number.
+Once I have your routing number, I can just send money to you whenever I want without interacting with you to get some code or confirmation.
+The thing about self-addresses is they do this in a way that preserves the user privacy.
+Not just the user privacy, but the privacy of all the users of Bitcoin.
+I'll talk about that maybe more a little bit later.
+So today, if one of you guys wanted to send me Bitcoin, the only way to do it is you'd have to get in contact with me via messaging app or something, and you'd ask me for a fresh address.
+And I would give you a fresh address and then you would use it.
+And then if the next day you want to send me Bitcoin again, you'd have to get in contact with me again, ask for a fresh address and so on and so forth.
+This is a cumbersome process that I think a lot of us are used to at this point.
+But if you're coming from any other, you know, if you're not familiar with Bitcoin, you're used to more of like a cash app or a Venmo or a PayPal-like experience, where you're like, hey, what's your tag or what's your email or what's your, you know, identifier?
+What's your routing number?
+And then once I have that number, I save you as a contact and I can just send stuff to you whenever I want.
+That's the user experience that a lot of people are used to.
+So it can be very jarring when they come to Bitcoin.
+And it's like, oh, I have this interactive process where I have to ask for a fresh address.
+And because of this friction, people often tend to do the bad thing of just reusing the same address.
+So you'll see people will post a Bitcoin address in their Twitter profile or their GitHub, or they'll give you an address and then instead of reaching out to talk to them again, you might be tempted to just reuse the same address.
+And there's nothing in Bitcoin that stops you from reusing the same address.
+But the problem is that same address shows up on chain multiple times.
+So now someone from the outside can say, ah, whoever owns this address has received X number of payments, holds this much.
+They can see the transactions that paid them.
+And you can now start to cluster a lot of activity.
+And when enough people do this, when you can cluster things, so like exchanges are big offenders here We'll post static deposit addresses and then everybody knows that any transactions to that address are actually someone depositing to an exchange It limits the anon and in a mini set of everybody else who's not doing that.
+So it makes it easier to kind of hurt the privacy of everybody who's using Bitcoin when we have this widespread on-chain address reuse.
+It also hurts your own privacy.
+So if I post an address on my Twitter profile and say, look, hey, If you're happy with the work I'm doing on Bitcoin, send me some Bitcoin.
+Anybody can come over to my Twitter profile, just look up that address in an address explorer and see how many times people have donated, what amounts.
+If they're a chain analysis firm, they can start to look at those people who donated and start to look at their UTXOs that they spent, which maybe leads to uncovering someone's identity.
+So, we've got all these problems, and yet this is what people are most inclined to do because it's not a really normal payment experience that we're used to of having to constantly interact with the person to get fresh payment information.
+So that's kind of the idea that these stealth addresses are trying to solve or this you know these group of solutions and the idea is very very simple.
+I'll just talk about silent payments right now and then Maybe later we can talk about comparisons to other things that have tried to solve this problem.
+But with silent payments, I will post this new address format called a silent payment address.
+It'll start with SP1Q instead of BC1Q.
+So it's clear that, okay, this is not like a regular Bitcoin address.
+And then it's going to be a little bit longer than like a regular Bitcoin address.
+Go ahead.
+There's a hand up there from Yash.
+Yeah.
+
+Speaker 2: 00:07:00
+
+So, so why, so why did we make this decision about making the silent payment address visually recognizable by a regular person?
+Can't we simply delegate all of that to the wallet software or something?
+
+Speaker 1: 00:07:17
+
+Yeah, that's a great question.
+So already, addresses are meant to kind of be this human readable component for Bitcoin, right?
+Because if we think about what a Bitcoin address is, we've got the script pubkey, And the script pubkey is actually what goes into the blockchain, but that's cumbersome.
+So we encode script pubkeys into addresses, and the addresses have this recognizable format to them.
+So like, segwit addresses always start with the BC1Q or BC1P, right?
+So we have SegWit version 0 addresses, which is our BC1Q, and then we have Taproot SegWit version 1, which is BC1P.
+So just looking at the address as a human, you can be like, ah, that's a Taproot address, so that's a SegWit address.
+They're also a little bit more compact than the full script pubkey.
+The batch32 and batch32m encodings are meant to remove ambiguous characters, so that a human can quickly look at an address and verify, okay, this looks correct.
+Addresses are already this convention of, these are meant for humans to be using.
+And then the wallet software is what takes care of decoding the address into the appropriate script pubkeys that the wallet understands.
+So with silent payments, we wanted to go the same direction and say we want something that you could show to a human being and they'd be like, oh, that's a silent payment address.
+And it would be very clear that it's not a regular Bitcoin address because we didn't want any confusion of like, what's a Bitcoin address?
+What's a silent payment address?
+So to kind of go off that same design, the silent payment address is supposed to be something that people will recognize.
+And then the wallet can parse that address and take care of actually doing the silent payments protocol.
+
+Speaker 2: 00:09:03
+
+Yeah.
+Another question on that one is like if the wallet that I use does not support silent payment addresses, Can these addresses be used like a regular address?
+
+Speaker 1: 00:09:19
+
+Yeah, that's another good question.
+This is something that we discussed early on.
+There's a whole section on this in the BIP, in the BIP discussion, where we talk about, okay, what if we use something like BIP 21 to do sign-on payments?
+Like Rather than come up with a new address format, let's just use existing ones.
+My argument against doing that is, I don't think, if a wallet doesn't understand sign-on payments and then it falls back to just using a static address, that could actually lead to more address reuse on chain than before.
+Because currently someone posts just a taproot address and they're like, hey, you know, anytime you want to send me Bitcoin, use this address.
+And this is horrible because of all the privacy concerns.
+And then you have someone else who's like, I don't really like that.
+I want to use silent payments.
+And I wouldn't have posted just a static Bitcoin address anyways.
+So Now I'm going to post the silent payment address, so anyone who understands silent payments can send to me.
+And anyone who doesn't will just fall back to using a static address, which then means we've added one more person who's using a static address.
+So the whole idea of silent payments is we want to prevent any and all address reuse.
+So it didn't really make sense to allow this fallback mechanism, which would allow you to do something which we're trying to avoid.
+We kind of decided to tackle that problem a little bit differently, similar to how we did with Taproot, where obviously when you launch a new protocol or a new address format, there's going to be a lot of people that don't understand how to use it.
+So we tried to, we didn't try, we designed the silent payment protocol such that sending and receiving are separate.
+So you can implement sending without receiving, you could implement receiving without sending, but that doesn't really make sense to me, or you can implement both.
+And the barrier to implementing sending is meant to be as small as possible.
+So rather how we'd approach it is, look, If someone wants to use silent payments, the most important thing is that there are a bunch of wallets out there that understand how to parse that address format and can send to that address.
+If there's one person in the world who wants to use silent payments and nobody else cares, we still need a lot of people who can send to a silent payment address.
+So we separated the protocol into send and receive, tried to make sending as simple as possible and as silent payments, like the first phase of, I guess, developer advocacy of reaching out to wallets and talking to them about this new protocol will be focused on, hey, even if you don't care about this, can you support sending to a silent payment address?
+So that way, even if your users don't want to use silent payments or they don't care about it, at least when they see a silent payment address in the wild, which is someone who's saying, hey, I do care about receiving Bitcoin in a more private way with like better UX, then their wallet is able to send.
+And then, you know, we can defer the much the more complicated problem of implementing receiving down the road.
+So the hope is that by making it as easy as possible to implement sending support, there will be widespread adoption for wallets to send and then the few wallets or people who really care about the receiving part can go build and do those as well.
+If we had done the the other way where you kind of have to implement the full protocol, I think it's less likely that people would do it and it would slow down adoption a lot.
+You'd have this bad experience of like you try to scan a sign-on payment address and it doesn't work.
+
+Speaker 0: 00:12:43
+
+That's interesting.
+The chicken and egg adoption type of problem seems like a common thing.
+I also remember the same with multi-language recovery phrases, where the first step was just to be able to read them.
+And then to have one aspect of it that's easier, that kind of gets things rolling, and then hopefully leads to a full adoption then later on.
+
+Speaker 1: 00:13:07
+
+It's particularly hard in an ecosystem like Bitcoin where you know you can't just go force people to do stuff you have to really meet them where they're at and and try to make things as easy for, I mean, a lot of wallets are run by volunteers or people who aren't getting paid, it's just passion projects.
+So when you go and you're like, hey, I made this new protocol, I don't care about that protocol.
+Like, you're asking people to do work to support it.
+So that's one area where we did try to put a lot of thought into it and learn from history where we've seen that work well or slow things down.
+
+Speaker 0: 00:13:40
+
+Do you feel like that was a problem with adoption of the previous attempts at this or Do you think there were different reasons?
+
+Speaker 1: 00:13:49
+
+It's hard to say.
+I mean, always when you look back at history, it's difficult to know what was going on at the time.
+I think the previous attempts at kind of solving the address reuse problem, they don't seem to have gained a lot of traction.
+But it's difficult to say, you know, why that might be.
+You know, one thing is early on, I don't think people really cared that much about address reuse.
+It's something that as we've, as we've seen more adoption, and people have cared more about Bitcoin, we've kind of started to realize, hey, this is actually really, really bad.
+And it doesn't just hurt my privacy, it hurts everyone's privacy.
+But in the early days when Bitcoin was just fun, I don't think anyone really cared about that.
+They were just like, oh, yeah, just reuse the address.
+I think Satoshi even had like an original pay to IP address in Bitcoin, which like if you're a privacy person, it's just like the worst possible thing you could do.
+But it's, you know, pretty nice UX.
+So I think that I do think, you know, in previous versions, or, you know, Bit 47 is kind of the one that has the most traction, it's like a stealth address scheme.
+I do wonder if having to implement the full send and receive for Bit 47 to work has limited their adoption.
+I don't know if that's something they've experienced or not.
+I know it's in requiring the full protocol like that, it is more work for wallet devs.
+So maybe just to wrap up, because we're starting to use PIN 47 and refer to other things and aware, maybe someone watching this hasn't quite got the punchline yet of like, what are we trying to do here?
+So I throw my silent payment address up somewhere.
+You see that code, your wallet parses that code without interacting with me, right?
+You find this address anywhere.
+You could find it printed on a billboard.
+You could find it in my GitHub.
+The point is it's interactionless.
+You don't have to text me or know who I am.
+You just be like, hey, I want to send some money to that address.
+Your wallet then sends to that address.
+And by following the silent payments protocol, it generates a guaranteed unique address that's never been used before, and that is only spendable by me.
+And then you send money to that freshly generated address, And then the next time you want to send money to me again, the whole process repeats a freshly generated address.
+Someone else can come along, use the same code and be guaranteed that they're not going to get an address that you might have previously used because they're also generating their own address fresh.
+And the way that this works and the way it's somewhat distinct from previous versions of self-addresses and how people have tried to solve it, all of the information for generating that specific address is contained within the transaction itself.
+So to be more specific, you use the private keys of the UTXOs that you want to spend, which are only spendable by you and nobody else, use those private keys in that transaction in combination with the public keys in my silent payment address to do something called elliptic curve Diffie-Hellman.
+Elliptic curve Diffie-Hellman is where two parties can exchange secret information in public and arrive at the shared secret that only they know.
+So you use your private keys in conjunction with my public key to create a taproot output that has never been created before and can only be created using your inputs that you spend and my silent payment address and then I scan through the transactions and I see the public keys in your inputs just by looking at the blockchain and I use the private key corresponding to my sign-up payment address to do the reverse process to identify that this was a payment to me and also have all the data that I need to spend the output.
+So this means that there's no state, no crossover.
+It's not like an X pub where like if I put an X pub publicly and Christoph sends me some money to one and then somebody else like simultaneously asks for a fresh address from the X pub and it gives me the same one that it gave Christoph because it hasn't registered that Christoph used it yet, then you guys both might send to the same one.
+There's no state management or anything like that.
+And there's also nothing that links any of these multiple payments from you to my sign-on payment address.
+So if you come to my sign-on payment address, let's say I'm the Signal Foundation, and I post a sign-on payment address that I want to receive monthly donations for people who want To support signal, but I don't want to know who they are I don't even want to know if they're paying me every month So Christoph goes and he donates on the first of the month in January and then he goes and joins on the first of the month in February, there is no way from looking at those transactions that the Signal Foundation would be able to say, ah, these two payments on January and February came from the same person.
+Each payment to a sign-on payment address is completely independent.
+They're not groupable by sender in any way.
+So I think this is like a really nice property for silent payments compared to something like BIT47 where it's BIT47 is more about establishing a payment channel.
+So you you do this notification on-chain with an op return or they have a few other mechanisms, but whatever the mechanism, you get this notification transaction out there and that notification transaction sets up a way for the counterparty to be able to derive fresh addresses when they want to send to you from this like X pub like thing.
+It's basically an X pub.
+They encode the information you need to do an X pub into an operator and you decode it.
+The issue with this, when you go back to that like Signal Foundation example I just gave.
+They might not know Christoph's identity, but they'll see a payment that came in on the 1st of January and a payment that came in on the 1st of February.
+And from their wallet's perspective, their wallet can determine, ah, these two payments came from the same entity because they're both derived from the same notification that we use to establish this.
+I think these are two distinct areas where silent payments adds some new and different properties that I don't think have been done yet with the stealth addresses.
+This is one area where I think silent payments does really well in the privacy that all of these things have done, which is try to limit address reuse and then add some additional guarantees of there's better sender privacy than other protocols.
+Another thing that I like about, an exciting thing to me about sign-on payments, is it's also a user experience improvement.
+Privacy is usually more costly and more difficult.
+Very rarely is it the easiest way to do something is also the most private way to do something.
+That's a problem for users because some of us really care about privacy, others of us don't care about privacy and we care just more about having an easy experience as we use something, while also not understanding that the decisions we make today might hurt our privacy in the future or might hurt the privacy of other people who do care.
+So like you may not care about address reuse, but your address reuse hurts my privacy because even if I'm not reusing addresses.
+So One thing we really have to do for privacy stuff is we have to make it as easy or more easy than doing it the non-private way.
+So with silent payments this is really nice because a silent payment transaction will not cost you anything more than a regular Bitcoin transaction.
+You don't have to pay for this one-time notification, You don't have to pay for this one-time notification.
+You don't have to pay for any extra data in the transaction.
+It's just a regular old Bitcoin transaction as if you had just been reusing the same address.
+It also doesn't look any different than any other Bitcoin transaction, which is a nice property that, you know, someone from the outside can't tell that these things are silent payments.
+But if you're a user who just does not care about privacy at all, and then someone tells you like, hey, here's this way to send and receive Bitcoin that's a little bit more like a username or a routing number, I think it kind of Trojan horses the privacy in for them were like oh, yeah This is like much easier than asking someone for a fresh address every time And it doesn't cost me anything more than what I would do to do a normal transaction user experience seems pretty much the same Why wouldn't I use this and then we've got people using bitcoin more privately Than they were before Come for the static ID stay for the privacy.
+
+Speaker 3: 00:21:57
+
+Yeah, right I Mean it's it sounds like Hey, I'm Michael by the way Let's meet you it sounds So it sounds like it's similar in principle to Bolt 12 for Lightning, right?
+So it's, I mean, it's the same kind of, let's say, like you said, routing number or unique identifier that in the background then generates kind of all the magic happens in the background.
+So that's really cool.
+
+Speaker 1: 00:22:32
+
+Yeah, Bolt12 is another great example.
+I think Bolt12 is the analogy of this for Lightning, where in Lightning right now, Lightning is even more interactive than in Bitcoin, where, you know, if I give you a Bitcoin address, you can send money to it whenever you want.
+If I give you a Bolt 11 Lightning invoice, you got to use it right before it expires, before I go offline, and so Bolt 12 is kind of handling that there.
+So my dream would be, you know, in the next X years, soon, TM, you would have a BIP 21 style QR code that starts with a bolt 12 lightning invoice and falls back to a silent payment address.
+And from a user experience, you have this static QR code that you could post anywhere, never have to change it, and people who use it will be using Lightning and Bitcoin in a more private way that doesn't have address reuse or any of these, you know, kind of interactive go-betweens.
+I think we need to see a lot more adoption before we get to something like that.
+But like that's kind of the user experience that I'm envisioning, that I think we should be driving towards.
+You know, you try to scan a QR code, it tries to do it first with bolt 12.
+If it can't do it with bolt 12, it falls back to a sign-of-payment address.
+
+Speaker 0: 00:23:49
+
+Very cool, Very cool.
+How's everyone doing here?
+Everyone's very quiet.
+If you have questions, you're welcome to put them in the chat, put them in the document here.
+Trying to take some notes.
+Feel free to ask anything.
+
+Speaker 2: 00:24:07
+
+Yeah.
+I think, Josie, that was a very good explanation.
+And also you like really pointed out very well like what are the benefits of silent payments.
+I love that.
+Yeah, so I think people could just listen to the conversation and like get like a quick summary.
+That's awesome.
+
+Speaker 1: 00:24:26
+
+Yeah, I guess, like you said, I think I've done a good job of mentioning the benefits of silent payments, maybe I should spend a second and talk about some of the trade-offs because there's no such thing as a free lunch.
+Ruben and I have not stumbled upon some mystery of the universe that nobody else thought of.
+So I think I'll cover the trade-offs really quickly because I think it is relevant.
+So if you have something like an XPub, an XPub, BIP32, Hierarchically Deterministic Wallet, It allows you to pre-generate private keys and public keys before they've been used.
+And so you kind of know all possible addresses that you could hand out in the future at any given time.
+And XPUBs have been used as a way of mitigating address reuse in the past, but I think there are usability problems with that, that silent payments definitely improves on, one being like gap limit scanning.
+You're never really sure with an XPUB, and there's also a lot of state management to make sure that you're properly keeping track of which addresses you've used before so you don't accidentally hand them out again.
+And you can really only use like an XPUB per person.
+I can't give the same XPUB to Michael and Christophe because then they're both going to be choosing the next index to send to me and might step over each other and then we end up in a problem.
+So that was the idea with XPUBs and then bit 47 kind of took this and said, well, let's make an XPUB per contact.
+So we don't have any of that problem and then they manage their state.
+So that's one idea there.
+But the benefit of the XPUB approach is I can pre-compute these keys and then I can check for them to see if anybody has sent money to them.
+And I can do that check just kind of using the UTXO set.
+Like the UTXO set says, hey, these are the ScriptPub keys that are currently unspent.
+And then you go to the UTXO set and you're like, oh, well, I have these keys, which could be turned into script pub keys.
+Let me see if any of those script pub keys currently have any Bitcoin.
+And that's kind of an easy way for you to scan.
+And if you want your wallet history, you've got to fall back and scan the whole chain.
+Right.
+With silent payments, it's a little different in that you can't pre-generate anything because the sender is actually going to generate that address.
+You have no knowledge of that address until the sender actually decides to send you money.
+The sender generates the address and then uses it in a transaction.
+So it kind of flips it.
+The problem with that is to be aware of that, you need to scan the chain.
+You need to be looking for transactions that have script pub keys, that look like they might've been generated with your silent payment address.
+So you can also scan the UTXO set, right?
+Where the trade-off I would say between like an XPub style way of doing things or a BIP32 where you pre-generate the addresses and the silent payment one, you have to scan the UTXO set for these outputs that are paying to you.
+And in order to do that, you need access to the input data of the transaction that was to create that.
+So it's you don't quite have to scan the whole chain but let's say for you know like a an XPUB style way of doing things all you need is the XPUB and the script pub keys in the UTXO set.
+For silent payments, you need the UTXO set and the inputs to the transaction that created that output in the UTXO set.
+So for full nodes, this is very easy.
+They already have full access to the blockchain, all of the transactions, So it's always available to them.
+I would say that if you're already running a full node, there's not much extra overhead to run silent payments connected to that node.
+For a light client, this is a little more tricky.
+Now they need this input data, which without getting too deep into the weeds, that input data is really just one single pubkey, which represents the sum of the pubkeys used in that transaction.
+So it's about 33 bytes of data per transaction.
+So some light client that doesn't have access to the full chain now needs access to this 33 bytes per transaction to be able to check whether or not outputs in the UTXO set belong to them.
+So there was a really good talk that Taj gave at Baltic County Badger where I think he said it better than I had been able to express is, in silent payments, we are making the process overall less interactive.
+The sender and receiver do not need to interact in order to complete a payment.
+And in order to facilitate that non-interaction, we're spending more in just raw compute.
+We have to do more scanning on the node side to find that data and do that and use that data.
+To me, I think this is a great trade-off because of the benefits we get.
+But I think it's worth mentioning.
+
+Speaker 2: 00:29:00
+
+Yeah, Quickly jumping in on that one.
+Yeah, so I think that was a very good one that we have made this trade out wherein we are replacing interaction and some other things that we used to do with just computing a lot of stuff.
+But my question leading into that is then not a lot of people run full nodes already and we have a lot of wallet users who are relying on their wallet provider running a full node somewhere else.
+And so does this, so how does this make silent payments like harder to use if at all?
+And the second question would be like, what is the privacy implication of that?
+Because like right now, I might have a non-custodial wallet that I use who do not regularly have to track my transactions and all of that.
+But now that I'm using silent payment addresses, My assumption, and I might be wrong, is that they would be the ones who would have to track the blockchain and my keys or something like that.
+Is that true?
+And if yes, what is the privacy implication of that?
+
+Speaker 1: 00:30:18
+
+So could you rephrase the first question again real quick?
+And we'll start there, then maybe jump on to the second one.
+
+Speaker 2: 00:30:23
+
+Yeah, yeah.
+So I think my first question was regarding the fact that not a lot of people run full nodes already.
+And so when they don't, there are some other trade-offs, like some other downsides.
+So what would that be?
+And then the second one was just focusing on the privacy aspect of that when it comes to the user and their wallet provider.
+
+Speaker 1: 00:30:48
+
+So I think, you know, this is kind of bigger than just the topic of silent payments.
+And it's something that I care a lot about and have been doing a lot of thinking about is essentially, if you do not run your own full node today, there is no private wallet for you.
+It just doesn't exist.
+I think most of the wallets out there are using the Electrum X protocol, which there's ElectRS, there's the original Python one and everything like that, which is where the wallet is actually talking to the wallet provider server, and the wallet is querying for specific addresses.
+And saying, hey, can you tell me anything about this address?
+There's just no way to do this privately.
+It just doesn't exist.
+And I think there's been some arguments about this in the past, where People have tried to claim that some of these things are private, but they're not.
+The server could, now you can claim, okay, well, they're not doing it.
+But if nothing prevents them from doing it, from a privacy threat modeling, you kind of have to assume they're doing it.
+You can't just take someone's word like, oh, we're not collecting logs.
+So any wallet that's using ElectrumX as a backend is just telling ElectrumX every single address that they're interested in.
+Can you tell me anything about this address?
+Can you tell me anything about this address?
+And so that server could be logging all of that, keeping track of that information, And now you have very limited privacy.
+I think really the only private like client wallet protocol that I'm aware of today is BIP-158, which was originally kind of conceived for these lightening nodes that wanted kind of a private way to ask for information about what's spent in a block.
+And this you can actually use privacy with the tradeoff that it takes a little bit more bandwidth.
+So in the BIP-158 world, full nodes kind of create this compact filter for the whole block and they say within this filter we encode every script pub key that was spent or created and then the light clients ask for these filters and All that the node or the wallet provider learns at that point is okay a client was interested in this block, but they don't know anything about which addresses they were interested in or anything like that.
+They just know they wanted a block.
+The light client then gets that block and they have this way of testing for existence.
+So if they have a script pub key they want to check, they can test if it exists in that filter.
+If it does exist in that filter, then they ask for the block, either from the same person or a different node to better preserve their privacy.
+They download the full block and then they have all the information they need to process the transaction they care about.
+And the nodes don't learn anything about the specific transaction.
+So this to me is like, this is really the best that we have right now.
+And it's not really widely used by wallets.
+And I think a lot of people defer to using this Electrum style thing where you're just kind of telling the server, hey, This is exactly the transaction and the output that I'm listed in.
+So TLDR, to kind of go back to the original, if you're not running your own node, you're just not running a private Lite client today for the majority of wallets.
+How this kind of matters to silent payments is, as we started talking about silent payments and in how we wanted to support like clients, in theory, it would work totally fine for a silent payments user to just hand their scan key to somebody else.
+You just be like, hey, so maybe it was worth mentioning.
+In the sign-of-payments protocol, the address is composed of two keys, a spend key and a scan key.
+The scan key is used for finding the transactions.
+The spend key is used for spending the transactions.
+So your spend key can be in some super cold storage, never touches the internet, whatever, and your scan key can be hot online on a full node that either you own or somebody else owns and it's doing the scanning.
+And if you lose your scan key and give it up to somebody, you lose your privacy.
+They can see all the transactions that have been sent to your sign-up payment address, they cannot spend them.
+So in theory, sign-up payments could also be used in a non-private way where someone just gives their scan key to somebody else who's running a full node, either a wallet provider or whatever, and that person does the scanning on behalf of them and then just tells them when they find a transaction.
+This is very similar to how it works currently with Electra.
+For me, that's not super interesting.
+I can't stop anybody from building that, but That's not interesting to me because the whole point of silent payments to me is like usability along with privacy.
+So one of the things that I've been working on and researching is, how could we use something like BIP 157 and 158 for supporting silent payments like clients?
+So I have some proof of concepts and some ideas there where what you would get from a full node is you would ask them, hey for a block give me all of the tweak data that I need which is going to be about 33 bytes per transaction that would be a silent payment transaction.
+And also give me a Bitcoin 58 filter for this block.
+You're asking for two pieces of data.
+You take that tweak data, you generate the silent payment outputs privately on your device that you're interested to check.
+And then you check if they exist in the filter.
+If they exist in the filter, you ask another node or the same node for the full block, you download the block, you process the transaction.
+And so this way you could have a Lite client that is operating completely privately without needing, well not completely, more privately, right?
+There's still privacy implications with Bitcoin 58, but about as private as you can get today.
+You're scanning for transactions in a light client.
+You don't need the full blockchain.
+The tradeoff you're making here is you do need more bandwidth.
+Right.
+So instead of Electrum uses the least bandwidth, I think.
+BIP 158 uses a little bit more for the filters, and then sign-on payments would use more than that.
+So it's kind of like, at least now, I think we're giving users the option of, like, hey, if you want to run a light client, you don't want to run a full node, here's an option for you to use a light client privately with more bandwidth than it would cost you to do it non-privately but less bandwidth than it would cost you to run a full node.
+
+Speaker 2: 00:36:42
+
+Yeah quickly I'm jumping on that so what you just described like this can keep providing that all of that stuff so so the user does not explicitly need to do any of this themselves right the wallet software can do this in the background.
+
+Speaker 1: 00:37:01
+
+Exactly yeah you know from a user experience standpoint you know I'll take I'll take BDK as an example.
+In BDK, they have this work where they have like composable backends where, you know, you want to set up a wallet, you're building with BDK, and then you pick a backend.
+And I think they're working on compact block filters, Bit158 as a backend, though it's not ready yet.
+But you could say like, hey, I want an Electrum backend.
+I want an RPC backend.
+Like I want it to connect to only my node or a node that I trust, or use one of Bit158.
+From the user's perspective, they don't care or know.
+I mean, they should, right?
+There's privacy implications for the backend.
+But from the user perspective, they don't really know.
+If the wallet's really well designed from a user experience, they're clueless.
+They just open up their wallet and they see that their wallet is doing stuff, but they don't really know how it's getting that information.
+And it would be the same here, except that we would expect, like, if you have an Electrum style wallet versus a BIP-158 style wallet, the user would see more bandwidth consumption.
+Maybe the wallet, like the loading screen takes longer, there's more bandwidth.
+And so I think part of the UX challenge of silent payments would be explaining that trade off to the user.
+Right.
+Like why?
+Why is my phone, why is my mobile phone, you know, Bitcoin wallet operating slower than, you know, like this other wallet or, you know, why is this app using more data?
+And I think there's kind of a UX challenge there of explaining to the user, well, yeah, like you're using more data because you're not giving up your privacy to another node.
+You could use less data but then you're just giving up all of your privacy and I think people do care about that and even if they don't then we're allowing them to kind of make that educated trade-off for themselves.
+
+Speaker 3: 00:38:45
+
+So but would they even notice?
+I mean, one of the points is that you can send asynchronously, right?
+So you're not even in contact.
+So that wallet could kind of in regular intervals scan for incoming transactions and it would alert you only when you you know when it found something so then then it would all already be kind of I don't know how realistic that is or or whether that's that's feasible but the implications might not even be that bad because you're probably a lot of the time you're not even expecting it, except if you really synchronously interact with the person paying you.
+
+Speaker 1: 00:39:32
+
+Yeah, I agree.
+I mean, I think there's a lot of usage patterns where it wouldn't generally matter.
+I would say though, like having mobile apps do things in the background is very difficult.
+I think this is something that people struggle with.
+The other thing is a lot of times people talk about push notifications, right?
+Like their wallet alerting them of something.
+And I just, I don't think push notifications can happen in a private and kind of like, where the user is kind of in control of the thing, right?
+Because if you imagine how most push notifications work, you have your client which is connected to some server and that server is doing a bunch of work and things for you and when that server finds something out, it proactively sends you information as the client.
+But by the nature of you outsourcing that work to the server, it usually means that the server is learning a lot about you.
+So this kind of comes up sometimes with Bit.158 style wallets.
+If you have ElectrumX, you know, an ElectRS personal server running as your wallet backend, when it finds a transaction, it can proactively send you that notification.
+The only way that that server knows to send you the notification is because it knows the transaction, which means you've lost all your privacy to the thing that is sending you the notification.
+So I think this is another way where we kind of have to educate people of like, you're going to use stuff more privately, you're not going to have the same user experience as maybe non-private alternatives.
+Maybe there's some really clever way that, you know, I'm not aware of that we can do notifications in a more private way.
+But what I imagine would be more the use cases, I have a Bitcoin mobile wallet on my phone and I'm using it on my phone because I don't want to run a full node or I don't have the ability to run a full node.
+But I had this Bitcoin wallet that I'm using like somewhat infrequently.
+I wouldn't expect that I'm pulling it up and using it every single day.
+So I turn it on and I wanna, maybe there's some user initiated action of like, hey, scan for recent payments, or maybe when the app opens, it just starts scanning in the background and it tells you like, hey I'm downloading all of these filters so I can check for payments, you know give me a second and then I'll tell you if there's any new payments.
+And this is very similar to like if you run a Bitcoin Core node on your laptop and you shut your laptop off for a couple days and you turn it back on, you open Bitcoin Core and it'll alert you.
+It'll be like, hey, the last synced block I have is this.
+The current tip is this.
+You know, give me five minutes while I sync the chain up to here.
+So I imagine it'd be similar in the wallet.
+Then the wallet does its work.
+And then while it's doing that, then it's like, ah, hey, by the way, and that time that you were offline, you know, three people paid you and here's your new balance and it's current, you know, up to this block, I'll check again in five minutes or wait for you to tell me to check again.
+And the reason I'm using this as an example, I think there's a nice improvement that we could do with silent payments where to minimize the bandwidth that the client needs to download.
+When I come online and start scanning again, I don't really want all the blocks since I was last online.
+I only want data for transactions that still have unspent outputs.
+So if I check on January 1st and I scan and I get all this data, I've checked all these transactions for this block height, And then I go offline and then I come online February 1st again.
+And I say, hey, I want to scan for more payments.
+The server, whoever's sending me those payments, ideally should just send me information for UTXOs that were created since my last scan.
+So if I create, you know, exactly right.
+This is something we sometimes call cut through, transaction cut through.
+I really don't need any data for an output that was maybe created on January 2nd and spent on January 10th.
+Because clearly it wasn't for me.
+If it was spent, it was not for me.
+So this is something that I've been kind of playing around with where I don't even think the bandwidth concerns are going to be that bad for us on a payment user if we can come up with a way to implement a protocol like this.
+Because now you're taking advantage of the fact that a lot of UTXOs are going to be created and spent before you decide to scan again.
+Like if you scanned once a day, I think last time I looked at the numbers, it was like 50% or more of the UTXOs are created and spent in less than a day.
+So if you're scanning for once of a day, you're already cutting down on 50% of the data that you need.
+So I think we should be totally upfront about this and being like, hey, look, if we're going to build private mobile client experiences, it's going to be really difficult if we expect the exact same level of UX from a non-private mobile wallet.
+And we shouldn't make that our goal, right?
+We shouldn't be trying to provide a Venmo or CashApp-like experience on something that is just fundamentally different in that it has privacy or reduced trust as kind of the things that it values the most.
+So we need to kind of highlight like, hey, here are the trade-offs you're making, here's what you're getting for it.
+And so that makes it challenging.
+But I'm also hopeful that like the more we push the boundary and research these and kind of like actual prototype things, we may find that the user experience degradation is really not as bad as we think it is.
+I think it's always going to be the case that someone who's using a BIP-158 style back-end for their wallet, they're not going to get notifications.
+They are going to have to spend more bandwidth.
+But if we can quantify that and be like, oh, yeah, it's 15, 20 megabytes more per month.
+To me, that seems like a very acceptable thing versus like, hey, here's a wallet that you can use non-privately and here's a wallet that you can use privately but it's like 20 gigs per month.
+
+Speaker 0: 00:45:11
+
+Yeah, I think it's also important to think about that.
+Are you comparing to, you know, Venmo, Revolut, Apple, $2,000, iPhone 5G experience, which is for a lot of people in the world, that's not the point for a lot of this Bitcoin stuff?
+Or are you comparing to not even be able to make any payments at all, for which this is an insanely huge improvement or somewhere in between.
+I had another question around backups.
+So let's say I'm in my wallet, I imported my seed and I click okay, generate one of these addresses for me.
+The wallet should probably tell me that, cool, you might need more bandwidth now because of this scanning, maybe.
+And make sure to back this up, or if you use this wallet in another application that not all transfers might show up if it doesn't support this feature or something.
+There's something that people might have to be aware of if they assume that they can put their seed in any place and everything will just be the same because it might just not be because of some choices they made, right?
+
+Speaker 1: 00:46:22
+
+Yeah, this is another area where we wanted to be really careful when designing the protocol.
+So, one of the reasons we decided to keep everything within the transaction.
+There's no extra data.
+There's no OP returns.
+There's no anything outside of the transaction itself as we didn't want the user to have to back up any additional information.
+So what the recommendation currently is on the BIP is we've proposed a new derivation path with the silent payments BIP number.
+So this is very in the same style as BIP 43, BIP 44, and like those that have followed, where they say, hey, look, if you're using a BIP 32 style seed, whether that be a BIP 39 seed phrase or BIP 32, This derivation path by the constant 352, this is reserved for silent payments keys.
+So I start with my seed phrase, I go to the 352 derivation path and I generate two private keys, one for my scan key, one for my spend key.
+So I don't have to back up anything except for the original seed phrase.
+And if I import that into another wallet, so long as that wallet supports sign of payments, they'll know to check that 352 derivation path the same as how the rest of these derivation path standards work.
+Now, what the user does need to be aware of is, hey, so you've imported this seed phrase that was used for sign-of-payments.
+You can scan the UTXO set.
+Again, same as an XPUB-style wallet.
+You scan the UTXO set first and that tells you what your spendable balance is.
+And then if you want your transaction history again, same as like a regular old wallet that's using XPUBs or something else.
+Now you need to scan the full chain and that will give you your full wallet history.
+So I think we're really trying to keep it as close to an experience as any other wallet is possible.
+And we don't want the user to have to go around backing up extra information.
+I think one of the nice properties of signup payments is as long as you have access to the Bitcoin blockchain, or as long as you can get access to it, the full chain, you can always recover your full transaction history and your full wallet balance.
+Where I'm not trying to FUD BIP32 or anything like that, but when you go into a BIP32 style world where we have like the gap limit and look ahead, there is kind of this complex management of, you know, you're scanning, but you're scanning.
+You need to check these derivation paths, you need to make sure you're looking far enough ahead with the gap limit to make sure that you're actually recovering all of your money.
+Whereas in silent payments, it's like, hey, you look at a transaction, you take the inputs of that transaction, you do Diffie-Hellman with this private key.
+If something doesn't show up in the outputs, this was not a payment to you.
+If something does show up in the outputs, you get a match, then this was a payment to you, and now you have all the data you need to spend.
+So it's kind of like, again, that trade-off of, yeah, you need to be able to get to the Bitcoin blockchain.
+But if you can do that, then you kind of have this peace of mind knowing that with just this backup from a seed phrase that allows you to generate the scan key, you should be able to find all of your money.
+
+Speaker 0: 00:49:31
+
+That's great.
+Go ahead, Yash.
+
+Speaker 2: 00:49:34
+
+Sorry, so I on this one, like so when I'm when I just add a wallet, add a wallet into an application and it, and it checks for addresses sequentially, it is like often able to like detect all the payments in a few seconds or a couple of minutes.
+But if we have silent payment addresses, it would take longer because it has to do a lot more computation, a lot more downloading data and stuff.
+So if I'm checking sequentially, it's like really easy, right?
+20 addresses, 100 addresses.
+But if I'm doing silent payments, it's like almost an unbounded number of addresses that I have to check for?
+
+Speaker 1: 00:50:18
+
+I think when you're checking addresses sequentially, you are relying on that gap limit heuristic, right?
+You're kind of like assuming you didn't use more than the look ahead window and everything like that.
+And so I think what you really should be doing is kind of checking the whole UTXO set to see if you have a match.
+So like I think it is faster, But for me, it's faster with less peace of mind, because really what I should do to be doubly sure that I'm getting all of the money from that BIP32 chain is I should be brute forcing way ahead on the gap limit, which is going to take a lot longer.
+So The fact that it's quick is good.
+And if you're scanning, if you're re-scanning, let's say you import a sign-up payment address and you're scanning the UTXO set, you are, it is going to take longer because now instead of pre-generating stuff and checking, you're going to check every unspent taproot output, right?
+Because any unspent taproot output could be a silent payment to you.
+So you're gonna have to check all of those in one pass.
+We haven't benchmarked this yet, but it's not crazy, right?
+We're not talking about crazy orders of magnitude.
+If you want wallet history, then both wallets.
+There is no fast way for an XPUB wallet to recover a wallet history or a sound payment wallet.
+You are going to have to scan the full chain.
+
+Speaker 2: 00:51:40
+
+Yeah, and I think even if it takes longer or needs more data, we could always convey that up front so the user can know that this is the trade-off and they can make the decision based on that, I guess.
+
+Speaker 1: 00:51:54
+
+Yeah, absolutely.
+I think it's always expectation setting.
+Another thing worth mentioning with sign-on payments, there is going to be a slight increase in the work to do the scanning because this ECDH step is an elliptic curve multiplication, which can be a somewhat expensive step for a wallet to do.
+So I think that's one of the things that we're planning to benchmark on the Bitcoin Core one is if we do a wallet rescan.
+Let's say today I have like my descriptor wallet set up and I decide to rescan the chain to look for wallet history that might take two hours.
+With sign in payments, I would expect it's probably going to take maybe like two hours and 15 minutes or two hours and a half.
+I don't think it's going to take much longer, but there is a little bit of extra work in there because of the ECDH step.
+
+Speaker 2: 00:52:42
+
+Yeah, does that increase the work that the wallet providers might have to do because like now we we might have in the future It might have thousands of users using silent payment addresses and now for each of those users the Wallet provider who does the full node has to do all of this extra work.
+And so that is just like a trade-off.
+
+Speaker 1: 00:53:06
+
+Yeah, that's another one that I'm interested to look at.
+So again, we're always talking about the non-private scenario here, right?
+Like If the wallet provider is doing the scanning for the user, we're strictly in non-private territory.
+There's no way to do this privately.
+So taking Bit47 as an example, one of the implementations of Bit47, if a user is not able to run their own node, then they will have the wallet provider scan for them because the user will give them the XPUBs to scan for.
+So the user is now losing their privacy to the server to do the scanning for them.
+And for bit 47, you have like a, I think an XPub per contact.
+So if I had opened a payment channel with Christoph, opened a payment channel with Michael, opened a payment channel with you, now there's three XPubs that that server is gonna have to scan for on the server side.
+So I think of it as the number of users times the number of connections those users have for that XPUB style scanning as a wallet provider, which blows up pretty quickly.
+But I think it's still not that bad because they can pre-generate what all of these addresses would be and put them in some sort of database.
+On the sign-of-payment side, and again, this is something where I'm like, I wouldn't recommend that people build it this way, but let's just say the server said, hey look, I've got an index for sign-of-payments, just give me your scan key, I'll do the scanning for you, and now I've got a million users.
+That does mean that that server would have to do a million ECDH steps, so a million elliptic curve multiplications to check for all of their users, which is going to be more work than the XPUB lookup in a database style of doing things.
+I think really, the way you push for payment adoption is I think we keep investing in these more private like client protocols because you know what I was describing earlier with BIP 157 and 158 It's another one of these nice ones that I think it It's private, but it also scales better right because one single server computes these indexes and distributes them to clients.
+The server does the computation of the index one time, and then they give it to whoever asked for it.
+If the server does the work once, it gives it to many clients.
+So this is like a good client-server model.
+Then each individual client does a little bit of work relevant to themselves.
+So, if I have a million silent payments users, and they're all using this more private protocol, they'll ask for the filter data from the node a million times.
+So the node would compute it once, give it to people a million times, and then you have a million phones each doing their own ECDH calculations to check for payments, which distributes that calculation a lot better, rather than having a single server just chewing through ECDH calculations to support n number of users.
+
+Speaker 0: 00:56:07
+
+We're at the hour now.
+We can still keep chatting if everyone wants to.
+But I was also wondering then, what's the status right now?
+What are the next steps?
+What are the goals?
+Is it to get implementations?
+Is it to do more of this benchmarking, testing, consensus building?
+Is this accepted as a solution by the ecosystem?
+Or is it possible to tell even?
+
+Speaker 1: 00:56:36
+
+Great, great question.
+The nice thing about silent payments is it does not require a soft fork.
+So we don't really need anyone to like agree or accept it, right?
+It's a wallet protocol.
+So I would say you know anybody who's interested feel free to reach out get in contact if you want to implement it.
+I would say in terms of status Ruben Thompson and I are very happy with the state of the BIP.
+I think the BIP, at least in my head, I'm considering it finalized.
+I don't expect that we're going to make any breaking changes to the protocol.
+Now, that being said, buyer beware.
+This is a BIP that is brand new.
+It hasn't been out for multiple years yet.
+I know six months ago, some people jumped in and were really eager, and then we had to make a change to a hashing step in the BIP.
+Some people were a little frustrated so it is you know it is new but I think you know for our purposes we're kind of saying like look the BIP is ready to go we've been spending the last couple weeks myself and another contributor we've been working on adding more test cases to the bit, so test vectors for wallets to implement.
+At that point, anybody is free to take a stab at it.
+Start implementing it in your wallet.
+I would really encourage people, if you're interested and want to play around with this, start implementing sending support.
+Even better, let's make libraries for sending support that we can start giving to people.
+Sending support should be very easy, right?
+I mean, relatively.
+It should be relatively easy compared to the receiving side of it.
+And you're not really, like to do sending support, You don't need to change anything about your wallet back end whatsoever.
+If you're a wallet that uses the Electrum protocol, you can send to sign payment addresses.
+No problem.
+You know, there's I expect that sending is that thing that you can do without really changing much.
+If we get enough momentum on the sending side, then I think the receiving momentum will follow.
+So that's kind of where we're at.
+I'm actively looking for people who want to start implementing sending, I'm happy to work with people on that.
+In terms of the Bitcoin Core implementation, that's still a work in progress.
+You know, we need more reviewers in Bitcoin Core because it moves very slowly there and we're kind of making a pretty big change to the wallet.
+But that's where I'll keep putting a lot of my attention, just continuing to work and get that.
+But I don't think, you know, nobody needs to wait for it to be on Bitcoin Core for people to start using this.
+You know, obviously it's nice.
+And I think for like clients, we're going to have to have something in Bitcoin Core, whether that be an index or some protocol for distributing the stuff.
+But yeah, I think we're in the phase now where we've spent a lot of time grinding on the protocol, working out the edge cases, making sure that we're happy with it.
+Now I'm fully in implementation mode for Bitcoin Core and I'd be excited to see other people starting to run with it and implement it.
+I guess it's ready.
+
+Speaker 0: 00:59:52
+
+It's awesome.
+Hey, Joshua, sounds like something we could do a side project on the Bitcoin Core app for.
+
+Speaker 1: 00:59:58
+
+Yeah, I think that'd be awesome.
+Yeah, And I think there's a lot of fun, you know, to me, there's a lot of fun design space around silent payments, right?
+It's not just, you know, you know, I have I have this dream in my head someday that we'll have like usernames for Bitcoin.
+And it kind of feels like, yeah, we could start thinking about like, what would the UX and design around a username be for something like a silent payment address.
+Another thing that I'm really excited in starting to do is reach out to exchanges and talk to them about it, about how exchanges could start doing silent payment support.
+Instead of sending to a static address to deposit your money to the exchange, you can now have a silent payment address that's unique to you.
+The exchange could allow withdrawing to a silent payment address, which I know today a lot of exchanges, you have to like register a single address and you have to like approve it in your wallet and then you withdraw to that address multiple times.
+Again, horrible for privacy.
+And then if you wanna change it, you have to go through this like two factor authentication and everything to be like, oh yeah, this is a new address, I'm not a hacker.
+Well, if we had sign of payment support, you go to the exchange one time, you register it, hey, this is my sign of payment address, you authorize it, go through all that safety to say, like, this is what I wanna withdraw to.
+And now, for the rest of the duration of your account with that exchange, you can always withdraw to that same address and never have to go through this painful process of updating every time.
+So there's a lot of things that are just like beyond strictly wallet and user experience that I'm kind of excited to start talking to people about and exploring the design space for.
+
+Speaker 2: 01:01:35
+
+Yeah, I'm super excited about this.
+And I'm Christoph like not just in the Bitcoin app, but in the design guide that we have, I think like if like Josie saying that hey like people can can run with it even right now and if in the Bitcoin design guide we have some sort of guidance around that and we might say people who want to implement this, we could save people some effort on the design aspect of it.
+Yeah, so I'm super excited for it.
+Want to work on it.
+Yeah.
+I love this.
+
+Speaker 1: 01:02:13
+
+That would be awesome.
+Like that was one thing I was really hoping to come out of a call like this because it's a fundamentally different user experience, right?
+You don't have this like generate fresh address every time you have a static QR code, a static address that can be reused for the duration of the wallet.
+So there's a lot of like different ways of thinking that I think maybe aren't, you know, there isn't prior art on for design.
+So that I mean, that'd be really cool to see some guidance come out for wallet developers.
+So we have this kind of like clean uniform experience for people.
+
+Speaker 0: 01:02:50
+
+Let's wrap it up here in a minute, but I just have one question because you mentioned it.
+Actual usernames on Bitcoin.
+I know that BIP47 people, they have these paynames and it's basically a centralized server, which I don't think that's what we want to shoot for.
+Do you think it's possible in any other way?
+I mean,
+
+Speaker 1: 01:03:09
+
+it's yeah, it's something I've kicked the tires on a little bit.
+You know, what one One idea is, let's say you did have a centralized server that was handing out silent payment addresses.
+So like I say, I want some username at domain.com and then the domain just returns.
+Like let's say I own the domain Josie.
+Under my well-known directory, I want to put my silent payment address.
+Now you can just hit me at josie.com and your wallet will retrieve the sign of payment address and parse it.
+Something like that would be really cool.
+There's obviously some threat leveling of like, oh, but someone could get in between and modify the address or whatever.
+So I've been thinking a little bit about this of like, how could we combine something like the sign-in payment address with our domains, with some way of signing and authenticating that data?
+I do agree, there's some less impressive ways to do it, which is just running a PayNM style thing where like, yeah, centralized server just maps the PayNM to the static code, but we're leaking a lot of information and we really aren't authenticating any of the data.
+Like in the centralized server handing out silent payment addresses, how do you know the server isn't just replacing every address with their own?
+
+Speaker 0: 01:04:34
+
+Yeah.
+
+Speaker 1: 01:04:34
+
+Right?
+So I've been thinking about stuff like that.
+I don't have any groundbreaking, but it's another one of those areas where I'm like, I feel like if we just keep kicking the tires on this, there's some interesting ideas.
+Someone was like, yo, we could like inscribe stuff, you know, we could have like, and I was like, you know, like, I want usernames, I don't want them that bad.
+Like, I don't really want to go that route.
+But it's a fun idea that I want to keep playing with.
+Yeah,
+
+Speaker 0: 01:05:02
+
+Yeah, that sounds like what Lightning addresses and Noster addresses, that type of format basically.
+Which, I guess we have to, we have both of these that are testing out right now.

--- a/bitcoin-design/misc/2020-08-20-bitcoin-core-gui.es.md
+++ b/bitcoin-design/misc/2020-08-20-bitcoin-core-gui.es.md
@@ -1,13 +1,11 @@
 ---
-title: Guía de Bitcoin Core
+title: Reunión introductoria de la GUI de Bitcoin Core
 transcript_by: Michael Folkson
 translation_by: Blue Moon
 tag: ['bitcoin-diseño']
 date: 2020-08-20
+aliases: ['/es/bitcoin-design/2020-08-20-bitcoin-core-gui']
 ---
-
-Name: Reunión introductoria de la GUI de Bitcoin Core
-
 Tema: Enlace del orden del día publicado a continuación
 
 Ubicación: Diseño de Bitcoin (en línea)
@@ -18,7 +16,7 @@ Agenda: https://github.com/BitcoinDesign/Meta/issues/8
 
 La conversación se ha anonimizado por defecto para proteger la identidad de los participantes. Aquellos que han expresado su preferencia por que se atribuyan sus comentarios son atribuidos. Si usted ha participado y quiere que sus comentarios sean atribuidos, póngase en contacto con nosotros.
 
-# Revisión de Bitcoin Core PR
+## Revisión de Bitcoin Core PR
 
 Parece que hay mucho que aprender sobre los antecedentes de Bitcoin Core, cómo se hace el trabajo, lo que debería ser, lo que es ahora mismo, por qué es como es ahora mismo. Tengo curiosidad por aprender más allí.
 
@@ -36,7 +34,7 @@ Soy razonablemente técnico, quiero jugar con la construcción. No estoy seguro 
 
 Lo que me gusta es que en Figma o Sketch, o cualquier otra herramienta de diseño que tengamos, se reproduce uno a uno el software real. Primero se hace un diseño antes del desarrollo y, cuando éste llega, todos los problemas de la interfaz de usuario se han discutido y resuelto. Esto simplifica el desarrollo porque no hay que construir la interfaz de usuario de una manera y luego rehacerla. Ya has resuelto muchas de esas cosas. Cómo deben llamarse, dónde están ubicados y todas estas cosas. Requiere un montón de coordinación porque en la fase inicial de planificación y discusión, es donde se hace el estilo y el diseño inicial. Al principio es más trabajo de planificación y coordinación, pero luego la implementación se hace más fácil. Eso facilita la colaboración de los diseñadores.
 
-# Diseñando para múltiples sistemas operativos
+## Diseñando para múltiples sistemas operativos
 
 Como codificador, ¿cómo van a soportar los diseñadores múltiples... la misma UI para MacOS, Windows, Linux?
 
@@ -62,7 +60,7 @@ La interfaz gráfica de Bitcoin Core utiliza el framework multiplataforma Qt, qu
 
 ¿Eso es sólo para el onboarding? Cuando llegas a la GUI real no estás usando las plantillas por defecto, ¿verdad?
 
-# Haciendo cambios en la GUI de Bitcoin Core
+## Haciendo cambios en la GUI de Bitcoin Core
 
 Está el desarrollo de características, está la capa de estilo visual y luego está la mejora o el trabajo en la capa de interacción. El flujo de incorporación que no añade ninguna característica, pero hace que la interacción sea más agradable para los nuevos usuarios para configurar las cosas. Entonces, acabamos de hablar del estilo visual. Personalmente, mi impresión es que el estilo visual es mucho menos prioritario que el nivel de características y algunos de los niveles de interacción. El nivel de características es la creación de nuevas cosas y en el nivel de interacción yo incluiría la introducción de algunas funcionalidades que existen en la API o en la línea de comandos y llevarlas a la GUI. Incluiría eso en la mejora del modelo de interacción. ¿Es correcta mi suposición?
 
@@ -84,7 +82,7 @@ Estaría encantado de ayudar en las pruebas si pudiera poner en marcha el materi
 
 Creo que es plausible ponerlo en marcha haciendo eso. No creo que sea difícil construir PRs. Volviendo a la discusión de la revisión no tienes que firmar todo. No es como si al hacer una revisión tuvieras que decir "Este código está bien. No hay errores. He mirado todos los aspectos de este RP y todo está bien". Puedes escoger un aspecto y decir "En la cuestión del diseño pienso esto pero no he revisado el código, no he hecho esto". La revisión es realmente importante y todo el valor que podamos obtener de cualquier conjunto de habilidades que alguien tenga, mejor. Ciertamente hay un valor que puedes aportar con tu experiencia.
 
-# Conseguir el consenso para los cambios de la interfaz gráfica de usuario
+## Conseguir el consenso para los cambios de la interfaz gráfica de usuario
 
 En el consenso, cuando trabajaba en la GUI de Monero lo que ocurría a menudo es que yo sugería algo a los desarrolladores y ellos decían "No nos lo digas a nosotros, díselo a la comunidad". Así que lo publiqué en Reddit con 150.000 personas. Con las características más grandes, las cosas más nuevas, el primer paso era lanzarlo al público para ver lo que todo el mundo piensa. Luego, sólo después, el equipo trabajaría en las cosas. Podían dar su opinión, pero la idea era ponerlo en el espacio público. Hubo un proceso en el que las ideas se probaron primero en una fase pública y se ajustaron las buenas. En un momento dado, pasaban al desarrollo real. Podía desarrollarse una pequeña cosa o el conjunto, tal vez se tardaba medio año más o menos. Era un proceso bastante lento. Si lo miras en una línea de tiempo más larga, es mucho más fácil para mucha gente pensar en ello y crear un consenso sobre algo. El consenso no se produce a nivel de relaciones públicas y asuntos, pero es un proceso más largo. ¿Está ocurriendo algo así?
 
@@ -100,7 +98,7 @@ Si te gusta hacerlo entonces hazlo. Si no crees que sea la mejor manera de obten
 
 Podría ser que el asistente de diez pasos viva en el espacio público y se discuta mucho mientras se implementa el primer paso. El resto se sigue discutiendo y cuando llega el momento de implementar el paso 2 o 3 ya se ha discutido mucho.
 
-# Interacción de los diseñadores con los desarrolladores de Core
+## Interacción de los diseñadores con los desarrolladores de Core
 
 Tengo una pregunta sobre la interacción entre el diseñador y el codificador. He visto bocetos en Figma pero como codificador necesito el tamaño de la ventana y los píxeles. ¿La ventana es fija? Necesito los nombres de las fuentes y el tamaño de las mismas. ¿Cómo funcionan estas interacciones? ¿Debería un diseñador abrir un tema en nuestro repositorio para describir estos elementos que el codificador debería implementar?
 
@@ -126,7 +124,7 @@ Fanquake hace mucho trabajo en el sistema de construcción, Luke hace mucho trab
 
 Lo que pasó en Monero fue interesante. Yo sólo tenía un diseño por diversión, lo publiqué en Reddit. Un desarrollador que había querido ayudar en la GUI de Monero, lo cogió y dijo "quiero implementar esto". Para él fue una oportunidad de unirse al proyecto porque ese era su interés pero no tenía algo con lo que trabajar. Coincidimos en este diseño. Era su manera de empezar. Tal vez si hubiera cosas interesantes por ahí que estuvieran abiertas y disponibles, entonces tal vez hubiera alguien que estuviera interesado en entrar. Poner las cosas ahí fuera a veces es todo lo que se necesita. No está garantizado. También tengo un diseño en el repositorio de Monero que ha estado allí durante un año y nadie ha hecho nada con él, lo que también está bien. A veces puede funcionar así.
 
-# Usuarios objetivo
+## Usuarios objetivo
 
 En los diseños actuales de Figma ([aquí](https://www.figma.com/file/FJ02rY3m8V9ZCDvoXjW39W/Bitcoin-Core?node-id=281%3A0) y [aquí](https://www.figma.com/file/FJ02rY3m8V9ZCDvoXjW39W/Bitcoin-Core?node-id=462%3A655)) ¿qué tipo de usuario teníais en mente para esto?
 

--- a/bitcoin-design/misc/2020-08-20-bitcoin-core-gui.md
+++ b/bitcoin-design/misc/2020-08-20-bitcoin-core-gui.md
@@ -1,12 +1,10 @@
 ---
-title: Bitcoin Core Gui
+title: Bitcoin Core GUI introductory meeting
 transcript_by: Michael Folkson
-tag: ['bitcoin-design']
+tags: ['bitcoin-core']
 date: 2020-08-20
+aliases: ['/bitcoin-design/2020-08-20-bitcoin-core-gui']
 ---
-
-Name: Bitcoin Core GUI introductory meeting
-
 Topic: Agenda link posted below
 
 Location: Bitcoin Design (online)
@@ -17,7 +15,7 @@ Agenda: https://github.com/BitcoinDesign/Meta/issues/8
 
 The conversation has been anonymized by default to protect the identities of the participants. Those who have expressed a preference for their comments to be attributed are attributed. If you were a participant and would like your comments to be attributed please get in touch.
 
-# Bitcoin Core PR review
+## Bitcoin Core PR review
 
 There seems to be a lot to learn about the background of Bitcoin Core, how work gets done, what it should be, what it is right now, why it is the way it is right now. I am curious to learn more there.
 
@@ -35,7 +33,7 @@ I’m reasonably technical, I do want to play around with building it. I am not 
 
 What I like is that in Figma or Sketch or whatever design tool we have there is a one-to-one reproduction of the actual live software. You do a design first ahead of development and by the time development comes around all the UI issues are discussed and resolved. It simplifies the development because you don’t have to build the UI one way and then redo it again. You have already resolved a lot of those things. What they should be called, where they are located and all this stuff. It does require a whole bunch of coordination because in the initial planning and discussion phase, that’s where you do initial styling and design. It is more planning work and coordination work at first but then the implementation becomes easier. That makes it easier for designers to collaborate to.
 
-# Designing for multiple operating systems
+## Designing for multiple operating systems
 
 As a coder how are you as designers going to support multiple… the same UI for MacOS, Windows, Linux?
 
@@ -61,7 +59,7 @@ Bitcoin Core GUI uses the multiplatform framework Qt which was chosen because of
 
 That’s only for the onboarding? When you get to the actual GUI you aren’t using the default templates right?
 
-# Making changes to the Bitcoin Core GUI
+## Making changes to the Bitcoin Core GUI
 
 There is feature development, there is the visual styling layer and then there is the improving or working on the interaction layer. Onboarding flow that doesn’t add any features but makes the interaction nicer for new users to set things up. Then just now we were talking about visual styling. Personally my impression is that the visual styling is much lower priority than the feature level and some of the interaction level. The feature level is creating new things and in the interaction level I would include introducing some functionality that exists in the API or the command line and bringing that into the GUI. Include that in improving the interaction model. Is my assumption there accurate?
 
@@ -83,7 +81,7 @@ I would be happy to help testing if I could just get the development stuff runni
 
 I think it is plausible to get you up and running doing that. I don’t think it is hard to build PRs. Going back to the review discussion you don’t have to sign off on everything. It is not like when you do a review you need to say “This code is fine. There are no bugs. I have looked at every aspect of this PR and it is all fine.” You can just pick one aspect and say “On the design question I think this but I haven’t reviewed the code, I haven’t done this.” Review is really important and whatever value we can get from whatever skillset somebody has the better. There is certainly value you can bring with your background.
 
-# Getting consensus for GUI changes
+## Getting consensus for GUI changes
 
 On consensus, when I worked on the Monero GUI what would often happen is that I would suggest something to the developers and they would say “Don’t tell us, tell the community.” So I posted on Reddit with 150,000 people. With bigger features, newer things the first step was to throw it out to the public to see what everybody thinks. Then afterwards only later would the team work on things. They could give their input but the idea was to put it into the public space. There was a process where the ideas were first tested in a public phase and the good ones were adjusted. At some point later they trickled into actual development. A small thing might be developed or the whole thing, maybe it took half a year or so. It was a pretty slow process. If you look at it on a longer timeline it is much easier for many people to think about it and build consensus on something. Consensus doesn’t happen at the PR and Issue level but it is a longer process. Is there anything like that happening?
 
@@ -99,7 +97,7 @@ If you like doing that then do that. If you don’t think that is the best way t
 
 It could be that the ten step wizard lives in the public space and gets discussed a lot while the first step is being implemented. The rest is still being discussed and by the time it comes to implementing Step 2 or 3 then there was already a lot of discussion.
 
-# Designers interacting with Core developers
+## Designers interacting with Core developers
 
 I have a question on interaction between designer and coder. I saw sketches on Figma but as a coder I need window size and pixels. Is the window fixed? I need font names, font size. How do these interactions work? Should a designer open an issue in our repo to describe these elements the coder should implement?
 
@@ -125,7 +123,7 @@ Fanquake does a lot of work on the build system, Luke does a lot of work outside
 
 What happened in Monero was interesting. I had just a design for fun, I posted it on Reddit. A developer who had been wanting to help on the Monero GUI, he picked it up and said “I want to implement this.” For him it was an opportunity to join the project because that was his interest but he didn’t have something to work with. We matched up on this design. It was his way to get started. Maybe if there were some interesting things out there that are open and up for grabs then maybe there is someone who is interested in coming in. Putting things out there sometimes is all that is needed. It is not guaranteed. I also have a design in the Monero repo that has been there for one year and nobody has done anything with it which is fine too. Sometimes it can work out that way.
 
-# Targeted users
+## Targeted users
 
 On the current Figma designs ([here](https://www.figma.com/file/FJ02rY3m8V9ZCDvoXjW39W/Bitcoin-Core?node-id=281%3A0) and [here](https://www.figma.com/file/FJ02rY3m8V9ZCDvoXjW39W/Bitcoin-Core?node-id=462%3A655)) what kind of user did you have in mind for this?
 

--- a/bitcoin-design/misc/_index.es.md
+++ b/bitcoin-design/misc/_index.es.md
@@ -1,5 +1,5 @@
 ---
-title: Bitcoin Design
+title: Miscellaneous
 ---
 
 {{< childpages >}}

--- a/bitcoin-design/misc/_index.md
+++ b/bitcoin-design/misc/_index.md
@@ -1,0 +1,5 @@
+---
+title: Miscellaneous
+---
+
+{{< childpages >}}

--- a/bitcoin-design/ux-research/_index.md
+++ b/bitcoin-design/ux-research/_index.md
@@ -1,0 +1,6 @@
+---
+title: UX Research
+source: https://www.youtube.com/playlist?list=PLpV0KfVOMojZxAZW946MGXKP_w95G1X2j
+---
+
+{{< childpages >}}

--- a/bitcoin-explained/_index.md
+++ b/bitcoin-explained/_index.md
@@ -1,5 +1,8 @@
 ---
 title: Bitcoin Explained
+hosts: ['Sjors Provoost','Aaron van Wirdum']
+source: "https://bitcoinexplainedpodcast.com/@nado/feed.xml"
+transcription_coverage: full
 ---
 
 {{< childpages >}}

--- a/bitcoin-explained/bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy.md
+++ b/bitcoin-explained/bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy.md
@@ -1,0 +1,1158 @@
+---
+title: "Bitcoin Core 26.0 (And F2Pool's OFAC Compliant Mining Policy)"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://bitcoinexplainedpodcast.com/@nado/episodes/episode-85-bitcoin-core-26-0-and-f2pool-s-ofac-compliant-mining-policy-ainlt
+tags: ['bitcoin-core']
+speakers: ['Sjors Provoost', 'Aaron van Wirdum']
+categories: ['podcast']
+date: 2023-11-23
+summary: "In this episode of Bitcoin, Explained, Aaron and Sjors explain what new features are included in the upcoming Bitcoin Core 0.26 release. They also briefly discuss recent developments concerning the transaction inclusion policy of mining pool F2Pool, which appears to have been compliant with the OFAC sanctions list."
+---
+Speaker 0: 00:00:20
+
+Live from Utrecht, this is Bitcoin Explained.
+Hello Sjoerd.
+
+Speaker 1: 00:00:25
+
+What's up?
+Welcome back.
+Thank you.
+
+Speaker 0: 00:00:28
+
+You've been back for, do you even live in this country still?
+
+Speaker 1: 00:00:31
+
+I certainly do.
+Yes.
+
+Speaker 0: 00:00:32
+
+You were gone for like two months?
+
+Speaker 1: 00:00:33
+
+No, one month.
+
+Speaker 0: 00:00:36
+
+One month, a couple of conferences.
+Where did you go?
+
+Speaker 1: 00:00:40
+
+Too many conferences.
+In fact, Bitcoin Indonesia, Nastrasia in Tokyo.
+
+Speaker 0: 00:00:45
+
+Well, but the thing is before that you were in the States for a while and you were in Portugal.
+
+Speaker 1: 00:00:49
+
+I was, but I was home for a few weeks in between.
+
+Speaker 0: 00:00:51
+
+All right.
+Well, you were gone for so long that there's a new Bitcoin Core release.
+
+Speaker 1: 00:00:55
+
+That's right.
+
+Speaker 0: 00:00:56
+
+Bitcoin Core 26.
+But before we get into it, so that's what this episode is going to be about.
+George, we're going to discuss Bitcoin Core 26.
+Cool.
+But there's been some recent developments that you suggest that we briefly touch on before we get there.
+
+Speaker 1: 00:01:10
+
+Yeah, I think so.
+So remember, dear listeners, if you listen to episode 37, back in 2021, we talked about MaraPool, which at the time was making blocks that they said were OFAC compliant.
+As far as we know they did not actually do any filtering but this triggered a developer which we will call 0xb10c to write a tool that monitors the blockchain for said censorship just in case that would ever happen.
+
+Speaker 0: 00:01:46
+
+Yeah, So just to reiterate what this all means, there is an OFAC list and this, and this means there are entities on there that you're not allowed to act with.
+And that's the US government sanctioned list.
+Is that the right way to think about it?
+
+Speaker 1: 00:02:02
+
+Yes, correct.
+
+Speaker 0: 00:02:03
+
+So these would include people that the US government does not like, essentially.
+
+Speaker 1: 00:02:08
+
+Yes, these are only people that the US government does not like.
+
+Speaker 0: 00:02:11
+
+Right, and there are Bitcoin addresses on this list?
+
+Speaker 1: 00:02:14
+
+Yeah, so I think the general idea is that they say, Hey, this guy and this guy, you should not do business with them.
+And this is how you recognize them.
+And they'll spell out their name in like five different ways.
+And give maybe some known addresses.
+And they might also give some known Bitcoin addresses that are associated with this person.
+
+Speaker 0: 00:02:31
+
+Right.
+So there are Bitcoin address on this list.
+And if you want to send Bitcoin to or from these addresses, then so what MarathonPool was doing was they would essentially filter these transactions and not include these transactions into a block.
+That's how they would comply with this list, right?
+
+Speaker 1: 00:02:49
+
+Yeah, but they didn't actually do that.
+I think they were thinking about doing that.
+And they put some operatory message in the block.
+But we explained that back in that episode.
+Because as far as I know, they didn't actually do any filtering.
+But it cost quite a lot of consternations and they backed out of that idea.
+I think they even replaced their CEO, though that may have been completely unrelated.
+But anyway, it was enough motivation for him to write this tool.
+And what this tool does is it basically runs a Bitcoin Core Fullnode and a Bitcoin Core Fullnode will propose a block.
+Basically, it just every 10 seconds creates what it thinks would be a correct block.
+It doesn't do the proof of work, it just constructs the block.
+And then when a real block appears, it compares it.
+It looks at which transactions are missing that were expected to be in the block and which transactions are not missing.
+And then for the transactions that are missing it would run it against a bunch of heuristics of why it might be missing.
+Usually it's completely innocent.
+So for example a transaction might be very new, maybe your node has heard about it one second ago, then it's very likely that other nodes have not heard about it yet, so it's not surprising that it's not in a block.
+Something else that tends to happen especially these days is that miners will have an accelerator service where they will prioritize transactions that if you look at their Bitcoin fees they should not be in the block but they are in the block because they've paid through credit card or some other way to be included in the block.
+And so basically some of the tools automatically filter some of these things and other times you basically wrote a blog post about it doing it manually just checking out what's going on here.
+
+Speaker 0: 00:04:32
+
+Okay, so what is going on here?
+Why are we discussing this?
+
+Speaker 1: 00:04:35
+
+Well what seems to be going on here is that there are four transactions by F2Pool which...
+Transactions by F2Pool?
+Well transactions not by F2Pool.
+
+Speaker 0: 00:04:45
+
+Transactions not included in a block by F2Pool.
+
+Speaker 1: 00:04:48
+
+Exactly.
+
+Speaker 0: 00:04:48
+
+Right.
+
+Speaker 1: 00:04:49
+
+Four of them.
+And if you look at each four of them, I believe two or three of those, there's not a good explanation of why they're not in a block.
+Could still be innocuous, but they're not recent transactions.
+They're not pushed out because other transactions were prioritized, etc.
+And then the explanation that would remain is that they were filtered because they were on that list.
+
+Speaker 0: 00:05:13
+
+So they are on that list.
+
+Speaker 1: 00:05:14
+
+They definitely are on that list.
+That's not the problem.
+
+Speaker 0: 00:05:17
+
+Okay, got it.
+So censorship is upon us.
+
+Speaker 1: 00:05:20
+
+Well, yes, but we didn't know for sure, I guess.
+We could just do the analysis, but then there was a tweet by, I guess, the person in control of F2Pool.
+
+Speaker 0: 00:05:36
+
+Wangchun?
+
+Speaker 1: 00:05:37
+
+Yes, who says, will disable the TX filtering patch for now until the community reaches a more comprehensive consensus on this topic.
+So basically…
+
+Speaker 0: 00:05:46
+
+So that is a confirmation that he was in fact filtering out OFAC transactions in breach of the OFAC list.
+
+Speaker 1: 00:05:54
+
+Yes, or at least some of them because it's not clear if he was filtering all of them.
+
+Speaker 0: 00:06:01
+
+But where does this patch even come from?
+Like is this a patch?
+
+Speaker 1: 00:06:04
+
+Presumably just self-written.
+Can I download this patch?
+
+Speaker 0: 00:06:06
+
+Okay.
+
+Speaker 1: 00:06:06
+
+No, you'd have to write it yourself.
+You'd have to do something like if this transaction arrives...
+
+Speaker 0: 00:06:12
+
+Bitcoin Core does not offer this patch.
+
+Speaker 1: 00:06:14
+
+No, But I guess you can write a patch that keeps things from going into your mempool.
+I don't know if we have a way to get things out of your mempool once it's in there.
+
+Speaker 0: 00:06:24
+
+Anyways so Wangchun F2Pool was using a patch, maybe self-written, maybe not, to filter these transactions out of blocks to comply with the OFAC list.
+And now he's…
+Well,
+
+Speaker 1: 00:06:39
+
+we don't know if it was to comply with the OFAC list.
+
+Speaker 0: 00:06:41
+
+Josh, why are you hedging everything so much?
+It's pretty obvious at this point, right?
+You did the analysis.
+
+Speaker 1: 00:06:46
+
+No, because there are some unconfirmed tweets that suggest that...
+
+Speaker 0: 00:06:48
+
+And he confirms it on Twitter.
+
+Speaker 1: 00:06:50
+
+Yeah, but there are some other unconfirmed screenshots of tweets that suggest that Motiv may have been slightly different.
+But in any case, we know that these transactions were deliberately filtered.
+
+Speaker 0: 00:06:58
+
+But what's the alternative motivation?
+
+Speaker 1: 00:07:00
+
+Well, it might be that he just doesn't like those particular people.
+
+Speaker 0: 00:07:03
+
+He just doesn't like the same people that the US government doesn't like.
+
+Speaker 1: 00:07:06
+
+Yeah exactly.
+
+Speaker 0: 00:07:07
+
+Okay but then still he's filtering transactions.
+
+Speaker 1: 00:07:09
+
+Yes.
+
+Speaker 0: 00:07:09
+
+Like there's still some form of censorship happening right?
+
+Speaker 1: 00:07:12
+
+Exactly but there could be two different reasons for censorship right?
+One is you're afraid of some government like the US government making your life difficult and the other could be well you think the US government is actually right.
+
+Speaker 0: 00:07:22
+
+Okay.
+
+Speaker 1: 00:07:22
+
+But we have no idea which of those two is the true motivation.
+I'm just saying either is possible.
+
+Speaker 0: 00:07:26
+
+Sure, sure.
+
+Speaker 1: 00:07:27
+
+Either is problematic.
+
+Speaker 0: 00:07:28
+
+Are we talking about this because we should be worried about this?
+Is your opinion that we should be worried about this?
+
+Speaker 1: 00:07:32
+
+I think we talked about that in the earlier episode, that I am worried about this in the long run.
+Now in the short run it's absolutely not a problem, because these transactions were just mined by another miner, the next block.
+Ironically by a US miner.
+
+Speaker 0: 00:07:46
+
+Yeah, maybe it's a bit much to go over this whole thing again.
+Again, we discussed this in episode 37, you said?
+Yes.
+Yeah, so that's what we discussed, I guess, in depth.
+How worried we are about it anyways.
+Short term, So now it's turned off.
+I guess the other thing maybe worth mentioning is, so this is something that…
+
+Speaker 1: 00:08:07
+
+So the fact that we were able to detect this at all is because of all this tooling, it's not that obvious normally because transactions, sometimes they appear in a block, sometimes they don't.
+So that's pretty cool that we have the tech to detect it.
+
+Speaker 0: 00:08:22
+
+Yeah, well another relevant episode perhaps to listen to in this context is the episode we did on Stratum v2, because Stratum V2 is kind of a solution for this problem if we consider it a problem, right?
+
+Speaker 1: 00:08:36
+
+Yeah, what Stratum V2 does that's relevant here is that it delegates the responsibility of putting things into a block, not to the mining pool, which tends to be quite large.
+You know, there's two pools that are 51% roughly of all the hash power, but it delegates it to individual miners.
+So, and that's far more of them.
+
+Speaker 0: 00:08:56
+
+Yeah.
+So we discussed that in episode 80.
+Okay.
+That's a, this was a long intro.
+I guess the reason this is worth bringing up is because, I mean, it seems.
+This is kind of the thing that Bitcoin, Bitcoin developers and journalists, maybe as well, sometimes have been like talking about and warning about for many years, and this is sort of the first time it's actually happening.
+So there's actually a reason now for…
+
+Speaker 1: 00:09:22
+
+If you go through, you know, this, if you just assume a slippery slope, which is always a problematic type of argument, but if you do, then The ultimate outcome of this is you're back to PayPal because all transactions have to be KYC'd in permission before they go into a block.
+Now we're nowhere near that, but does this make sense to worry about this?
+
+Speaker 0: 00:09:39
+
+Right, it is sort of a first step in that direction and it's interesting to see how things will play out, I guess.
+So the first step we now saw is that Wankyun disabled his patch.
+But yeah, it's an event in that sense.
+Like it's a beginning of something that could go in a very wrong direction, even though it's only a very small step right now.
+Right?
+Is this, are we done with this?
+This was the intro to our Bitcoin Core 27, wait, where are we?
+26th episode.
+Okay, let's talk about Bitcoin Core 26 then.
+Yes.
+First of all, I think everyone knows this by now.
+Actually, I'm not even going to ask you about this anymore.
+I'll just preface this.
+So the way it works, Bitcoin Core releases a new version of the software every six months.
+And that means that every new future that was done within the six months is in Bitcoin Core.
+And that's, that means that's a new release.
+There is not a new release because there is a new future.
+There's just a new release and whatever is new is new.
+
+Speaker 1: 00:10:42
+
+That's right.
+Yes, exactly.
+So yeah, so there are no like things that must be finished before the deadline.
+Whatever is ready is ready.
+
+Speaker 0: 00:10:49
+
+Right.
+So the last release was about half a year ago, apparently, right?
+At this point, where are we in the release process?
+
+Speaker 1: 00:10:58
+
+There have been two release candidates.
+As far as I know, the second candidate does not have many problems, so maybe it's the last one, maybe there'll be another one.
+
+Speaker 0: 00:11:07
+
+Right, so potentially the new Bitcoin Core release could be announced, released any day now.
+
+Speaker 1: 00:11:13
+
+Exactly.
+Okay.
+Or maybe a few weeks.
+What's interesting perhaps is that there is a testing guide.
+Now every release there is always a testing guide but this one apparently has had some extra love and attention.
+If you've ever wanted to test a release you should look for the, I think if you Google Bitcoin Core 26 release testing guide, you'll find it and hopefully it'll be in our show notes.
+
+Speaker 0: 00:11:35
+
+Who is this for?
+This is for developers, I would assume.
+
+Speaker 1: 00:11:38
+
+I would say a little bit lower barrier to entry than being a developer.
+Anybody who can download a piece of software and carefully follow instructions.
+
+Speaker 0: 00:11:46
+
+What are you testing?
+
+Speaker 1: 00:11:48
+
+You're testing things that have changed.
+So there's all the features that we're talking about, but there's also lots of smaller changes and the testing guide will basically take you through some of the changes and how you might go about testing them.
+Of course, you should also test things in a way that's not in the guide.
+
+Speaker 0: 00:12:02
+
+How would you go about testing them?
+Like what, can you give an example of what we're talking about here?
+
+Speaker 1: 00:12:08
+
+Yeah, well, I guess we can do that when we cover the actual changes.
+
+Speaker 0: 00:12:12
+
+Okay, sure.
+Do you want to get into the actual changes?
+Sure.
+Okay, so the actual change.
+So what we did, well, mostly short to be honest, is you picked out a couple of features in this new release that are noteworthy.
+Even more, like you picked out the most noteworthy of the most noteworthy changes.
+Right?
+
+Speaker 1: 00:12:36
+
+I just picked the ones that I thought were cool.
+
+Speaker 0: 00:12:38
+
+Okay.
+So the first one, oh yeah.
+And we mentioned some of them in our previous episode, actually, because in the previous episode, which I guess by now is two months ago, We did mention some new inclusions in Bitcoin Core, or you did already.
+So we'll sort of repeat these for whoever missed that episode or just to give a complete picture.
+So the first one is peer-to-peer transport encryption.
+
+Speaker 1: 00:13:01
+
+That's right.
+
+Speaker 0: 00:13:02
+
+What's the BIP number for that again?
+Do you remember?
+Do you know?
+No. It's not BIP 151, right?
+That one was replaced?
+
+Speaker 1: 00:13:09
+
+No, it's a new one.
+It's peer-to-peer encryption.
+So we did a whole episode on this, episode 77.
+That really explains why you want to do this.
+But the short version is that nodes will encrypt their traffic between each other so that the especially internet providers cannot simply just listen to what you're doing.
+This is actually very easy to test.
+It's also something that's not on by default but as part of testing you might want to turn that on.
+So roughly the way you would test this is you download Bitcoin Core, the new version, you turn this feature on by changing the configuration setting And then your friend also downloads Bitcoin Core, also turns this feature on, and now you try to connect to them.
+So in Bitcoin Core normally it automatically finds peers, but you can manually say, hey, please connect to this IP address.
+And then you can actually get something called a session ID.
+It should be in the instructions, but basically you'll be able to see a number just like with Signal, a long number, and if you compare that long number with what your friend sees as a long number, then you know that you are directly connected to them.
+There's not a man in the middle.
+So that's the kind of thing you can test.
+And it'd be very worrying if the number was different, that would indicate a bug.
+Or somebody spying on you, but probably a bug.
+
+Speaker 0: 00:14:27
+
+Okay, well, let's linger here a little bit, because now you spoke about testing and we did discuss it in previous episodes, but still.
+So right now Bitcoin Core nodes, they, you know, they're part of the peer to peer network, so they communicate with each other, which specifically means they send transactions and blocks to each other.
+And right now they do that over an unencrypted channel.
+They just, it's just plain text.
+It's just plain information.
+Right.
+So that means that, that internet service providers can see exactly which transactions and blocks you're sending.
+And I guess the main problem is that this would allow ISPs to sort of see where transactions originate.
+Is that the main problem?
+
+Speaker 1: 00:15:09
+
+Yeah, I'd say that's one problem.
+And the other is it makes censorship easier because if it's very easy to detect that it's a Bitcoin node, it's also very easy to block it.
+Now that's still easy with this encryption in place for other reasons, but having encryption, it makes it one step easier to get around censorship.
+
+Speaker 0: 00:15:25
+
+Okay.
+That, yeah, that's, that's basically it, right?
+That covers this.
+Okay.
+So this is now in Bitcoin Core, but it's optional?
+
+Speaker 1: 00:15:34
+
+Yes.
+
+Speaker 0: 00:15:35
+
+So you can switch it on.
+And is there preferential, or did you just explain it?
+Is the preferential seeking of other nodes that do the same thing?
+
+Speaker 1: 00:15:44
+
+Yes.
+No, it's not preferential.
+But if it happens to connect to another node and it knows that it has this feature, it will use it.
+But it's not preferential.
+
+Speaker 0: 00:15:53
+
+Okay, so it still connects to other nodes randomly, but they will first sort of try, hey, are you using encryption?
+
+Speaker 1: 00:16:00
+
+No, they will only try if they think the other side can use it.
+
+Speaker 0: 00:16:03
+
+Oh, so how do that?
+So how would my notes think that your note is using encryption?
+
+Speaker 1: 00:16:08
+
+So we talked about, I think in episode two or three, we talked about, how nodes bootstrap and, and learn about other notes.
+So they learn about nodes by having a list of IP addresses to connect to, but in addition to those IP addresses there's also some metadata of which features these nodes support.
+So in your long address book of potential nodes to connect to is information like is this a prune node or a full node, does it have specific bloom filters or whatever filters you want.
+And as of now, it also tracks whether the node supports v2 transport.
+So if your address book says that this other node supports that new feature, which could be a lie, but at least that information would be there, then he'll try that first and if it fails, just tries the v1 connection.
+Now I guess in the future we might turn that around and just always try the v2 and then fall back to v1 if it doesn't work.
+
+Speaker 0: 00:16:59
+
+Yeah, why wouldn't you just always try it?
+Just because it has extra data to communicate?
+Like this extra try, like why wouldn't you just by default first try encrypted?
+Encrypted?
+
+Speaker 1: 00:17:10
+
+Because if you first try encrypted and it, and the other side does not support it, the other side will hang up on you.
+So you have to connect again.
+Which is not the end of the world but right now the majority of the network doesn't support it so that means all of your connections would fail and you'd retry.
+But I don't know if that's a big enough deal in the long run so it might be turned around just try it.
+
+Speaker 0: 00:17:31
+
+Yeah I would assume eventually the goal is that everyone would use this right?
+Are there any downsides to using this?
+
+Speaker 1: 00:17:38
+
+Well there is now because it's too new so if something goes wrong your note might simply fail to connect or get hung up on by all of its peers and you don't get the latest blocks, right?
+So right now it's not safe yet, but in the long run I don't think there's any downside.
+It was designed to not have downsides, in the sense that it's actually even a little bit faster than the original protocol.
+You'd think it'd be slower because it's encrypted, but the original protocol uses checksums to make sure that the messages are correct, and those checksums use SHA-256, which is very slow, and the new algorithm uses a quicker checksum.
+So it's better in, hopefully in every way, if it's not broken.
+
+Speaker 0: 00:18:17
+
+Right.
+So how, if I download Bitcoin Core 26, how do I switch this on?
+
+Speaker 1: 00:18:22
+
+You go into your Bitcoin.conf settings file and then you turn on, I think you enter v2 transport equals one, but it'll be in there, either the release notes or the testing guide.
+
+Speaker 0: 00:18:33
+
+Right.
+Alright, moving on to the next point.
+Assume UTXO was implemented for Cignas testnet?
+Not mainnet, right?
+
+Speaker 1: 00:18:42
+
+That's right.
+
+Speaker 0: 00:18:43
+
+Okay, so what is Assume UTXO again?
+
+Speaker 1: 00:18:46
+
+We covered that in episode 14, so that's quite a while ago.
+It's basically the short version of it is that instead of starting at the genesis block when you start your node and going all the way to the most recent block, which takes a long time, you start at a snapshot and you assume that it's valid and then you go from this snapshot which might be a few months ago to the present to the tip and then once you've done that you you start from the genesis block and in the background you check all the blocks and you make sure that you indeed arrive at this snapshot that you assumed initially.
+
+Speaker 0: 00:19:20
+
+So the benefit here would be that you can start using the Bitcoin Core node before fully syncing?
+
+Speaker 1: 00:19:27
+
+Yes, you would basically sync only the last 10% of the blockchain and you would be immediately able to use a wallet, receive coins, send coins, but there's still some chance that your starting point was wrong.
+And what could go wrong then is let's say there's some malicious developers and they just create fake coins.
+Well, now you think you've received coins, but these coins don't actually exist.
+Now that's a really, really expensive attack, right?
+Because somebody still has to make a block with enough proof of work that is wrong according to all the other nodes, but only correct according to you or the list of victims that they have.
+So I don't think that attack is super realistic, but we still want to...
+
+Speaker 0: 00:20:09
+
+Plus you need to, plus the developers need to be corrupt, obviously.
+
+Speaker 1: 00:20:12
+
+Yeah, so this depends on the distribution mechanism.
+Right now the idea is that the correct block is hard-coded into the source code, so you would indeed have to compromise the developers.
+You could, we could still change that approach.
+I don't know if it'll be changed, but the approach could be that, no, you can just use any block and the developers do not bless any of the blocks.
+Because it's the downside of the developers blessing the blocks is that, well, now if you compromise the developers, you're screwed.
+
+Speaker 0: 00:20:41
+
+The upside is that...
+How would you use any block?
+
+Speaker 1: 00:20:44
+
+You basically, Bitcoin Core wouldn't care.
+You would just give it a block, say assume this one is correct.
+You just download that from somebody on the internet that you trust.
+And then you'll find out if it was right or not, but it'll take a while.
+
+Speaker 0: 00:20:56
+
+Right, I see.
+And obviously, so-
+
+Speaker 1: 00:21:00
+
+So that means there's no centralized group of people to pressure or to corrupt.
+But the downside is you will get scammed left and right because everybody can just make their own fake one.
+
+Speaker 0: 00:21:10
+
+Yeah.
+Okay.
+Interesting.
+So wait, so which version is implemented in Bitcoin core right now?
+
+Speaker 1: 00:21:15
+
+The blessed one.
+
+Speaker 0: 00:21:17
+
+Okay, the developers have blessed it.
+Yeah.
+Okay.
+So yeah, you mentioned...
+
+Speaker 1: 00:21:22
+
+And for testnet and Cygnet, obviously, that's fine.
+
+Speaker 0: 00:21:25
+
+Right.
+
+Speaker 1: 00:21:25
+
+But it's also not, there's also no theft risk there.
+
+Speaker 0: 00:21:28
+
+Right.
+It's only on testnet now, and Cygnet, which is a version of testnet.
+So yeah, so you mentioned, even if it would be on mainnet, the attack would be expensive because you need to create a fake block and you need to, at least in the current version, corrupt the developers.
+Plus it would only work temporarily because it's kind of a stopgap until you've actually synced from yeah basically once you've synced from the genesis block the note would crash it's kind of a yeah right it's sort of a solution until in the meantime yeah and therefore it's obviously also optional you can just opt to actually wait until it's fully synced before you receive any transaction.
+
+Speaker 1: 00:22:05
+
+Although in that case you should just not use the feature.
+
+Speaker 0: 00:22:08
+
+Yes well that's what I'm saying the future is basically optional.
+
+Speaker 1: 00:22:12
+
+That's true in general yes.
+So if you wanted to test this, again you download BitConcord, then you obtain the SIGNET or the TestNet snapshot.
+There's some links to Torrents I believe.
+And then you just run one command and you'll see it in action.
+
+Speaker 0: 00:22:28
+
+Okay, so that's also new in BitConcord 26.
+On to the third point.
+The third handpicked selection by Shortz is network diversity.
+There's a new upgrade in updated network diversity tools.
+What's going on Shortz?
+
+Speaker 1: 00:22:47
+
+Yeah, so I believe if I understand this feature correctly, and I did not read it up in detail, it's been a while, but here's the thing.
+Bitcoin Core will connect to about eight nodes, will make connections outbound to about eight nodes.
+
+Speaker 0: 00:23:01
+
+That's the default?
+Eight is the default?
+
+Speaker 1: 00:23:02
+
+Yes, it might be 9 now but and then other nodes might connect to you but if you're behind a router etc then that won't happen.
+Now those 8 nodes by default would just be on plain internet, IPv4, IPv6, but if you want to you can also connect to Tor nodes if you turn Tor on.
+Now if you don't do anything you may or may not have a connection to a Tor node and if you have one and you lose that connection because they hang up on you or something goes wrong, then you're just going to connect to a new node and maybe it's a Tor node, maybe not.
+
+Speaker 0: 00:23:36
+
+Wait, if I'm using Bitcoin Core, which I am, but I haven't explicitly made any sort of change to connect through Tor, can I still connect to other Tor nodes?
+No, right?
+
+Speaker 1: 00:23:46
+
+No, you have to turn something on to do that.
+
+Speaker 0: 00:23:48
+
+Okay, got it.
+Okay, go on.
+
+Speaker 1: 00:23:49
+
+But once you have turned it on and you, but you let the VidCon core node automatically handle what it connects to, you may or may not have a connection to another Tor node.
+And if you have a connection to another Tor node and you hang up on that one, or they hang up on you, maybe you won't have it again.
+
+Speaker 0: 00:24:03
+
+Right, so what you're saying is I'm connected to eight nodes, one of them is a Tor node because I switched the thing on that allows me to connect to Tor nodes.
+Now this guy's internet, Wi-Fi fails, whatever, I'm disconnected with him, So now I'm going to reconnect randomly to another node, which may or may not be a Tor node.
+So it's possible that I'm connecting to not a Tor node, and now I'm not connecting to any Tor node.
+
+Speaker 1: 00:24:25
+
+Yeah.
+So basically the Tor feature so far just does not guarantee that you actually connect to a Tor node.
+You may or may not.
+And so this new change makes sure that you do.
+It makes sure that at least, I don't know what the percentage is, but let's say at least one connection will go to Tor if you have Tor on.
+And it will basically, if that connection disappears it will make another one.
+
+Speaker 0: 00:24:45
+
+And so the way I would do this again is I go into the config file and I say...
+
+Speaker 1: 00:24:49
+
+No, this just works.
+This just works.
+
+Speaker 0: 00:24:51
+
+Out of the box.
+
+Speaker 1: 00:24:52
+
+If you have Tor on, yes, this just works.
+Tor does not work out of the box.
+
+Speaker 0: 00:24:57
+
+Sure.
+Okay, so what's the...
+So This will basically guarantee that I'm going to connect to a TOR node if I want that.
+
+Speaker 1: 00:25:04
+
+Well, assuming there is one that you can connect to at all, but it will try.
+And now, what's the benefit?
+This solves a problem known as eclipse attacks.
+And we have done previous episodes, too, about eclipse attacks.
+
+Speaker 0: 00:25:15
+
+Also probably very early on, I think.
+
+Speaker 1: 00:25:17
+
+Yes, I forgot to write down the numbers, but you'll find them.
+Basically in Eclipse Attack the idea is that some evil person makes sure that your node only connects to them.
+So you think you're connected to 8 different peers, but you're not, you're connected to the same person because they have eight different IP addresses and tricked you into connecting to them.
+I'll explain all that.
+Now if you also connect through Tor, this attack becomes more difficult because they might be able to trick you into connecting to them through normal IP addresses but they may not be able to trick you into connecting to them through Tor.
+Or if they're making the connections to you, they might not know your Onion address that they're connecting to.
+They only know your normal IP address.
+Yeah.
+So that's why this helps.
+
+Speaker 0: 00:25:59
+
+It's kind of a safeguard.
+Like Eclipse attacks themselves are kind of unlikely to happen.
+There are more tools against that, right, in Bitcoin Core?
+
+Speaker 1: 00:26:08
+
+Yeah, I would also say Eclipse attacks, you know, again, in order of Eclipse attacks are getting more and more difficult.
+And if you want to do them, You probably want to have a motive, like you want to be able to scam somebody into accepting your payment and then double spending them and working with miners and all that stuff.
+They're not easy attacks, but we like to make them impossible or harder.
+
+Speaker 0: 00:26:27
+
+So Tor is kind of a lifeline to still get the latest blocks in case they're being censored in some sort of eclipse attack scheme.
+Yeah, exactly.
+Okay, so this is also new in Bitcoin Core.
+You'll…
+so network diversity is embedded more and more thoroughly.
+Then I'm seeing you selected, there's a Taproot Miniscript upgrade.
+
+Speaker 1: 00:26:52
+
+Yes, so we covered Miniscript in episode 4.
+A very long time ago.
+
+Speaker 0: 00:26:56
+
+Really?
+Yep.
+
+Speaker 1: 00:26:58
+
+One of the first things we did.
+So what's the TLDR of Miniscript?
+It is a subset of script, you could say.
+So not all of Bitcoin script, but a part of Bitcoin script that has been handpicked by super wizards like Andrew Polstra and SIPA to make sure that you don't shoot yourself in the foot.
+And that you can combine pieces of script.
+Like two pieces of script and you put and in between it etc.
+So these allow you to do complicated fancy wallets with like okay I want two signatures but after one year I only want one signature etc.
+And this worked, This has been added to Bitcoin Core a year ago or so in various steps, which we've covered in earlier episodes.
+And the latest step is that you can now also use Miniscript with Taproot.
+
+Speaker 0: 00:27:45
+
+Right.
+And what is the benefit?
+
+Speaker 1: 00:27:48
+
+So the benefit of Taproot in general…
+
+Speaker 0: 00:27:50
+
+Maybe should I first, for those that didn't follow that, so yeah, Bitcoin transactions use scripts, so it's basically a programming language for Bitcoin, allows you to lock Bitcoins up in all sorts of creative ways, time locks, multi-stick, whatever.
+A mini script is a way to sort of simplify that.
+And it's really for developers, right?
+Like I'm not going to use it.
+It's for people like you and.
+
+Speaker 1: 00:28:13
+
+It's for developers or for wallets that have been written by very small developers and that do it for you in the background.
+
+Speaker 0: 00:28:19
+
+Right.
+But with regular script, it's kind of easy to make mistakes and lose coins.
+And with mini scripts, kind of the most common ways to make these mistakes are just ejected.
+Like you can't use this.
+Only the simple stuff is left.
+And because of that, you can actually make fairly complex things relatively simply and safely.
+Yeah.
+Okay.
+So this was already available in Bitcoin Core.
+So what this means specifically is I think you can connect wallets that use this to Bitcoin Core.
+I don't think I'm saying that right.
+Can you say that right?
+
+Speaker 1: 00:28:56
+
+That's true, yeah.
+So, well, the Bitcoin Core wallet supports Miniscript.
+
+Speaker 0: 00:29:00
+
+Right.
+
+Speaker 1: 00:29:00
+
+But there's no like graphical way or anything in the interface where you can do that.
+You'd have to manually type these pieces of mini script.
+But there are wallets out there that will connect to Bitcoin Core using the RBC, for example.
+And they might use the Bitcoin Core wallet for the key storage, et cetera.
+But they would have some graphical user interface and they would construct a mini script.
+
+Speaker 0: 00:29:21
+
+So where, I think I'm skipping ahead.
+
+Speaker 1: 00:29:25
+
+So where Taproot comes in.
+
+Speaker 0: 00:29:28
+
+I don't want to go there yet.
+Where is this?
+I don't know how else to ask it.
+Is this in the Bitcoin Core wallet or is this in the Bitcoin Core like node software?
+So where do I find whatever we're talking about?
+
+Speaker 1: 00:29:40
+
+Well, the mini script lives in the Bitcoin Core wallet.
+
+Speaker 0: 00:29:43
+
+Yes.
+So this, Okay, so we're talking about a Taproot upgrade.
+Let's go there then.
+Yeah.
+So now this has been made available in Taproot.
+So is this an upgrade in the Bitcoin Core wallet?
+Yes.
+Okay, got it.
+So what's the upgrade?
+
+Speaker 1: 00:29:58
+
+So the upgrade is that you can now use this mini script, so these safe pieces of script, not just in SegWit, in regular SegWit, which used to be the only thing, but you can now also use it in Taproot scripts.
+And remember what's nice about Taproot scripts is you can have all these multiple ways that you can spend a coin, you can now hide all the ways that you're not using by putting them in different leaves.
+So your wallet would basically know that, okay, there are five different subscripts, essentially, that are possible, and the user will tell me which one of these five to use when I want to spend this coin and will hide the other ones.
+And there were some like, there's some subtle changes between the scripts in Taproot and the scripts in SecWit before some limits were dropped, but that's not that important.
+
+Speaker 0: 00:30:42
+
+Right.
+It's just, It's basically just the benefits of Taproot are now available in combination with Miniscript in a Bitcoin Core wallet.
+
+Speaker 1: 00:30:50
+
+Yes, but either you will have to write your little Taproot Miniscript yourself and put it in the wallet.
+Once you've put it in the wallet, by the way, it just works, right?
+You just click on receive new, make new address, it'll show an address, looks like any other address, and you'll be able to spend from it and it'll just work.
+But you generally do not want to type mini script yourself, even though it's safer than regular script, you probably want to use some other tool that does that for you.
+
+Speaker 0: 00:31:13
+
+Right.
+So this is available in Bitcoin Core now, Bitcoin Core 26.
+Well, I say now, at the time of recording, we're still in.
+
+Speaker 1: 00:31:21
+
+Yeah, I don't know if this is in the testing guide.
+Maybe it is, that would be pretty cool.
+
+Speaker 0: 00:31:26
+
+Who's gonna benefit from this?
+Are there any Wallets that use this right now or that want to use this?
+
+Speaker 1: 00:31:32
+
+I think Liana Wallet wants to because they're trying all sorts of fancy multisig, yeah, multistage multisig things, right?
+What's it called?
+Multisig.
+
+Speaker 0: 00:31:42
+
+No, the wallet.
+
+Speaker 1: 00:31:44
+
+Liana.
+
+Speaker 0: 00:31:44
+
+Liana.
+Have I heard of this?
+I don't think so.
+
+Speaker 1: 00:31:46
+
+Wizard Sardine is the company.
+
+Speaker 0: 00:31:48
+
+Oh yeah, yeah, yeah.
+Okay, Kevin.
+
+Speaker 1: 00:31:51
+
+Yeah, and they do a lot of work on Miniscript in general to contribute back.
+
+Speaker 0: 00:31:55
+
+Yep, that's true.
+
+Speaker 1: 00:31:57
+
+But hopefully, and I know for example that there's other wallets that support Miniscript already, But the hard part is the setup part, I would say.
+So many wallets might be able to sign Miniscript, even hardware wallets, but they will not...
+Like, once you've put it in there, it's not that easy to make these wallets in the first place.
+
+Speaker 0: 00:32:21
+
+Right.
+
+Speaker 1: 00:32:23
+
+Okay,
+
+Speaker 0: 00:32:24
+
+last point I think.
+We're going to the last point, the last mentionable upgrade in Bitcoin Core 26.
+Submit package RPC, you wrote down.
+
+Speaker 1: 00:32:35
+
+Yeah, I believe in previous episodes, we have talked about the idea of package relay for transactions.
+So then the simplest example is, I have a Lightning channel, I want to force close that Lightning Channel.
+My partner of the Lightning Channel, or no longer partner of the Lightning Channel, is offline.
+So all I have is the last time we co-signed a transaction, and this was before ordinals were invented, and fees were super low.
+And so I try to broadcast that transaction, but it simply does not even go into the mempool of my peers.
+
+Speaker 0: 00:33:06
+
+We have a solution for that though.
+You can use child pays for parent shorts.
+That's right.
+The only problem is that the child...
+Hang on, let me explain the solution.
+So the solution is I'm going to spend the money from this transaction to myself with a higher fee.
+So now the miner will see that if he wants to confirm the high fee transaction, he'll also have to confirm the low fee transaction and I'll get the money and the problem is solved.
+Correct.
+
+Speaker 1: 00:33:32
+
+Yes.
+And the miners already do this as far as I know.
+The problem is getting it to the miner.
+Because this is where the bureaucrats come in.
+You basically go to your peers in the network and you say, here's the transaction, but hold on one second, I've got another transaction.
+But no, no, no.
+Your peers say, no, this transaction is too low of a fee.
+But wait, I have this other transaction.
+Here's the other transaction.
+Well, that has a really high fee, thank you.
+But it's spending a transaction that I've never heard about.
+
+Speaker 0: 00:34:01
+
+Yeah, hang on, you got to emphasize.
+So when they say this has not enough fee, the fee is too low.
+What they even mean is the fee is too low for the mempool.
+They're not even going to include it in the mempool.
+Yes.
+So yes, it would not fit in the block.
+Now that's fine because it usually goes into the mempool and then you can use the child pays for bear tricks that I explained.
+But in this case the transaction because of all these ordinals isn't even gonna fit into the mempool and therefore it's not gonna be seen by anyone and therefore the higher fee transaction is not going to be seen by anyone either because it's not spending funds from a transaction that anyone is seeing.
+
+Speaker 1: 00:34:39
+
+Yeah, because mempools only process transactions one by one and if the first one doesn't pay enough fee, it's not going in there.
+
+Speaker 0: 00:34:45
+
+Right.
+
+Speaker 1: 00:34:46
+
+So, what is the solution?
+It is You need a way to send two transactions at the same time to your peers.
+
+Speaker 0: 00:34:53
+
+So peers and miners will consider them in tandem right from the get-go, before it even goes in the main pool essentially.
+
+Speaker 1: 00:34:58
+
+Yeah, and this thing is called Package Relay and work is in progress to do that.
+It's not easy and we've discussed some baby steps in that direction.
+One of the first baby steps was the RPC called Submit Package and the idea was to send transactions to your own mempool, so not to your peers just your own mempool.
+And I think half a year ago or so we covered how that worked.
+You would give this RPC two transactions and it would just basically reject it because it would use the same logic as always, it would process them one by one.
+So why was that added?
+Well, because the next step makes it more useful.
+Now with the 26.0 release, it will actually consider both of them and therefore include it in its own mempool.
+Right.
+But not really yet.
+
+Speaker 0: 00:35:47
+
+So this upgrade only applies to...
+So if I make two transactions, one of them is a Lofi, one of them is a Hyvi, I can now send this transaction over RPC to my own node?
+But that's it, right?
+
+Speaker 1: 00:36:03
+
+Yeah, and you could imagine maybe there would be a website of a miner where you can send it directly to the miner this way and they would use their own RPC.
+That's not the future obviously, but you could see some use even of this primitive feature.
+
+Speaker 0: 00:36:17
+
+Right.
+So there's now something in Bitcoin Core, it's a baby step, it's a step towards packet relay, right?
+That's just a way to think about it.
+Yeah.
+It's not, it's actually kind of useless in itself.
+Or is there, you just speculated about a potential maybe use case of a miner?
+
+Speaker 1: 00:36:33
+
+Yeah, and the other is like at least it would be in your mempool and so maybe once the fees go down, you know, it's a bit easier to...
+
+Speaker 0: 00:36:38
+
+Rebroadcast it or something.
+
+Speaker 1: 00:36:40
+
+But rebroadcasting is also not automatic.
+So yeah, no, it's not there yet.
+
+Speaker 0: 00:36:44
+
+It's basically useless, but it is a step towards package relay which itself is a useful and important upgrade one day hopefully right yes okay great so these are we've now discussed six five of the most important upgrades in Bitcoin Core.
+That's the episode actually, right?
+
+Speaker 1: 00:37:06
+
+That's right.
+That's a wrap.
+Okay.
+Thank you for listening to Bitcoin Explained.

--- a/bitcoin-explained/hashcash-and-bit-gold.md
+++ b/bitcoin-explained/hashcash-and-bit-gold.md
@@ -1,0 +1,1126 @@
+---
+title: "Hashcash and Bit Gold"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://bitcoinexplainedpodcast.com/@nado/episodes/episode-88-hashcash-and-bit-gold-a5cjn
+tags: []
+speakers: ['Sjors Provoost', 'Aaron van Wirdum']
+categories: ['podcast']
+date: 2024-01-03
+summary: "In this episode of Bitcoin, Explained, Aaron and Sjors discuss two electronic cash projects that predate Bitcoin: Adam Back’s Hashcash and Nick Szabo’s Bit Gold. As detailed in Aaron’s new book, The Genesis Book, these systems introduced design element that were later utilized by Satoshi Nakamoto. Aaron and Sjors explain what these elements are, and how they inspired Bitcoin’s design."
+---
+Speaker 0: 00:00:18
+
+Live from Utrecht, this is Bitcoin Explained.
+Hey Sjoerds.
+Yo, yo.
+Are you going to do the jingle again?
+
+Speaker 1: 00:00:26
+
+I am not, but I know now that you are the best ad reader, so please read the ad.
+
+Speaker 0: 00:00:45
+
+Hardware stuff.
+Shors, do you know what else they have?
+They have the OpenDime, they have the BlockClock, I think, right?
+
+Speaker 1: 00:00:51
+
+Zetskart.
+
+Speaker 0: 00:00:52
+
+Zetskart.
+They got everything you need.
+What a coincidence.
+That's our sponsor, CoinKite.
+All right, Shors.
+That was my read.
+Hey, that's an improvement compared to last week, I think.
+Probably.
+What do you think?
+We're getting there.
+
+Speaker 1: 00:01:07
+
+So, Aaron, you wrote a book.
+
+Speaker 0: 00:01:08
+
+Yeah.
+Oh, yes, I did.
+Cool.
+It's, well, at the time of recording, it's almost published.
+So we're publishing it tomorrow, January 3rd, but that's like midnight actually, UTC.
+So it's like one hour time.
+So in a couple of hours, Jors, my book will be live.
+Yeah.
+So that's kind of cool.
+So that's kind of cool.
+It is called the Genesis book Shorts, And it tells the prehistory of Bitcoin, the origin story of Bitcoin.
+It's the story of the people and projects that inspired Bitcoin.
+So, of course, to celebrate that, we're going to discuss some of the topics from my book.
+
+Speaker 1: 00:01:45
+
+That's right.
+
+Speaker 0: 00:01:46
+
+So it's actually kind of for the first time, I think, not really an episode about Bitcoin.
+Have we done something about it?
+
+Speaker 1: 00:01:54
+
+We've done an episode about DigiCash.
+
+Speaker 2: 00:01:57
+
+Well, no, hang on.
+We also did the episode about the Tornado Cash.
+
+Speaker 0: 00:02:00
+
+That was actually not about Bitcoin, kind of.
+
+Speaker 1: 00:02:03
+
+Exactly.
+
+Speaker 0: 00:02:03
+
+Anyways.
+
+Speaker 1: 00:02:05
+
+And we'll still cover things that are very relevant to Bitcoin.
+Right.
+
+Speaker 0: 00:02:08
+
+Well, my entire book is very relevant to Bitcoin.
+Everything in my book is relevant to Bitcoin, of course.
+So of course, also what we're going to discuss.
+Excellent.
+Did I mention it's called the Genesis book and you can find it on the Bitcoin magazine store and Amazon and I don't know where else.
+
+Speaker 1: 00:02:23
+
+Sounds good.
+
+Speaker 0: 00:02:24
+
+I think, the, I, I, I'm, the Genesis book.com should be live by the time you listen to this, hopefully.
+
+Speaker 1: 00:02:32
+
+All right.
+
+Speaker 0: 00:02:32
+
+You want to know anything more about where you can find my bookshores?
+
+Speaker 1: 00:02:35
+
+No, but we will put it in the show notes.
+
+Speaker 0: 00:02:37
+
+Okay, we'll go to the episode then.
+So yeah, we're going to discuss.
+So okay.
+I discuss in my book, there are sort of five main digital cash projects that are sort of precursors to Bitcoin in a way.
+There are more, and there's also a lot more in the bookshores.
+There's all kinds of background and stories and colors and storylines and adventures.
+
+Speaker 1: 00:03:05
+
+Yeah, from what I've been reading, you cover Austrian economic stories and sort of alternate the digital money story versus the political story.
+
+Speaker 0: 00:03:16
+
+Anyway, enough with the shilling.
+Let's get to the actual episode.
+So there's five electronic cash projects in the book that sort of have a bigger focus than some of the more minor ones.
+So the first one of that is eCache, which was produced by DigiCache.
+We're not going to talk about that because we kind of already did in episode 52, which was about, what was it about?
+Fetiment, right?
+
+Speaker 1: 00:03:43
+
+Yeah.
+In episode 52, Fetiment, we start all the way back with how David Chomps' E-cash works, how Blinded Signatures work, definitely recommended listening.
+And then we go all the way to how that's now applied to, well, Pediment and Cashew.
+
+Speaker 0: 00:04:00
+
+Yeah, so to sort of, we're going to skip that one.
+We're not, we're not going to talk about that again.
+So instead this episode will be about Hashcash and Bitworld.
+And I think this will be sort of, I don't know how we're going to do this format, which because usually I'm kind of the one who asks questions and We just still do that and I don't know.
+We'll figure it out, I think.
+Well, no, actually, I have no idea how to do this now.
+
+Speaker 1: 00:04:22
+
+Well, you should tell a little bit of the story and then we'll get to some of the technical juicy bits where I might have some opinions too.
+
+Speaker 0: 00:04:31
+
+Okay, cool.
+Yeah.
+So the first one is HashCash.
+So the background here is, so in the nineties, the internet was becoming more popular and also there was the Cypherpunks mailing list.
+And they had, first of all, they had their own mailing list where they were discussing privacy technologies, but also more ideological types of posts or how to create digital cash, of course, and all these kinds of discussions.
+And they were also, a bunch of the cypherpunks were running remailers.
+So this was sort of the precursor of Tor.
+There was a way to send an email anonymously, send an email without the recipients knowing where the email came from.
+The problem was that spam was becoming popular around this time as well.
+So the Cypherpunk mailing list itself was being spammed.
+Anyone else who had an email address was being spammed.
+And especially also these remails or remailers were starting to be spammed to the extent that it was becoming burdensome to run one.
+So it was potentially an attack on these remailers.
+Either it was a spam attack that remailers were being abused for, or maybe it was just an attack on the remailers themselves, as sort of a denial of service type of situation.
+So people wanted to create, Cypherpunks specifically wanted to create digital cash.
+
+Speaker 1: 00:05:54
+
+And I think, well, one step back, I think they also, they wanted to fix the spam problem, right?
+With digital cash maybe in the back of their mind.
+
+Speaker 0: 00:06:02
+
+Sorry, I said digital cash, I meant digital postage, and that's what you're getting.
+
+Speaker 1: 00:06:06
+
+Yes, digital postage stamps.
+But it might be interesting, something you also mentioned in the book is that there was a worry that if the cypherpunks didn't fix this problem, then governments would step in and they would start dealing with spam.
+And this would be a problem because then you would get, if governments have to fight spam, then the way they would probably do that is by de-anonymizing everyone and basically KYC-ing email to the extent of where if there's a spammer, they know who they are.
+
+Speaker 0: 00:06:36
+
+Yeah.
+Plus the government would then have to make a judgment call about what is spam and what kind of relevant to Bitcoin these days, actually with the whole ordinal thing.
+But yeah, then governments have to make a judgment call about what is spam.
+So what actually is legal?
+And then by the time they can find a spammer, yeah, that would have to be some sort of identification.
+
+Speaker 1: 00:06:54
+
+And they would have to ban anonymous email, which is, you know, the kind of thing they were trying to do.
+
+Speaker 0: 00:07:00
+
+Right.
+So the cypherpunks didn't like this and specifically Adam Back didn't like this.
+Adam Back was of course one of these cypherpunks.
+I don't think he needs an introduction to anyone who listens to this podcast.
+So Adam Back wanted to come up with digital postage.
+Maybe should I…
+
+Speaker 1: 00:07:19
+
+First I think we should go back in time, right?
+Because everybody talks about HashCash and how Adam Beck invented that.
+And he did, but it was not the first time it was invented as often happens in history.
+
+Speaker 0: 00:07:30
+
+Yeah.
+I was also considering if I should talk about the other ways they were thinking about digital postage, but I think we should skip that.
+Right.
+That's what you can find in the book.
+
+Speaker 1: 00:07:40
+
+Exactly.
+
+Speaker 0: 00:07:41
+
+Okay.
+So yeah.
+Okay.
+So shall I hand it to you here?
+Because yes, so actually Adam Beck was not the first person to invent digital postage.
+He did think he was, like he was not aware of the previous proposal, but there was actually another proposal that's a bit older and quite similar to Adam Back's proposal, which was the names from the top of my head.
+
+Speaker 1: 00:08:06
+
+Duerck and Naur.
+
+Speaker 0: 00:08:07
+
+Yeah, I was thinking of their first name, but yeah, their last names were definitely Duerck and Naur, Moni Naur and Cynthia Duerck, I think.
+
+Speaker 1: 00:08:14
+
+Yeah, and They did not come from a cypherpunk background.
+They came from it with a just, hey, we are people using email and we don't like spam background.
+And so they-
+– Well,
+
+Speaker 0: 00:08:27
+
+they were for IBM, right?
+They were computer pros.
+
+Speaker 1: 00:08:31
+
+– Yeah, they weren't random people, but they were not saying, how can we prevent the government coming into this email world?
+It's just like, how do we get rid of spam?
+And so they invented, essentially They came up with the idea of introducing proof of work for email, and they came up with three different work algorithms.
+
+Speaker 0: 00:08:51
+
+Yeah, and to be clear, the term proof of work didn't exist yet at this time.
+
+Speaker 1: 00:08:55
+
+I don't know exactly what they call it, but something along the lines of like a challenge or…
+But basically, they picked three algorithms, and I think one of them boiled down to finding, if you take a number and you wanna figure out which two primes are necessary, can be multiplied to get to the number.
+So let's say you pick the number 100 and you say tell me which two prime numbers multiply to 100 and you would say I don't know because it's 10 times 10 so that's not those are not prime.
+
+Speaker 0: 00:09:28
+
+Kind of a bad example.
+
+Speaker 1: 00:09:30
+
+No it's a fine example but it shows that as soon as you give me the right answer, I can very quickly verify that, yes, these two numbers multiply to this total.
+Actually, I think you didn't have to find prime numbers, it's just modular prime number.
+
+Speaker 0: 00:09:43
+
+I think the way it works is you have two very big prime numbers, these are factored into another big number, and then the big number can only be produced by two specific prime numbers then, right?
+
+Speaker 1: 00:09:56
+
+I think that's RSA, but not what this here.
+
+Speaker 0: 00:10:01
+
+Oh, this works a bit different?
+
+Speaker 1: 00:10:02
+
+I think this was much simpler.
+This was something called modulo a prime number.
+So if you take a much smaller number we know the number 13 is prime, right?
+And so you would say okay here's the number 10.
+Find me two numbers that you can multiply to get the number 10, but you can multiply and then you do modulo 13.
+So you can say this is not very good in math, but if you do 3 times 4 that's 12, So that's not enough.
+If you do three times five, that's 15.
+Modulo 13 is two, right?
+So you can do et cetera, et cetera.
+You keep looking for this number that if you go around in circles around this prime number, it gets you the correct result.
+
+Speaker 0: 00:10:45
+
+Okay, we're getting very into the weeds now.
+Let's get back to the main road.
+So they had three ideas.
+
+Speaker 1: 00:10:50
+
+Exactly.
+So this is one of them and the key part is that it takes a while to find these numbers, but it's very quick to check.
+You just multiply modulo and you're done.
+And they had two other algorithms that I don't want to go into also because I don't know them, but they had an interesting property from them is that you could build an exception into it.
+So basically saying, well, if you're the mailing list operator, then you can use this special key and you can bypass the work.
+I don't know whether that would be practical or not, but that's sort of what they came up with.
+
+Speaker 0: 00:11:23
+
+Right, the backdoor function.
+
+Speaker 1: 00:11:25
+
+Yeah.
+
+Speaker 0: 00:11:27
+
+The points being here though, so was Nowr and Dwork also, like what they, the idea they come up with is that whatever calculation you have to make, you have to make it in combination with some data from the email itself.
+
+Speaker 1: 00:11:41
+
+Yes, because you can prove that you did a bunch of work, but if that's unrelated to your email, you would just reuse the same work.
+So you have to make sure that the work is always a function of the email itself.
+And ironically, they discovered the use of hash functions for that, or they knew that you needed hash functions for that part.
+So you take the hash of the email, and then you use the hash as the starting point of your challenge.
+
+Speaker 0: 00:12:05
+
+Oh, they did use the hash for that part?
+Yeah.
+Oh, I didn't know that.
+That's interesting.
+Yeah, so because we should maybe spell this out for those who haven't realized this.
+So Naor and Dwork were not using hashes for the proof of work.
+They were using, what's it called?
+Is there a better term for what they were?
+
+Speaker 1: 00:12:25
+
+They were just using math problems.
+
+Speaker 0: 00:12:26
+
+Yeah, right.
+Now the idea was still very similar to, I mean, I think most people that listen sort of know where proof of work came from, that's why we're sort of skipping some parts maybe, but we should actually spell it out.
+So the idea was if you attach a little bit of proof of work to an email, Then most people that want to send an email, that's not really a problem.
+That's like a couple of seconds of computing time.
+However, if you're a spammer that wants to send tens of thousands, or maybe even millions of emails, which you usually have to do to be a profitable spammer, then it becomes so expensive that it's not worth it anymore.
+So that's how it's postage.
+So it's different in postage in the sense that you're not buying it from anyone.
+And also whoever you're sending the email to is not getting the money or anything like that.
+It's just, you're proving that you spend some resources, some energy, and that way it's too expensive for a spammer to be a spammer.
+
+Speaker 1: 00:13:23
+
+Yes, exactly.
+
+Speaker 0: 00:13:25
+
+Okay.
+So that's what's now or and Dwork essentially came up with.
+This was in 1992, but then independently, basically, it was sort of a parallel invention.
+Not exactly parallel, though, you know, some time difference, but Attenbach was not aware of this solution.
+So when they were discussing this problem on the Cypherpunks list, they didn't know it was actually kind of a solved problem.
+But then he reinvented something very similar.
+
+Speaker 1: 00:13:54
+
+Yes, but then using a hash function, SHA-1 in this case, but that doesn't really matter.
+And The thing is, it's not actually better or worse than the design that was made before.
+
+Speaker 0: 00:14:08
+
+Okay, explain how it works.
+
+Speaker 1: 00:14:10
+
+So you basically take some aspects of the email, as we said before, And then you add a nonce to it.
+A nonce is a number that you pick randomly, doesn't matter what it is.
+But you have to pick it such that the resulting hash starts with a certain number of zeros.
+Right.
+Notice that in Bitcoin Core, the hash does not only start with a number, certain numbers of zeros, but actually has a specific value that it has to stay under, but it's roughly the same idea.
+
+Speaker 0: 00:14:37
+
+Right, so then, yeah, you would send the email, you include this hash, and then the recipient would check if there's actually a valid hash in it.
+If not, the email would just bounce.
+Exactly.
+So I guess that was the same with Nowrintworks system.
+
+Speaker 1: 00:14:53
+
+I didn't spell that.
+
+Speaker 0: 00:14:54
+
+Yeah, I didn't spell that out, but same idea, basically.
+
+Speaker 1: 00:14:57
+
+Yep, they both have the concept of difficulty, essentially, where you can make the hash more or less difficult, depending on what your perceived spam problem is.
+
+Speaker 0: 00:15:04
+
+Yeah.
+So anyways, the recipient will then say, or in the case of the remailers, right, which I mentioned earlier, the remailer will check, does this have a failed hash?
+If not, just reject it.
+And if so, it's forwarded to whoever it needs to be forwarded to.
+So that's basically the idea of HashCash, right?
+Did we forget about anything?
+Yeah.
+So that's HashCash.
+I think that you, well, I can tell you that in the early days, there was some adoption of it.
+So Apache used, is that how I pronounce it actually?
+
+Speaker 1: 00:15:43
+
+I think Apache, yeah.
+Spam Assassin.
+
+Speaker 0: 00:15:45
+
+Yeah, they used it in Spam Assassin and Microsoft recreated something very similar.
+Like it was incompatible with, you know, different standards, but basically the same idea again.
+And then more recently…
+
+Speaker 1: 00:15:59
+
+And those two are completely unused right now because Spam Assassin removed it again and the Microsoft thing doesn't exist anymore.
+More recently, as you're getting to, Tor is being used in proof-of-work.
+So again, it's a completely different algorithm, but it is an example of proof-of-work being used outside of a cryptocurrency.
+So where it's not used to produce value, it's simply to prevent spam.
+So this concept is still alive and well.
+
+Speaker 0: 00:16:27
+
+Right.
+
+Speaker 1: 00:16:27
+
+Now, one interesting aspect I wanted to talk about…
+
+Speaker 0: 00:16:33
+
+This is why we're talking about it in a Bitcoin podcast.
+Why we're focusing on Hashcash more than the NowrDwork concept, right?
+Is that where you're getting at?
+
+Speaker 1: 00:16:42
+
+Yeah, well, there's an interesting kind of a historical coincidence, I would almost say.
+And this is something you pointed out earlier that I think Adam Beck was aware of and he pointed it out, which is to say that there are two kinds of, well, there are multiple kinds of proof-of-work, but in particular two different kinds are stochastic and non-stochastic proof-of-work.
+And that's a distinction I hadn't really thought about.
+But the idea here is that you, with a hash function, you may or may not get the right result and it will take us, statistically will take a certain amount of time before you find a solution, but it's random.
+So sometimes you find the right solution instantly, other times it takes a very long time.
+Whereas with these earlier algorithms, There's a sort of a guaranteed time of how long it takes to find the square root, for example, of two numbers.
+So I suppose you could maybe make it random, but assuming you use a standard algorithm, it'll take a fixed amount of time to find a solution.
+
+Speaker 0: 00:17:45
+
+And you might think- let me give an analogy that I've used, not in the book, actually, I think, but in an article I wrote earlier, it's kind of the difference between, let's say there's a hundred lottery tickets and one person buys 40 tickets and another buys 60.
+So now the person that has 60 has more chance to win 60%.
+But the person that bought 40 still has 40% to win as well.
+While if you take, you know, two cyclists and one of them can ride his bike 60 miles an hour and the other 40 miles, then any time they do a race, the one that can cycle 60 miles an hour will just win like every time.
+Exactly.
+There's no, there's every time the same cyclist will win.
+There's no 40% chance that a 40 mile per hour cyclist will ever win.
+It's just not going to happen.
+
+Speaker 1: 00:18:35
+
+And so if you translate that to the context of Bitcoin mining as it is today, let's say we had picked a non-stochastic form of proof of work based on that original paper.
+So basically if Adam Beck had known about the original paper and had not bothered to implement something based on a hash function, because there's already a solution out there, then you would have the biggest miner, whoever that is, will just always find the next block first because they would always find that big prime number or whatever the challenge is.
+They would always find it first.
+
+Speaker 0: 00:19:04
+
+Right.
+It will be like that 60 mile cyclist rather than like currently Bitcoin mining kind of works like this lottery.
+But if the biggest miner just always wins, then you can't have Bitcoin like we have it today.
+
+Speaker 1: 00:19:16
+
+And of course, we still have some centralization problems in that sense, but this would be centralization on steroids if we did not have hash-based proof of work.
+
+Speaker 0: 00:19:23
+
+Yeah, basically Bitcoin wouldn't work, like not as it's designed today.
+
+Speaker 1: 00:19:27
+
+Yeah, or maybe we would have figured it out and then changed it, but definitely would have been not optimal.
+
+Speaker 0: 00:19:32
+
+Yeah.
+So essentially, what you alluded to, like we may have been quite lucky in that sense that Atomback wasn't aware of the prior proposal.
+So he invented this in a way that's actually useful for Bitcoin.
+
+Speaker 1: 00:19:45
+
+Exactly.
+But it's not something he was aware of at the time.
+Or at least he didn't put it in the paper.
+
+Speaker 0: 00:19:51
+
+As far as I know, and I've discussed it with him, so either my memory is failing me, but I'm pretty sure he only realized that after Bitcoin himself.
+He only figured that out, so that actually Hashkai specifically only works for Bitcoin.
+Yeah, no, that was not some sort of pre-planned thing for Mr. Back.
+
+Speaker 1: 00:20:09
+
+Yeah, now before we get to the next topic, which is Bitgold, we should talk about something that the author of Bitcoin observed about proof-of-work.
+That's kind of the bridge I wanted to make.
+
+Speaker 0: 00:20:23
+
+Yeah, well, that is also the bridge I make in my bookshorts.
+
+Speaker 1: 00:20:26
+
+Excellent.
+Yes.
+It's almost like I read it.
+
+Speaker 0: 00:20:29
+
+I mean, I think, at least if we're thinking about the same thing.
+So yeah, you mean, so hash cash or proof of work essentially for the first time brought something aching to digital scarcity, created something, introduced something aching to digital scarcity Because there is an actual cost of physical cost energy in the real world required to produce it.
+Yeah.
+So rather than just copying numbers, you have to actually invest something, real resources, and that sort of creates something that you could see as digital scarcity, right?
+That's what you're getting at.
+
+Speaker 1: 00:21:05
+
+That's not where we're getting it, though it is true.
+Oh. What I'm getting at is that the question is how do you define proof of work, or how do you measure it?
+How is it different from other cryptography?
+
+Speaker 0: 00:21:18
+
+This is not a bridge I make in my book, Jors.
+Unless I'm completely confused where you're going.
+
+Speaker 1: 00:21:23
+
+It is a new bridge, but basically Nick Szabo wrote an article about something he calls now I lost the term, that's not smart.
+
+Speaker 0: 00:21:33
+
+You mean secure benchmark functions?
+
+Speaker 1: 00:21:35
+
+Yes, secure benchmark functions.
+So here's the thing we know that with normal public key cryptography for example and with hash functions like SHA256 We know that it's easy to verify and easy is then defined as like just takes like a very short time on a typical computer and impossible or like you know it would take forever effectively to hack it, to coincidentally go back from the hash to the original from the public key to the private key which is then called hard.
+But with proof-of-work you're doing something that's a little bit in between.
+It is definitely not easy to go back to find a certain number of zeros, for example, in the proof-of-work in the hash, but it's also not hard in the sense that it will not take forever.
+In fact, you don't want it to take forever because then you cannot, you know, make the proof-of-work on your email if it would take forever to make the proof-of-work.
+So then the question is, how do you sort of define that?
+How hard is hard enough?
+Should not be too easy, should not be too hard.
+And Nick Szabo wrote this paper, well this article about it basically, the coining of term secure benchmark function.
+Now if you look at the 1992 paper about proof-of-work, they were also informally defining it as something that's not too easy, not too hard.
+So, what in between?
+So, Sabo put it in slightly more mathy terms.
+And the analogy we could get into, I guess, is the one-way function, or what it's comparing it with.
+So we talked about one-way functions in an earlier episode, where you actually were correct and I was wrong.
+
+Speaker 0: 00:23:15
+
+So I remember that.
+Good.
+
+Speaker 1: 00:23:18
+
+So keep enjoying that feeling.
+
+Speaker 0: 00:23:20
+
+Yes.
+I think everyone heard that, right?
+Can you repeat it one more time?
+
+Speaker 1: 00:23:25
+
+So let's just try and explain it correctly, because I don't even remember exactly what I was saying.
+
+Speaker 0: 00:23:30
+
+Go on.
+
+Speaker 1: 00:23:31
+
+A one-way function is a function that is very easy to go in one way, like checking that a hash is correct, but very hard to go the other way.
+She's like trying to produce a fake hash, no, a fake original, basically.
+And there are a bunch of one-way functions out there.
+One is finding the factors in a big number, or these prime factors as you mentioned with RSA.
+Another is a discrete logarithm problem, or that's sort of a more generic one, but that is used for public and private key cryptography, like the elliptic curve.
+And then there's cryptographic hash functions like SHA-256, which so far has not been broken.
+The problem is there is no mathematical proof that this actually exists.
+So we think these functions are one-way, and They better be one-way, but it may turn out that some mathematician somewhere proves that they're not.
+And then you get into the whole P is NP stuff that we're not going to get into.
+Now, there is a special kind of one-way function called the Trapdoor One-Way Function.
+That is public key, private key cryptography, where it is very hard to go back, it is very hard to go from a public key to a private key, in fact like, you know, take the age of the universe, unless you know the private key.
+Then it's trivial.
+
+Speaker 0: 00:25:03
+
+Yes.
+
+Speaker 1: 00:25:04
+
+I think I said it wrong, it's like, it's very hard to fake a signature, for example, but if you know the private key, then it's trivial to make the signature.
+And that is the trapdoor, the secret passageway through which you can do things.
+So that was the distinction we wanted to make back then.
+
+Speaker 0: 00:25:18
+
+There actually is, sure, a chapter about this in my book as well.
+
+Speaker 1: 00:25:21
+
+Yeah, so then the secure benchmark function has to be less strenuous.
+It can't be a one-way function because then you'll never go back.
+So if you go to the Wikipedia article about one-way functions, it defines this little thing like, okay, for any blah, blah, blah function that you try a hundred thousand times or whatever, statistically you should almost never find the correct answer.
+That's sort of how they defined it.
+And then Szabo basically writes a similar formula, but then explaining what this secure benchmark function should look like.
+
+Speaker 0: 00:25:57
+
+And the...
+Sure, Are we still just making a bridge?
+
+Speaker 1: 00:26:02
+
+Yes, we are.
+
+Speaker 0: 00:26:03
+
+This is a big bridge you're building here.
+
+Speaker 1: 00:26:04
+
+I'm almost done with the bridge.
+One thing that is interesting there is that when it comes to these one-way functions, it doesn't matter what hardware you have.
+They just seem like you can have the whole universe and you still cannot crack it.
+You can have a Dyson and you can't crack it.
+But in the secure benchmark function, the device that you use, the machine that you do things on, actually matters in the math.
+You cannot just abstract away the machine.
+You have to say, okay, what is a realistic computer?
+Because, and then you get back to the spam problem.
+If a spammer has an ASIC, a modern-day ASIC, and let's say the algorithm was SHA-256 instead of SHA-1, well then you as a consumer trying to send an email would have to burn your phone to the ground in order to just send an email, but that guy with the ASIC can just spam a million people because per watt of electricity that you're putting into that ASIC you can just produce enormous amounts of spam, whereas your phone is less efficient so it would just get too hot.
+And so that's why it's very hard to find functions that are hard enough, like that are easy enough for a phone, hard enough for an ASIC.
+And he kind of anticipated that problem in that very short paper.
+
+Speaker 0: 00:27:12
+
+That was Shor's building, the Brooklyn Bridge over here.
+Beautiful in its own right.
+
+Speaker 1: 00:27:17
+
+Exactly.
+And that's why he needed, for his Bitgold proposal, he says like, yeah, make sure you, you know, whatever you do, because he didn't actually build the project, make sure it's one of those secure benchmark functions.
+
+Speaker 0: 00:27:31
+
+Yes.
+Okay.
+Yeah, in my book, I sort of muffle this way in a footnote, and I just call it hashes because Okay.
+So, let's talk about bit goals.
+I don't know if there's much specifically to introduce unless I you know, I can tell the whole story about how the cypherpunks want to create digital cash and the example was one of them, but let's At some point.
+
+Speaker 1: 00:28:04
+
+I think it might be interesting to mention the, I think it was like seven points that he describes that this system should do.
+
+Speaker 0: 00:28:12
+
+Well, that was Adam Back.
+
+Speaker 1: 00:28:15
+
+Oh, I thought the BitGold paper also lists like seven properties of the system.
+Basically like it has to be in the BitGold paper.
+Yeah.
+Or at least it's been a while since I read it.
+
+Speaker 2: 00:28:24
+
+Well,
+
+Speaker 1: 00:28:24
+
+maybe you just describe it in general terms.
+
+Speaker 0: 00:28:27
+
+BitGold itself.
+Okay.
+So we're getting more to the technical side then.
+
+Speaker 1: 00:28:32
+
+Yes.
+What the architecture of the system is and how it should work.
+
+Speaker 0: 00:28:35
+
+Okay.
+Yeah, I can do that.
+Okay.
+So basically Nick Szabo wants to create digital cash, right?
+Hash cash was introduced.
+So now there was something aching to digital scarcity.
+Now It wasn't real digital scarcity, obviously, or at least it was at least not limited because over time it becomes easier and easier to create valid hashes.
+There were a number of problems with hashcash, why you couldn't use it as money.
+Also, of course, you can't pay someone with hashcash.
+It's like a one-time use.
+
+Speaker 1: 00:29:03
+
+Yeah.
+So what you're describing is the inflation problem, right?
+
+Speaker 0: 00:29:06
+
+Well, that's the one problem.
+And also you can't transfer it to anyone.
+Like you can't re-spend hashcash.
+Yeah.
+Right.
+So it wasn't really digital money yet.
+It was digital postage, essentially.
+But it did introduce something aching to the digital scarcity.
+And this idea inspired, for example, Nick Szabo to propose their own digital currency schemes.
+Now, Bitgold was never implemented.
+It was only ever a proposal, but it's still interesting.
+So the way it works is you start with a candidate string.
+The candidate string can be anything, I guess.
+It doesn't really matter, but let's just say a random string of numbers.
+And then with a proof of work or a secure benchmark function, as you just explained, that's how Nixarbo called it in his paper, I believe.
+At least in one of his posts, he very specifically called it that.
+
+Speaker 1: 00:30:03
+
+Yeah, I think in the post I read, he just used all of the terms, but then made this benchmark a more specific definition.
+
+Speaker 0: 00:30:11
+
+Right, exactly.
+
+Speaker 1: 00:30:12
+
+But we can just call it proof of work because that's what it is.
+
+Speaker 0: 00:30:14
+
+Yeah, let's call it proof of work.
+So you use proof of work.
+So there's a candidate string.
+Anyone can use proof of work to create a new valid hash, essentially.
+Now the person who creates this valid hash becomes the owner of this hash.
+
+Speaker 1: 00:30:32
+
+So whoever creates it first.
+Yeah.
+
+Speaker 0: 00:30:33
+
+Whoever creates this first.
+Yeah.
+I don't think it was specifically defined or specified how this initial ownership would work, but the obvious solution is you hash your public key with it.
+And that would just be an easy way to do it, right?
+Anyway, so whoever creates a valid hash using Proof-of-Work on the candidate string gets to own that string, and then the valid hash becomes the new candidate string.
+So now everyone can start hashing that to find the next candidate string, which then, to find the next valid hash, which then becomes the next candidate string.
+Okay, so that's how you own these strings, essentially.
+Transferring strings is much like Bitcoin.
+You sign a message saying, this string now belongs to this public key.
+And if that message is cryptographically signed with the corresponding private key of whoever was owning it, whatever public key was owning it, then the transfer is valid.
+The challenge was who gets to keep track of who owns what, or perhaps more specifically, how do you prevent double spending?
+One person could sign one transaction or several transactions go to several people.
+
+Speaker 1: 00:31:50
+
+And how can you prevent, you know, afterwards multiple people saying that they found it first, right?
+If the new thing was discovered.
+
+Speaker 0: 00:31:58
+
+Yes, right.
+Yes, that too.
+So there needs to be, you know, consensus on who owns what.
+Also smaller, well, other problems are like, for example, censorship.
+Anyways, so double spending, let's just say is the main problem.
+And Xabo envisaged like a ownership registry.
+So there would be a bunch of internet servers and they would essentially vote on whether or not a transaction is valid or which transaction out of conflicting transaction is valid.
+Now.
+
+Speaker 1: 00:32:31
+
+Yeah.
+So the, the key part there is it's at least it's not a central party that's doing it, but it's somehow decentralized, multiple people are tracking it, everybody can sort of check that it's at least, you know, maybe a bit honest.
+I mean, there's certain things you can check because signatures are signatures, you can't forge them.
+But if all these public parties keeping records either disagree, it's hard to decide which is right.
+You can't just count them, for example.
+
+Speaker 0: 00:32:56
+
+Yeah, well, the first thing you mentioned is kind of interesting about the signatures.
+So if...
+Okay, wait.
+So the problem is essentially that this registered, this pop, this registry, these servers, they can be corrupted in different ways.
+So for example, it wasn't stable resistant, or at least an example hadn't come up with a robust way to make it civil resistant.
+In other words, one guy could join with 10,000 different servers and just outvote everyone else and double spend everyone.
+Like there was no robust way of stopping that.
+
+Speaker 1: 00:33:31
+
+Yeah, it's basically all the proof of stake problems.
+
+Speaker 0: 00:33:35
+
+It's similar.
+Yeah, it didn't use proof of stake itself, but yeah, there was nothing at stake in that sense.
+That's for sure.
+Now, Nixzabo at that time thought a potential sort of mitigation against this is that users themselves can sort of keep an eye of what's going on.
+And then if there's, let's say the civil attack happens, and then the honest servers, the honest nodes in this registry system, they can split off.
+They can say, no, that's actually someone's trying to cheat.
+We're just going to start our own registry.
+And then users who are paying attention can sort of see, yep, this registry is honest and this registry is not.
+And that was supposed to sort of solve that problem, but it doesn't really.
+Like for example, if you're offline and you come in line and you weren't paying attention, so to say, you're a new user or something like that, you were just offline, you were on holiday, who knows?
+And all of a sudden there's two registries, there's no way to know which one was cheating and which one was not.
+
+Speaker 1: 00:34:44
+
+Exactly.
+It sounds like you need to be online all the time and you need to download all the transactions.
+And then you can sort of, it's like running your own Bitcoin node, although there wasn't an actual blockchain at the time.
+Well, there may have been, sort of.
+
+Speaker 0: 00:35:01
+
+Yeah, wait.
+The way you're phrasing it now sounds like it would have been a solved problem.
+
+Speaker 1: 00:35:06
+
+No, you would.
+If you were to implement this system, then it sounds like everybody should just be verifying everything so that there is no third party.
+
+Speaker 0: 00:35:14
+
+Well, so that's what we're getting later, sure.
+But Bitgold did not have this idea yet in any case.
+
+Speaker 1: 00:35:20
+
+No, no.
+The idea would be that there would be multiple servers doing this job basically.
+But in order to check the servers, the only logical conclusion to me would be that everybody has to check everything.
+
+Speaker 0: 00:35:33
+
+But you're very smart.
+
+Speaker 1: 00:35:34
+
+Well, and I have the benefit of hindsight.
+
+Speaker 0: 00:35:37
+
+Maybe mostly that or both.
+Well actually, so there is a fairly recent sort of analogy we could draw from this sort of non-solution, you could say, which would, for example, be Ethereum Classic and Ethereum, right?
+At some point, a valid transfer happened on Ethereum and then that money was stolen back.
+And then the people that stole it back said, no, we're the real Ethereum.
+And at that point, there were two Ethereums, and the actual Ethereum was forced to change its name, while the Ethereum where the theft happens went on, and that's what people today call Ethereum.
+
+Speaker 1: 00:36:20
+
+I mean, that's one perspective, and the other is that, you know, the people who call things Ethereum apparently, you know, do not primarily follow what the software says.
+
+Speaker 0: 00:36:30
+
+That's kind of the point.
+So you can debate about this and there's no clear solution.
+And I mean, I still think what I said is correct.
+Like I really mean that, but that's sort of besides the point, the point is you're now expecting users to keep an eye on everything.
+So it wasn't really a good solution.
+However, it was of course very innovative.
+It had a very innovative idea of how you could sort of, you know, it was a big step into thinking about creating digital cash, specifically digital cash based on Hash Cash that wasn't backed by anything else.
+
+Speaker 1: 00:37:03
+
+Yeah, I think one innovation there compared to DigiCash, because we talked about that earlier or eCash.
+In eCash you have a mint, that's the entity that creates coins, and they are also the entity that is essentially the central bank that clears all transactions.
+So there is a single point, the entity that issues the coins, that checks all the transactions, that kind of has a monopoly on the transaction log, or maybe not.
+Whereas at least the issuance now is completely decentralized because everybody can deliver their proof of work.
+I think that ingredient is there.
+And the verification, although still a bit hand-wavy, at least the idea is that it shouldn't be one entity.
+And I think he also was mentioning RPOW already, but that's something to discuss another time.
+
+Speaker 0: 00:37:54
+
+He was not mentioning RPOW because RPOW came years later.
+
+Speaker 1: 00:37:59
+
+Maybe I read a newer paper.
+
+Speaker 0: 00:38:01
+
+Yeah, that's probably it then.
+Where were we?
+Okay, yeah.
+So we saw, okay, let's for the sake of convenience now imagine that this system would have worked.
+So now you can create these strings and you can send them to other people.
+And there's this registry that keeps track of which public key owns which string.
+Now we're getting close to something that looks like money, but there is a second big problem that Bitgold was facing with or that it sort of solved.
+So the second big problem is that it over time becomes cheaper to produce valid hashes, right?
+Yeah.
+So at first, because computers just get better and better, it gets faster and faster, so it's easier and easier to cheaper and cheaper to create valid hashes.
+
+Speaker 1: 00:38:48
+
+And there's more of them.
+Well, that's actually not important that there's more of them, but that it is cheaper, yes, costs fewer kilowatts of energy to do it.
+
+Speaker 0: 00:38:57
+
+Right.
+So the problem then is that the money isn't fungible necessarily.
+Like it should be that each currency unit is worth the same or each currency unit of the same denomination should be worth the same.
+
+Speaker 1: 00:39:10
+
+Well, either it's fungible, but in that case, all the money you created in the past is now worthless.
+So it's fungible, but highly inflationary.
+Or it's not fungible where you, and that's I think the solution that he proposed, is where you value older work more.
+So you say because this work was generated 10 years ago on a slower computer, we know that more energy was put into it, therefore we can correct for that.
+And then the hope is that the market actually does that.
+
+Speaker 0: 00:39:41
+
+No, no, the market doesn't have to.
+If the market doesn't do that, that's even better.
+
+Speaker 1: 00:39:45
+
+Then it's highly inflationary.
+So you mine your coins in 1999, you have a hundred of these coins, and now a hundred units of work.
+And now ten years later, somebody makes a hundred units of work in a fraction of a second.
+So either your hundred units of work are worth nothing in the future, or they are valued because they are old.
+But whether the market will pick one of these two, I don't think there's any guarantee.
+He does argue that there are some precedent, like that older collector items are worth more, a bit like ordinals, I guess.
+But that's not the part of Ordinalis that's taking off the most.
+
+Speaker 0: 00:40:18
+
+Yeah, or like I think the misprints of certain postage stamps or something were worth more.
+Yeah, anyways, yeah, so indeed he does argue that.
+So the idea that he proposed was we'll create a market for these strings, for these hashes.
+And on these markets, people can trade them against each other.
+So that's how the markets can figure out how much is a, you know, 2005 hash worth in relation to a 2015 hash.
+So maybe one 2005 hash is worth 10 2015 hashes.
+I should note all these hashes are also timestamped.
+Like first of all, they're of course made in order.
+
+Speaker 1: 00:41:01
+
+You can prove that they are a certain age.
+Yeah.
+
+Speaker 0: 00:41:06
+
+Yeah.
+Which is also another chapter in my book, Chores, where I talk about the invention of timestamping.
+
+Speaker 1: 00:41:12
+
+Great.
+
+Speaker 0: 00:41:13
+
+But I won't get on that detour.
+So Bitgold, yeah, so there's this market for strings and you can figure out how much these strings are worth in relation to each other.
+Then Nick Szabo's vision was there will be sort of banks, like in a free banking type of environment, where these banks will collect the different strings and sort of bundle them together into, you know, buckets of strings of the same value.
+
+Speaker 1: 00:41:39
+
+This was written before the derivatives markets implosion in 2007, right?
+
+Speaker 0: 00:41:47
+
+Yes, we're in 1998, So yes.
+
+Speaker 1: 00:41:50
+
+Yeah, when all these triple A rated buckets and I'm thinking about what happened there.
+
+Speaker 0: 00:41:54
+
+Right, right, right.
+Yeah, has nothing to do with this short, but thanks for that color.
+So in my example earlier, where one 2005 hash is worth 10 2015 hashes, one bucket could consist of one 2005 hash and another bucket could consist of 10 2015 hashes.
+So now you have back buckets of the same value.
+And these banks would then use these buckets or these bundles, whatever you want to call them, to issue coins on top of digital coins still.
+So for example, every bucket is worth 10,000 coins and these 10,000 coins are issued to people's account.
+So now you have sort of a digital form of cash that people can pay each other with.
+
+Speaker 1: 00:42:41
+
+And once someone would be, that is actually digi cash, right?
+That layer on top.
+
+Speaker 0: 00:42:45
+
+Yeah.
+You could use e-cash for that.
+Yeah.
+I mean, it doesn't have to like in a free it's free banking.
+You're free to do whatever you want.
+Sure.
+
+Speaker 2: 00:42:50
+
+Yep.
+But Yeah, you could use e-cash for that.
+Yeah.
+I mean, it doesn't have to like in a free it's free banking.
+You're free to do whatever you want.
+Sure.
+Yep.
+
+Speaker 0: 00:42:51
+
+But yeah, you could use e-cash for that.
+If you want to offer privacy to your customers and, you know, get customers that way.
+But yeah, this was the idea.
+So once you have 10,000 coins in my example, you can exchange them for an actual bucket of strings, and then you have the actual bucket and you can maybe bring them to another bank or, and also because this is all like these strings, it's cryptographically provable Who owns them, you can also have like the proof of reserve type of stuff.
+Like Nick Zabo was already thinking about that kind of stuff to address your 2008 concern, by the way.
+
+Speaker 1: 00:43:27
+
+Yeah.
+Yeah.
+It's a free banking system.
+
+Speaker 0: 00:43:31
+
+So this is how, yeah, this was basically the idea of Bitgold.
+Did I miss anything?
+
+Speaker 1: 00:43:37
+
+Yes, so we talked about inflation and I guess this sort of these buckets also address the change problem, right?
+Because another issue is that when you had the original e-cash system you could go to a shop and you would come with your 10 euros worth of this stuff and they would immediately go to the bank, essentially redeem it and give you your change back.
+So change wasn't a problem in the original system.
+Change is also not a problem in Bitcoin because the transaction itself creates a change.
+But in this system these strings don't have change so what you could do is somebody could make lots of small little pieces of work and distribute those just like you would distribute small change and then you go to a shop and you get these little strings back for your change but it may be easier to do all this on a second layer and just have big buckets somewhere that don't need to be changed all the time.
+Because also it would mean having to track all the movement of all these mini-strings.
+Like tracking the movement of every penny on the planet essentially.
+
+Speaker 0: 00:44:39
+
+Right, yeah exactly.
+It's interesting you mentioned that.
+Nixzabo was already thinking about second layer solutions, you know, as are being developed and exist on Bitcoin today.
+This was also sort of an original Nixabo fission to have different layers for different types of transactions.
+Yes.
+So that's, that's Bitgold in a nutshell, I think, Jors.
+
+Speaker 1: 00:45:01
+
+All right.
+Well then I guess I can conclude Bitcoin fixes this.
+
+Speaker 0: 00:45:05
+
+Yeah.
+Well, we're going to make one more Genesis Book Chill episode, right?
+
+Speaker 1: 00:45:09
+
+I think so.
+Yeah.
+
+Speaker 0: 00:45:10
+
+Maybe next week or the week after we'll make one on B-money and ARPAO.
+Cool.
+
+Speaker 1: 00:45:16
+
+All right, then.
+In that case, thank you for listening to Bitcoin Explains.

--- a/bitcoin-explained/ocean-tides.md
+++ b/bitcoin-explained/ocean-tides.md
@@ -1,0 +1,939 @@
+---
+title: "Ocean Tides"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://bitcoinexplainedpodcast.com/@nado/episodes/episode-86-ocean-tides-hktbg
+tags: ['mining']
+speakers: ['Sjors Provoost', 'Aaron van Wirdum']
+categories: ['podcast']
+date: 2023-12-06
+summary: "In this episode of Bitcoin, Explained, Aaron and Sjors explain what features are offered by Ocean, the relaunched and rebranded Eligius mining pool. They discuss how payouts from this pool are (partially) non-custodial, how the block template creation is fully transparent, and how payout distribution is determined. Aaron and Sjors also briefly touch on the “spam” filtering employed by Ocean, and how that potentially affects profitability of the pool."
+---
+Speaker 0: 00:00:21
+
+Live from Utrecht, this is Bitcoin Explained.
+Hey Sjoerds.
+Hello.
+Sjoerds, we have a sponsor.
+
+Speaker 1: 00:00:28
+
+That is correct.
+We have a new sponsor.
+
+Speaker 0: 00:00:30
+
+Isn't that great?
+
+Speaker 1: 00:00:31
+
+That's right.
+Our new sponsor is Coinkind, the company behind the cold card.
+And dear listener, if you have no idea what a cold card is, please let us know because then we'll explain it because otherwise it's a bit ridiculous if we explain it because we I think we we think you all know.
+
+Speaker 0: 00:00:48
+
+Oh my God, this is the worst ad read in history, Sjoerds.
+Excellent.
+Can we at least mention it's a hardware wallet?
+
+Speaker 1: 00:00:56
+
+Yes, it's a hardware wallet.
+
+Speaker 0: 00:00:57
+
+It's a hardware wallet you can use to store Bitcoin.
+All right.
+Sjoerds, today we're going to discuss a new mining pool launched.
+Well, kind of.
+Ocean Pool.
+I was invited to the launch event.
+It was sort of a mini conference.
+
+Speaker 1: 00:01:15
+
+I felt a very strong FOMO for that one.
+I saw the video, you guys were in the middle of nowhere and some like, like video, like some horror movie video shoot game basically scene.
+
+Speaker 0: 00:01:26
+
+Right.
+Yeah.
+Well, it was quite nice actually.
+There was like this hydro plant, a very, what's a good English word for this?
+Rustic?
+I don't know if that's the right word.
+Maybe, but it was nice.
+Let's just say it was nice, nice environment.
+And yeah, they launched this pool.
+So it's really the relaunch or re-brand or re something of Elytius.
+If that's how I pronounce that pool, the Luke Dasher pool.
+This time it's backed by Jack Dorsey, my other investors.
+And their goal, their intention is to re-decentralize mining essentially, or decentralized mining.
+
+Speaker 1: 00:02:04
+
+Right.
+And they're calling it Ocean.
+
+Speaker 0: 00:02:07
+
+Yeah.
+Didn't I mention that?
+No. Okay.
+Yes.
+Ocean, ocean pool.
+Yeah, so decentralizing mining pools or at least this one or mining in general, ultimately is the goal.
+The sort of most notable innovation that they started with, that they launched with, is they have this non-custodial setup.
+Kinda.
+Or I mean, that's the goal, that's the intention.
+
+Speaker 1: 00:02:34
+
+I guess one diplomatic way to call it would be custody minimized.
+I mean, you can have long legal discussion about what custody means, but I think we care most about the technical sides of it.
+And then you can ask practical questions like could the mining pool steal your money?
+Could the big forces steal your money?
+Etc.
+And we can try to get into some of the nuance there of what they're actually doing.
+
+Speaker 0: 00:02:57
+
+So to clarify this, what mining pools usually do is, well I don't want to get into the whole thing, but basically when a mining pool finds new coins, the mining pool gets these coins.
+And in fact, these coins can't be spent for a hundred blocks, right?
+Yeah.
+And then after these a hundred blocks, well, that's actually not what happens with most pools.
+I was, I w I was going to say after a hundred blocks, these coins are distributed to the miners, but that's not actually how money pools work.
+
+Speaker 1: 00:03:28
+
+I would say there's a bigger separation there, right?
+The mining pool as a whole has a wallet and the coins they earn go into that wallet and the miners are paid from that wallet but it is a bit of an omnibus and not necessarily trivial to understand which mindset belongs to which specific individual miner.
+
+Speaker 0: 00:03:46
+
+Yeah a way that they will explain it or Bitcoin Mechanic, for example, is essentially most Bitcoin miners or hashers, as we've also called it, aren't actually mining Bitcoin.
+They're just selling their hash power to a mining pool, basically.
+And the pool operator is the one that's actually...
+
+Speaker 1: 00:04:03
+
+Well, that sounds a little bit like a separate issue, though it's a bit related to whether you know you're really...
+What it is that you're doing as a miner.
+Are you producing blocks or are you just delivering hash rate to a buyer?
+And that depends on the incentive model, the exact business model.
+I think we'll get into that a bit later, but the idea of holding coins custody, you know, you could, you could do that with this model too, I think you just don't have to.
+
+Speaker 0: 00:04:30
+
+Right.
+Yeah.
+It is a slightly separate issue.
+I just wanted to point it out real quick, but yes.
+Yeah.
+So the main innovation here is essentially that hashers as well.
+They'll call them.
+So to clarify that there's the mining pool or the mining pool operator, that's, you know, doing most of the Bitcoin stuff, you know, downloading blockchain and constructing the blockchain template, which is a big part of it, which might not happen in the future with Stratum V2, but we've made another episode about that, at least right now, most mining pools still create block templates or which transactions go into a block.
+And I lost my train of thought, but I think I was going to say with Ocean, the new coins are directly paid to the hashers.
+Oh, I was still explaining.
+
+Speaker 1: 00:05:16
+
+So the coin-based transaction, which is what every new block contains, has a number of outputs and typically these just go to the general wallet of the pool.
+But with this new Ocean Pool, as much as possible, the coin-based transactions go directly to the miners.
+Right.
+With the caveat that you cannot do that for all mine transactions.
+Not for all miners.
+And there are two reasons for that.
+
+Speaker 0: 00:05:41
+
+Okay, so let's get into that.
+First let's point out some advantages of this.
+And the biggest one is probably, so right now, if you're a hasher and you want to join a pool, most pools have sort of KYC stuff going on, like you need to actually tell the pool who you are, at least some of the big ones have this.
+And Ocean does not have this.
+
+Speaker 1: 00:06:00
+
+Yeah, but I don't think that's inherent to this model at all.
+Like you could still have KYC in this model or not.
+
+Speaker 0: 00:06:07
+
+Yeah, so well, I mean, I guess in their view or what they will argue or what they think or what they believe is that they, that it's sort of a, this way it's legally possible to not do KYC.
+
+Speaker 1: 00:06:18
+
+Well, we're not lawyers.
+We're, I'm a developer, you're a journalist, but let's,
+
+Speaker 0: 00:06:23
+
+but in any case, they aren't doing KYC stuff.
+That's for sure.
+
+Speaker 1: 00:06:26
+
+Right now, you can just plug in and start mining.
+One thing that they're doing very practically is that you as a miner don't create an account or you don't have to.
+You just provide a Bitcoin address straight as you're directly from the miner.
+
+Speaker 0: 00:06:40
+
+Right.
+Okay.
+So you mentioned, so you, So you get paid directly from the Coinbase as a hasher to the extent that it is possible.
+
+Speaker 1: 00:06:52
+
+Yeah, and that extent is quite limited because of two reasons.
+One is a Coinbase transaction can only have this many outputs.
+Or even if you could have as many as you want, at some point it's just not worth paying the fees.
+Or not so much paying the fees because the Coinbase transaction doesn't pay fees, but you are forgoing, you know, you're using up space that others could pay, that other people are paying you fees as a pool.
+So if you make a one megabyte Coinbase transaction, then you can do that and you pay zero fees for it, but you are now no longer mining anything.
+
+Speaker 0: 00:07:25
+
+Right, well, you could create a four megabyte Coinbase transaction.
+
+Speaker 1: 00:07:28
+
+I don't think so because there's no witness.
+
+Speaker 0: 00:07:30
+
+Maybe two.
+Oh, Oh, right.
+Okay, let's separate these issues.
+So first of all, you said you can't necessarily pay every hasher because the number of outputs in the Coinbase transaction is limited?
+
+Speaker 1: 00:07:42
+
+Or at least, I don't know if there's an actual limit there that matters, but basically it's just not worth the opportunity cost of making very small payments in the Coinbase.
+But there is a second...
+
+Speaker 0: 00:07:52
+
+So it's the same issue.
+There is no actual limit to the number of outputs in the Coinbase transaction.
+
+Speaker 1: 00:07:56
+
+I think it's just a regular transaction, whatever that limit is.
+It might not be one.
+Okay.
+I should know that, I guess.
+So the second limit, the second limit is a little bit more mundane.
+Apparently some of the mining hardware out there starts to panic if you put more than 20 outputs in a coin based transaction.
+So that has nothing to do with the Bitcoin limits.
+It's just that some mining equipment just panics when there's too many outputs.
+So in practice, the limit is about 20.
+So the 20, and in this case, the top 20 miners get paid directly from the Coinbase.
+Then there's some amount left and that essentially goes to a wallet you could say, but they make sure that from that wallet after a hundred blocks, because then you can spend it, it immediately goes to the correct miners as if they were part of the Coinbase essentially.
+
+Speaker 0: 00:08:49
+
+Right.
+Okay.
+So we just, so I thought wrongly probably that there was a limit on the number of transactions on the Coinbase output.
+And you just said, That's probably not the case, but there some hardware has this issue.
+That's, that's where the limit comes from.
+Yeah.
+Okay.
+And you say that limit is 20.
+I apparently roughly 20.
+20 ish.
+Okay.
+There can only be 20 transaction outputs from a Coinbase transaction.
+
+Speaker 1: 00:09:16
+
+So, So that secondary transaction, which can only happen after a hundred blocks, because the Coinbase maturity rule, that's a consensus rule.
+That transaction is kind of just like it was part of the Coinbase itself, right?
+It also has the same fee trade-offs here where yes, you can put whatever giant transaction you want in there as a pool, but then you're foregoing fee revenue from other transactions.
+This transaction just spends from the Coinbase.
+
+Speaker 0: 00:09:40
+
+Okay.
+So if there's just too many hashers that need to be paid from the Coinbase, if it's more than 20 essentially, then some of them will be paid later, still as soon as possible, but later.
+And then the other thing was, if you mine, if you're a hasher and you don't earn enough from a block, then you'll only, also won't get paid immediately.
+
+Speaker 1: 00:10:03
+
+Right, So then the idea is to basically wait until you, until you've accumulated enough credit as it were, and then you get paid.
+So there, it really starts looking like just a wallet that's custodial, but only for small amounts.
+
+Speaker 0: 00:10:18
+
+Sjoerd Right.
+Okay.
+So that's how it works today.
+And then there are some ideas in the future, for the future to improve that a little bit more.
+So one of them is using Lightning for payouts.
+
+Speaker 1: 00:10:32
+
+Arno Yeah, that kind of makes intuitive sense.
+When you have very small miners that want to collect small rewards, maybe they get like 20 Satoshis every block.
+Lightning is a way to do that.
+Then the question is, can you, you know, how non-custodial can you make lightning?
+I believe if you listen to the Stefan Levera podcast, Bitcoin Mechanic explains some ideas of how to do that roughly, using, I believe, some sort of market where, like, if you have, if you have lightning liquidity, you essentially buy the rights to the payouts from the pool.
+So the pool is not doing the lightning payouts.
+They're just, they're just giving payouts to addresses, but then you, somebody else does some swapping of who gets which points.
+
+Speaker 0: 00:11:15
+
+Right.
+And then there's another potentially cool idea, which is not possible yet on the Bitcoin network, but with check template verify, it could actually be implemented that if this 20 limit threshold in the Coinbase is reached, then the other hashers are still guaranteed their payment through a CTV transaction because of that.
+
+Speaker 1: 00:11:39
+
+Yeah, and even better than that, regardless of this 20 limit, right now, if you're putting something, you have to put the addresses in the Coinbase right now.
+And so you kind of don't want to do that when fees are really high because that's an opportunity cost.
+But maybe you want to pay people when fees are low.
+So CTV is quite interesting for that.
+We have not really discussed that in any podcast, but it's basically a software proposal that commits to certain transactions happening in the future.
+And one of the intended use cases is congestion control.
+And this would be a very nice use case for it, where the Coinbase only has one output, or maybe a couple, which is the CTV transaction.
+And then all the miners know for sure that they will get those coins, but they'll wait until fees are low and then they'll get them.
+
+Speaker 0: 00:12:26
+
+Right.
+All right.
+That was the non-custodial part of the pool, which is probably kind of the main innovation, but it's not the only thing going on.
+
+Speaker 1: 00:12:36
+
+Yeah.
+Or the custody minimized part of the pool.
+Right.
+
+Speaker 0: 00:12:38
+
+Right.
+I'm sorry, Sjoerd.
+You're very right.
+The other thing is, so the block template is transparent.
+So usually at most pools right now, because they have this FPPS model, which I briefly mentioned earlier, where hashers are basically just selling their hash power to a mining pool and the mining pool just makes a block with it.
+Now on Ocean it's completely transparent what the block will actually look like that everyone is working on, right?
+
+Speaker 1: 00:13:09
+
+Yeah, so I don't know how inherent this limitation is in normal pools.
+I do know that Stratum V2 doesn't have this problem.
+In Stratum V2 you know exactly what you're mining, but in this case OceanPool will show you what you're mining without even using Stratum V2.
+And typically you don't know what you're mining, you just get a hash and you're grinding away on that hash.
+Now you can go to, at least you can go to an API and check.
+And this could be interesting, especially for bigger miners because bigger miners they're paid directly from the Coinbase.
+So they can see that they're mining a block that pays them.
+Like they know for sure.
+Smaller miners Again, with the CTV technique, they might also be able to check this.
+Probably not in real time, right?
+Because you don't want to spend 10 seconds calculating if you're mining the correct block.
+You just want to start mining.
+But you can at least, within a few seconds, say, hey, I'm being scammed.
+I'm going to stop mining now.
+So that's quite nice.
+For tiny miners that have to be paid through Lightning.
+I don't think this offers any benefit in terms of knowing that you're going to be paid, but you still know what you're mining.
+You might realize that you're censoring certain stuff that you're not happy with, et cetera.
+So that's good.
+
+Speaker 0: 00:14:18
+
+Yeah.
+The counter or one of the examples that, you know, Bitcoin mechanic, for example, bring up is that, there've been pools that have minds blocks that are basically one big inscription or have big inscriptions in them.
+And hashers had no idea that that's what they were doing.
+Now, maybe they also don't care that that's what they're doing, but maybe they do care.
+In any case, with Ocean, hashrers will actually know what they're doing.
+
+Speaker 1: 00:14:41
+
+Yeah, but also with Stratum V2, I believe they'll know.
+
+Speaker 0: 00:14:45
+
+So, yeah, about Stratum V2, we already made an episode about that and I also already mentioned that, but, it does seem like that sort of on the roadmap for ocean, but they don't,
+
+Speaker 1: 00:14:56
+
+I'm sure it is, but I'm always skeptical of roadmaps, right?
+
+Speaker 0: 00:14:59
+
+Right.
+
+Speaker 1: 00:14:59
+
+Show it to me.
+
+Speaker 0: 00:15:00
+
+Yeah.
+They don't have it now yet in any case.
+
+Speaker 1: 00:15:03
+
+I'm sure they will, but they don't have it yet.
+
+Speaker 0: 00:15:07
+
+All right.
+And then we get to possibly the most complex topic of, of all of them.
+Yesterday we had a sort of preparation call with also with Bethke mechanic and with the CTO of the pool, Jason Hughes.
+And it was one of these calls where I was on it and Shorts was just sort of Going on adventure with the CTO and I couldn't really keep up with everything you were discussing.
+So let's see what you've figured out.
+
+Speaker 1: 00:15:38
+
+Yeah.
+So in case people think that I confidently understand stuff spontaneously, no, that takes a lot of effort.
+Right.
+
+Speaker 0: 00:15:45
+
+Okay.
+So I'm barely even sure how to introduce this.
+
+Speaker 1: 00:15:50
+
+Well, I think we should generally talk about shares a little bit without any of the crazy mechanics that are being used generally.
+But the idea is if you are mining, you need to prove to the pool that you are actually doing some work.
+
+Speaker 0: 00:16:03
+
+Yeah, how does the pool decide which hashers get how much Bitcoin?
+
+Speaker 1: 00:16:07
+
+And I think we discussed this also in the Stratum V2 episode, by the way, so you could re-listen to that.
+But the general idea is that you will mine a block with a much, much, much lower difficulty.
+And for example, the block that you're trying to mine, the pool wants to see it if it is like a thousand times easier than the real block.
+
+Speaker 0: 00:16:25
+
+Yeah, you're basically mining invalid blocks.
+
+Speaker 1: 00:16:28
+
+Yeah, but they're not randomly invalid.
+They are like as if the proof of work difficulty was still at the level it was when Satoshi started, basically.
+And the nice thing is that when you do that, you cannot lie about it.
+You are providing proof of work, just a little bit less proof of work because you're only sharing it with the pool operator and not the whole internet.
+Yeah.
+So it's fine to have a little bit more spam.
+And generally they'll aim to have like eight blocks a second, sorry, eight blocks per minute.
+That's, I believe often an interval.
+
+Speaker 0: 00:16:58
+
+You're basically proving to the pool that you're at least trying to find the block.
+
+Speaker 1: 00:17:02
+
+Exactly.
+Right.
+And then occasionally you will find a block.
+
+Speaker 0: 00:17:05
+
+Right.
+Exactly.
+And yes.
+Okay.
+So Ocean has this way, it's called tides.
+So how do you decide which hasher gets how much Bitcoin?
+
+Speaker 1: 00:17:16
+
+Yeah, that is the hard question.
+And I think we'll also get a little bit into how other pools do that, but I actually don't really understand how other pools do it.
+And I think I do understand how this pool does it.
+Cause it's, I think it's a fairly elegant and simple system.
+
+Speaker 0: 00:17:29
+
+Well, I think how other pools do it is that's the FPPS system, right?
+So basically a pool just says, we'll pay you X amount of Bitcoin for X amount of hashes, and that's just it.
+
+Speaker 1: 00:17:42
+
+Yeah, but there's a little nuance of how much X is.
+
+Speaker 0: 00:17:46
+
+How X is calculated, you mean?
+
+Speaker 1: 00:17:48
+
+Yeah.
+So let's try and explain this.
+
+Speaker 0: 00:17:50
+
+I've never really looked into that and let's skip that.
+That's the easiest thing to do here.
+And let's get into how Ocean actually does it.
+
+Speaker 1: 00:17:57
+
+Right.
+That was, that was sort of the idea.
+Okay.
+So basically the idea is that there is a bucket, or it's not really a bucket, it's a queue.
+And you are adding work, little loads of work, little shares of work into a queue.
+Let's say the two of us are mining, I've got my little vintage S9 that I've clocked down to 1 terahertz so that a tera hash so that it uses less power and makes less noise and it can sit here in my living room basically without driving me nuts.
+And you have the same so we're each hashing away.
+
+Speaker 0: 00:18:32
+
+It just not clocked down and it's driving me crazy because I don't know how to do that.
+Oh. Go on.
+
+Speaker 1: 00:18:38
+
+Anyway, so both of us are mining and what we do is to the pool we're proving that we're doing this amount of work.
+And so the pool is keeping track of that.
+You're submitting a share, I'm submitting a share, you're submitting a share, I'm submitting a share, and over time this builds up.
+And eventually a block is found, and then in the simplest case, we've both submitted the same number of shares, and the shares are adjusted for how strong our miners are so but in this case we assume the miners are equally strong.
+The block arrives then half the coinbase transaction output goes to me, half the coinbase output transaction goes to you.
+This is very simple.
+Now, let's, so this bucket of shares does not fill up to infinity.
+So if we do this for a few years, then we're not gonna, the division who gets how much is not, does not depend on the total amount of shares we submitted throughout history, but it only depends on the recent past.
+It's kind of like a rolling window.
+
+Speaker 0: 00:19:42
+
+How recent?
+
+Speaker 1: 00:19:43
+
+The equivalent, so this is where it gets a little more complicated is the equivalent of eight blocks of work for the whole network.
+So the number of hashes, or sorry, the number of shares it would take statistically to produce eight blocks.
+You know, with my miner that would be, I don't know, two million years worth of blocks or something.
+Or two million years worth of mining, let's say, and for you the same thing.
+But as soon as the mining pool has more shares than that, it starts discarding all shares,
+or at least it starts ignoring them.
+So in practice, let's take another example where we actually have two really fast miners.
+In fact, our miners are as fast as the whole Bitcoin network.
+Somehow we've turned off all the other miners in the network, and so this this Elysium pool, sorry, the Ocean pool is now the only pool and we are continuing with the Bitcoin network at the same hash power.
+So just to keep the analogy a bit simple here.
+
+Speaker 0: 00:20:45
+
+Yes, please.
+
+Speaker 1: 00:20:47
+
+Yes, Now in this case, actually, sorry, our miners are a little bit different.
+That is my miner is as strong as the entire Bitcoin network is, and your miner is as strong as the entire Bitcoin network is.
+I'm going to turn it on, you're not, and then at the end you're going to turn it on and I'm going to turn it off.
+Because then the question is, how much do we get?
+So let's take the simplest possible example, or about 40 minutes, I turn it on and then for 40 minutes you turn it on and By just complete coincidence Blocks are found exactly every 10 minutes.
+Mm-hmm.
+So then the question is what happens?
+Initially I Turn it on first, right?
+So initially I get everything for the first block, second block, third block, fourth block,
+because I was the only one mining and I'm the only one in the history, ignoring that there's a further past.
+Now You turn on your miner and I've turned off mine.
+So what happens in the next block?
+Well, it's looking back at the equivalent of eight blocks, which is more than so far what we've collected.
+And so you are going to get one fifth and I'm going to get four fifth of the next block.
+And then...
+
+Speaker 0: 00:22:02
+
+That sounds very unfair.
+
+Speaker 1: 00:22:04
+
+It doesn't because if we look at that history for the last eight blocks, you have done one fifth of the work and I've done four fifth of the work.
+
+Speaker 0: 00:22:12
+
+I'm not getting one fifth of the Bitcoin.
+
+Speaker 1: 00:22:15
+
+You are getting one fifth of Bitcoin.
+
+Speaker 0: 00:22:17
+
+Not of all Bitcoins that have been issued so far.
+
+Speaker 1: 00:22:19
+
+No, you're getting one fifth of the next block.
+Yeah, it's always what you get in the next block.
+
+Speaker 0: 00:22:23
+
+Uh-huh.
+
+Speaker 1: 00:22:24
+
+Now the block after that,
+
+Speaker 0: 00:22:25
+
+you're getting...
+It feels like I'm being scammed here, Sjoerd.
+
+Speaker 1: 00:22:27
+
+I don't think so.
+
+Speaker 0: 00:22:28
+
+Go on.
+
+Speaker 1: 00:22:28
+
+I think the next block, you're getting two sixth of it.
+Then the next block, you're getting three sixth of it.
+And then the next, sorry, three seventh of it.
+And then the next block you're getting half of it, four out of eight, because now you have done half the work in the past eight blocks.
+
+Speaker 0: 00:22:42
+
+I'm still being scammed.
+Like you got all the Bitcoins of the first four and you still get part of the Bitcoins of the last four.
+Even though we both,
+
+Speaker 1: 00:22:50
+
+it sounds pretty evil, doesn't it?
+But, but now, we continue in time and you keep hashing and I don't.
+And it goes up, you get five, eight, six, eight, seven, eight, eight, eight.
+You get all of it.
+
+Speaker 0: 00:23:02
+
+Yeah, but now I still did two thirds of the workshops and I didn't get two thirds of the Bitcoin, I think.
+Anyways, I, I do think probably if you keep the logic going long enough, then it will probably work out, but so far I'm still being scammed here.
+
+Speaker 1: 00:23:16
+
+I don't think you're getting scammed, but it is true that it's a bit hard to reason about it because one of the problems is if you stop and there's no other miner, then, then you get nothing.
+Right.
+But if I then take over, you will continue to get rewards for the next eight blocks or so.
+It'll decrease as your, your work goes back into the past.
+So I think it works out.
+
+Speaker 0: 00:23:40
+
+But wasn't there a thing, wasn't there a thing that with the first, like the actual first eight blocks, so including the actual first eight blocks that I think Ocean is mining, the logic is a bit different.
+So aren't you now explaining the logic that will work fine later on, but not for the first eight?
+
+Speaker 1: 00:24:01
+
+No, I think it was fine for the first 8 too, because we are simply splitting the work between us in that case.
+
+Speaker 0: 00:24:10
+
+No, but we just established that I got scammed.
+
+Speaker 1: 00:24:15
+
+I don't think you got scammed, I think you're just bad at math, but I don't know for sure either.
+
+Speaker 0: 00:24:21
+
+Surely I'm not bad at math.
+Like in your example, you mined the first four and I mined the last eight and we're still splitting the coins, the total coins 50-50.
+
+Speaker 1: 00:24:31
+
+So you've mined the last eight, but you still will get rewards in the future, right?
+So you haven't had it yet, but you will get it right, right, right, right.
+But somebody has to do the mining.
+So the question then is when, when is that game done?
+Well, if I then take over, you will get the part that you still owed.
+
+Speaker 0: 00:24:47
+
+Right, yes.
+Okay, now that actually makes sense.
+For direct, I am bad at math.
+But in this case, I was still kind of right, I think.
+But yes, you're right that if you keep it going, then yes.
+
+Speaker 1: 00:24:57
+
+Slightly different experiment, because in reality, blocks do not arrive every 10 minutes.
+And so the question then is, well, what if blocks arrive really quickly and then it takes a really long time?
+How does that division work?
+Right?
+It's not that the blocks, that the rewards are equally divided between the actual blocks.
+It's based on the effort you're putting into the system.
+So an example that I just wrote down this morning or afternoon would be this.
+I am mining, I mine seven blocks, again we are the entire pool, I mine seven blocks, one every minute.
+And then I stop and you start mining.
+And, and only after two hours you find block number eight.
+
+Speaker 0: 00:25:44
+
+Is it, But that's just because of bad luck in your example, right?
+Yes.
+It's not lower hash power on my end, it's bad luck.
+
+Speaker 1: 00:25:51
+
+It's just bad luck.
+
+Speaker 0: 00:25:52
+
+Yeah, okay.
+
+Speaker 1: 00:25:53
+
+And so in this scenario, I got lucky.
+Well, again, this is kind of the bootstrapping problem, but if we kind of ignore that, I get lucky.
+The first seven times I get a hundred percent of the work of the coins even though I only mine for seven minutes that's just because of the luck mm-hmm and then but you have been mining now for eight hours or sorry two hours or one hour and 53 minutes whatever you want to say mm-hmm the question then is and you find a block how much do you get and how much do I get?
+
+Speaker 0: 00:26:26
+
+I mean, judging by your logic so far, I'm going to be scammed somehow, so tell me.
+
+Speaker 1: 00:26:31
+
+No, you get a hundred percent.
+
+Speaker 0: 00:26:33
+
+Because of what?
+
+Speaker 1: 00:26:34
+
+Of the reward in that eighth block.
+Oh, right.
+
+Speaker 0: 00:26:38
+
+And so this is the, because statistically there's been eight blocks on the network, even though there haven't, right?
+
+Speaker 1: 00:26:44
+
+Yeah.
+Or in, You know, the accounting system is checking how much work you submitted and you have submitted more than eight blocks worth of work now because it's two hours.
+So that's about, you know, normally you'd expect 12 blocks in that time period.
+So you have submitted eight blocks, roughly worth of equivalent worth of work.
+And therefore all the old stuff that I submitted no longer counts for the accounting, you get all of it.
+You still got unlucky, but in a way it's fair.
+Well, that depends on your definition of fair, but yeah.
+Yeah.
+But this is to make the distinction between, it's not actually eight blocks.
+It's not the last eight blocks.
+It's about the equivalent amount of work that went into the pool.
+
+Speaker 0: 00:27:23
+
+Yes.
+And that's calculated just based on the difficulty.
+
+Speaker 1: 00:27:27
+
+Yes, that is exactly.
+That's based on the current difficulty.
+So it gets a bit more complicated, I guess, if the difficulty goes up or down.
+But every two weeks, you know, the difficulty is constant and then it changes once.
+So as long as you don't go over that boundary, the math is pretty simple.
+But this is, I believe, also one reason why alt shares are not thrown away.
+Because you could be in a situation where the difficulty goes up and now the equivalent of 8 days is more than it was before and so you need to go back in time and look into the log of the people that were doing something a little bit before the window.
+Let's say the difficulty doubles, right, overnight.
+Now you're looking at the equivalent of eight days, which is in reality would have been 16 days of actual work if you're looking at the past.
+So you cannot throw away the past, or at least, you know, not unreasonably.
+
+Speaker 0: 00:28:22
+
+All right.
+Well, I'm glad you sort of understand this part of the ocean pool.
+Did we cover this part sufficiently, you think?
+
+Speaker 1: 00:28:30
+
+I think so.
+
+Speaker 0: 00:28:31
+
+Okay, good.
+
+Speaker 1: 00:28:33
+
+Yeah, so the funny thing is we did not cover a number of topics that are quite popular when talking about mining pools.
+We did not talk about pool hopping.
+We did not talk about PPS and FPPS and all these different rewards systems, but not in much detail.
+Partially is because I don't fully understand those systems.
+But partially is because, you know, we already explained this system and you guys are getting tired and our editors getting tired.
+So we might, we might actually come back to it some other time.
+
+Speaker 0: 00:29:04
+
+Right.
+Yeah.
+Maybe that's an episode on its own, I guess.
+Let's stick to Ocean for now.
+There's one other aspect about it that's kind of controversial, which is that they're filtering for quote unquote spam.
+They're filtering transactions that they consider to be spam.
+So the most often...
+
+Speaker 1: 00:29:26
+
+Yeah, so I believe to be precise, they are using Bitcoin Nod's default settings.
+So that's an alternative version of Bitcoin Core by Luke Dasher.
+And it does not relay transactions with an operator of more than 20 bytes, I believe.
+So that's less than the default in Bitcoin Core.
+And because it doesn't relay them, it doesn't have it in its mempool and so when it generates a block template these things are not in there.
+It also does not have a transaction accelerator right so so in general these big ordinal transactions are not in there.
+The big ones that so I guess there's three things right normal pools don't just they don't filter out stuff mostly with one exception that we talked about last episode.
+But they also don't include very large things.
+They don't include transactions over, I think it's 400 kilobyte.
+
+Speaker 0: 00:30:20
+
+Right.
+
+Speaker 1: 00:30:20
+
+So this pool doesn't put anything in there with opportunities more than 20 bytes.
+
+Speaker 0: 00:30:25
+
+Right.
+Yeah.
+I guess I'm not really sure.
+Do you have an opinion on this?
+Let's just start there or what would you, I guess the problem or the critique or the controversy or whatever you want to call it, is that this would potentially make the pool less profitable because if there's a transaction that pays a high fee, but has a too big up return, then this pool isn't going to, Ocean pool is not going to include it while another pool might.
+
+Speaker 1: 00:30:51
+
+Yeah, but the most fair comparison would be another equivalent of Ocean pool, Ocean two pool, which would include those transactions.
+And then I think it's fairly straightforward that the other pool would just make more money.
+
+Speaker 0: 00:31:03
+
+Yeah, well, let's break it down a little bit.
+So because I did discuss this with Bitcoin Mechanic and also Jason, the CTO.
+So what they will argue, I just want to mention what they will argue.
+So they will argue that this is not necessarily true because there are, yeah.
+So like you said, it's kind of an unfair comparison if you compare it to other mining pools.
+So it's not necessarily true.
+
+Speaker 1: 00:31:25
+
+I think if you compare it to an ocean two pool, it's very clear.
+It's better to include more, But if you compare it to actual other pools, it's a different story.
+
+Speaker 0: 00:31:33
+
+Right, exactly.
+And the reason for that is that Ocean does have other benefits that other pools don't have, including profitability benefits.
+So, one obvious example is some of the pools have, once in a while there's this thing in the news that someone accidentally paid a hundred Bitcoin fee or something like that.
+
+Speaker 1: 00:31:53
+
+That seems to be a trend.
+
+Speaker 0: 00:31:54
+
+And then the mining pool will pay it back just because they're being nice to whoever accidentally included that high fee.
+
+Speaker 1: 00:32:02
+
+They may be nice, so they may not want to get sued.
+Some combination of both.
+
+Speaker 0: 00:32:06
+
+Yeah, in either case, Ocean will not do that because they essentially cannot or well,
+
+Speaker 1: 00:32:12
+
+they can, but they will.
+
+Speaker 0: 00:32:13
+
+They cannot because the hashers are directly paid from the Coinbase, but now the hashers themselves have to decide if they want to give it back or not.
+
+Speaker 1: 00:32:20
+
+Yeah, that's true for the first.
+But it depends.
+So it depends on how quickly they figure out it's an accident.
+If they figure it out while it's in the mempool, they could theoretically not mine it, I guess that would be the easiest thing, Or they could mine it and then not include it in the rewards for those people.
+But that would obviously require some serious intervention and some very quick intervention.
+Now the miners...
+
+Speaker 0: 00:32:44
+
+Right now they're not doing it.
+
+Speaker 1: 00:32:45
+
+No, and the miners that they pay out after 100 blocks, they have 100 blocks to think about it.
+So they could again, you know, but then you would be treating the first 20 miners different from the rest.
+So it's certainly a lot less easy for them to decide that on behalf of the individual miners.
+
+Speaker 0: 00:33:03
+
+Yeah.
+Another argument would be that FPPS, which I mentioned, which most pool use, which is that the mining pool basically just pays you for a hash power, is essentially undervalued.
+And one of the reasons for that is that, miners will collect out of band payments.
+Wait, I don't know if it makes sense what I just said.
+
+Speaker 1: 00:33:23
+
+Well, so the problem is more about transparency.
+So if we very briefly explain FPP as it is basically saying that you get paid for the hash power that you're putting into it, which is then how much SATs should you be paid for your hash power and that calculation is based on the block reward plus the sort of the expected fees or the average fees over time or some whatever complicated algorithm.
+It's not that trivial to compare.
+So when a miner receives, when such a pool processes payments out of bound, like an accelerator, they may or may not pay their miners for that.
+It's non-trivial to figure out if that's happening or not.
+Whereas in this pool example, it's very clear when it's not happening.
+
+Speaker 0: 00:34:05
+
+Right.
+In either case, I think we both sort of agree that if there was an Ocean 2 pool that just does everything exactly the same as Ocean and somehow they also have the same size and same hash power, the same variance, the same lock.
+And Ocean does not include these transactions while Ocean 2Pool would, then Ocean 2Pool would at least be as profitable and usually more profitable.
+
+Speaker 1: 00:34:31
+
+Yes, and Ocean 2Pool could also have an out-of-band transaction accelerator and not pay the individual miners.
+However, it would be kind of obvious that their transaction is being included at a implausibly low fee.
+And so as a miner, you would definitely notice that and you'd say, Hey, I am definitely not getting sats for that because I can see exactly how many sats I am getting from these transactions.
+So, you know, somebody is getting the sats and it's not me.
+Therefore, you know, maybe I'll switch to another pool or yeah.
+
+Speaker 0: 00:35:01
+
+Right.
+Yeah, just to point this out, Jason and, Mechanic also disagree with it or this, or at least they weren't necessarily agreeing, they seem to be disagreeing.
+They seem to Their argument was that there could be more complex things going on, like child pays for parents type of stuff that Ocean 2 pool would not see an Ocean pool like their pool would actually include.
+And therefore they would still be more profitable.
+
+Speaker 1: 00:35:30
+
+The way you're describing that to me makes no sense, but that is because it's like a Chinese whispers game.
+So.
+
+Speaker 0: 00:35:35
+
+Yeah, right.
+I'm just sort of trying to convey someone else's argument here, which I'm not very convinced by, but you know, I'm, I am trying my best to, in the case anyone is wondering, the reason we don't have them on the podcast is because we just want to do our podcast in person, not over calls or internet or Zoom or whatever else is available.
+
+Speaker 1: 00:35:59
+
+Exactly, Which is also the reason why we didn't do a lot of episodes in the last couple of months.
+But we are back in this very cold country.
+And I guess that's all?
+
+Speaker 0: 00:36:07
+
+I think so, Sjoerd.
+
+Speaker 1: 00:36:08
+
+All right then, thank you for listening to Bitcoin.
+Explain.

--- a/bitcoin-explained/the-block-1-983-702-problem.md
+++ b/bitcoin-explained/the-block-1-983-702-problem.md
@@ -1,0 +1,1373 @@
+---
+title: "The Block 1,983,702 Problem"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://bitcoinexplainedpodcast.com/@nado/episodes/episode-87-the-block-1-983-702-problem-s7s3j
+tags: []
+speakers: ['Sjors Provoost', 'Aaron van Wirdum']
+categories: ['podcast']
+date: 2023-12-21
+summary: "In this episode of Bitcoin, Explained, Aaron and Sjors discuss the so-called “block 1,983,702 problem”. They explain how a bug in early Bitcoin implementations could in rare cases cause a loss of funds, or in a worst-case scenario even lead to consensus failures, while they also explain how BIP 30 and BIP 34 solved this problem. As it turns out, however, BIP 34 introduced a new problem, that could become an issue about twenty years from now…"
+---
+Speaker 0: 00:00:19
+
+Live from Utrecht, this is Bitcoin Explained.
+Hey Sjors.
+
+Speaker 1: 00:00:24
+
+So last time I read the sponsor and it was a complete disaster.
+So this time you're going to do it.
+As the song goes, Aaron reads ads, Aaron reads ads, Aaron reads ads.
+
+Speaker 0: 00:00:36
+
+Nice.
+I forgot all about the jingle.
+You haven't read any toots, what's it called?
+Boost.
+You haven't read any Boost for a while.
+
+Speaker 1: 00:00:46
+
+What's going on with that?
+No, we might do that later again.
+Because we've gone this hyper-commercialized entity now with sponsors and stuff.
+
+Speaker 0: 00:00:52
+
+True, yeah.
+Shors, do you know who our sponsor is?
+It's CoinKite.
+And they produce the cold card.
+You know what I love about the cold card?
+Besides the fact that they are our sponsor, Sjoerds.
+I love that they're Bitcoin only.
+I love that they're a hardware wallet.
+It's secure.
+It's for your Bitcoin.
+It's to store your Bitcoin on.
+How long is our read, Sjoerds?
+Did I get there yet?
+I think you're good.
+The cold card is great, get it.
+That's right.
+Shors, today we're discussing a very niche bug that I had never heard of, but apparently there's a bug in the Bitcoin protocol.
+
+Speaker 1: 00:01:31
+
+Well, there was a bug in the Bitcoin protocol.
+
+Speaker 0: 00:01:35
+
+Right, but there's still a problem.
+
+Speaker 1: 00:01:38
+
+There was a bug, then there was no bug, then there was a bug, then there was no bug.
+There's still a problem, but not a bug.
+
+Speaker 0: 00:01:45
+
+Right, okay, I see.
+So there was a bug, now there's no bug, but there's still a problem which is not a bug.
+
+Speaker 1: 00:01:51
+
+Well, it's kind of a bug, but it's not like a dangerous bug like the original thing.
+
+Speaker 0: 00:01:55
+
+Sounds pretty buggy.
+Anyway, so it's called the 1,983,702 problem.
+Did I say it right even?
+The block 1,983,702 problem.
+
+Speaker 1: 00:02:11
+
+Yeah, that sounds good.
+Or the block 198,3702 problem.
+
+Speaker 0: 00:02:14
+
+Right.
+So this will be a problem in.
+
+Speaker 1: 00:02:18
+
+Yeah, there's another term you could use is the BIP34 does not imply BIP30 problem.
+
+Speaker 0: 00:02:27
+
+I don't know which one is worse.
+They're both pretty bad.
+
+Speaker 1: 00:02:30
+
+Okay, cool.
+
+Speaker 0: 00:02:31
+
+So this will be a problem in block, well, again, 1,900,000 something.
+
+Speaker 1: 00:02:38
+
+Yeah, which is like a couple decades from now.
+
+Speaker 0: 00:02:40
+
+Yes, like 22 years from now, my sort of napkin math told me.
+
+Speaker 1: 00:02:44
+
+And to be clear, It's a problem, it's not like bad.
+
+Speaker 0: 00:02:49
+
+Right.
+Okay, but it is something that needs to be solved eventually, in some way or another.
+
+Speaker 1: 00:02:55
+
+It's better if we solve it, yeah.
+But it's not like the 2106 problem, which, like in the year 2106, the whole blockchain simply stops.
+That's definitely a problem.
+
+Speaker 0: 00:03:05
+
+Right, this is not a problem that's going to require a consensus change.
+
+Speaker 1: 00:03:09
+
+No, ideally it would.
+But not a hard fork.
+
+Speaker 0: 00:03:12
+
+Right, okay.
+How did you find about it?
+Like I said, I'd never heard of this.
+Is this just something you, this is your hobby you look for very niche things that no one else has heard about?
+
+Speaker 1: 00:03:23
+
+Well we sometimes need to scrape the bottle of the barrel for episodes titles, but in this case I was trying to understand a bug in StratMV2, something I'm working on recently, and had something to do with the Coinbase transactions and whether or not it has a witness.
+Turns out it does have a witness, or at least it can have a witness, which I didn't know, and That's why I kept banging my head against it.
+But as I was trying to understand how the code works, I was reading the code comments and I came across this like almost full page story about this problem.
+
+Speaker 0: 00:03:57
+
+Okay, I'm gonna just call it the 1,900,000 problem because I don't wanna read it in full every time.
+So the 1 million 900,000 problem, we'll start at the beginning.
+So you mentioned there was a bug.
+It all started with a bug, right?
+And this has been a bug in Bitcoin since the beginning?
+
+Speaker 1: 00:04:18
+
+Yes.
+
+Speaker 0: 00:04:19
+
+Like it's an OG Satoshi bug?
+
+Speaker 1: 00:04:21
+
+Exactly, an OG Satoshi bug, which is that it was possible for two identical transactions to exist, or more than one basically, identical transactions to exist in sequence.
+
+Speaker 0: 00:04:33
+
+It was or wasn't?
+
+Speaker 1: 00:04:35
+
+It was possible.
+
+Speaker 0: 00:04:35
+
+It was possible.
+
+Speaker 1: 00:04:37
+
+And this was creating a problem because, well, when the transaction exists twice, then the original one essentially just disappears.
+This has to do with how transactions work.
+
+Speaker 0: 00:04:51
+
+Yeah, let's halt here for a second.
+So how do you get two identical transactions?
+
+Speaker 1: 00:04:56
+
+Same hash.
+So the same hash means it's the same content.
+So it's the same inputs, the same outputs.
+And so typically you would expect this in a Coinbase transaction in the early days, because a Coinbase transaction doesn't have any inputs, or maybe it is the name of your pool, which would be the same if you were mining multiple blocks.
+And then the outputs might be the address that you're paying yourself to, which might also be the same of your pool.
+So if you mined in the early days two blocks to the same address and with the same pool name and you were like, I guess that,
+
+Speaker 0: 00:05:30
+
+yeah.
+That makes sense.
+So you're a pool in the early days, you have your Bitcoin address, one blah blah blah blah blah, because that was the early addresses, and you're mining new coins, so there's no inputs, and you just, these new 50 coins are sent to this one blah blah blah address.
+And if that happens twice, if you say you mine two blocks in a row, it's going to be the exact same transaction.
+
+Speaker 1: 00:05:54
+
+Yeah, however, it also would have to be the same amount, right?
+So this would be either a block with no transactions in it, so no fees.
+So the Coinbase amount would be exactly 50 Bitcoin back in the day, or it would be coincidentally the exact same total fees.
+The thing is, it only happened twice.
+
+Speaker 0: 00:06:14
+
+Especially In the early days, there were still a lot of transactions that didn't pay any fee, I guess.
+Or there was a fixed fee for a while.
+
+Speaker 1: 00:06:20
+
+Probably a fixed fee.
+So then maybe if you had...
+I don't know.
+I didn't look at those specific blocks.
+
+Speaker 0: 00:06:24
+
+Right.
+Anyways, that is the most likely reason why that would happen.
+Is it plausible that it could happen in any other circumstance to identical transactions?
+
+Speaker 1: 00:06:36
+
+Well, it could happen as a child of the coin.
+So if the Coinbase transactions are identical, then you could make another transaction.
+Basically, you could just replay another transaction from the past that spends that Coinbase transaction.
+So the whole history of that Coinbase could be repeated.
+So if somebody mines a block and then they send it to the Pirate Bay and they download a movie, you could redo all that history.
+
+Speaker 0: 00:07:00
+
+Yeah, It would just have to start from the same coinbase transaction that's already identical.
+That's the only way you can get more identical transactions.
+Exactly.
+You start from there, yeah.
+
+Speaker 1: 00:07:09
+
+Or if you break SHA-256.
+
+Speaker 0: 00:07:12
+
+Which is also an episode we recorded at some point, I think.
+
+Speaker 1: 00:07:17
+
+I don't think anybody broke SHA-256, but we did talk about hashes in general.
+
+Speaker 0: 00:07:21
+
+We talked about what it means to break it, I think.
+Anyways, I'm going on to tangents here.
+Okay, so that's how you can get identical transaction IDs. And so you said it's possible, so why is it a bug if it's possible?
+Because I thought you were gonna say it's impossible, but you said it's possible.
+Why is it a bug then?
+
+Speaker 1: 00:07:42
+
+It's possible, it was possible to be exact, but the bug is that it creates problems for you, especially for you as the recipient of that transaction.
+
+Speaker 0: 00:07:52
+
+Right, so the miner in this case?
+
+Speaker 1: 00:07:53
+
+Yeah, so the miner mines, say, 50 Bitcoin and doesn't spend it, and then a week later, he mines 50 Bitcoin and also doesn't spend it.
+Now he's like, oh, I've got 100 Bitcoins, how am I gonna spend this?
+Oh, I'm gonna make a transaction and this transaction points to a previous transaction, that's what a transaction is to do.
+So you would point to the original Coinbase transaction by its hash and then also by the position of the output in the Coinbase transaction.
+But then the question is, which one do you mean?
+And the Bitcoin Core software would simply look at the most recent one and would spend that.
+And There was only one entry, so it would just be overwritten.
+So the original coins would be gone.
+
+Speaker 0: 00:08:42
+
+Okay, you have to explain this, I think.
+Why would the original...
+So you say Bitcoin Core would just take the most recent one.
+So why wouldn't the older one just also still exist for next time you want to spend?
+
+Speaker 1: 00:08:53
+
+Well, so Bitcoin Core keeps track of a list of outputs that exist.
+Basically, the transaction hash and the identifier.
+So if you add another one that is the same, it would just overwrite it.
+
+Speaker 0: 00:09:05
+
+Oh, sorry, do you just mean the UTXO set here?
+
+Speaker 1: 00:09:08
+
+Yeah, although I think at the time the UTXO set worked a little different than it does now.
+But I think essentially it was the same thing.
+It's just a list of coins that exist.
+So it's a transaction hash and an identifier and whatever script you need to spend it.
+And so if you were to create the transaction again, that would just be the same entry in the database.
+So the database would think there's only one.
+
+Speaker 0: 00:09:29
+
+Okay, so not both transactions would be included in this database.
+It would just be considered as the same transaction, so there's only one.
+So then if you spend it, both are gone because they overlap.
+
+Speaker 1: 00:09:41
+
+Because you deleted one entry.
+So this can lead to quite strange situations.
+For example, let's say you mine a transaction once and then a couple blocks later you mine it again and then you spend it and so then it disappeared, right?
+That's one way, but let's say you mine one transaction.
+Sorry, yeah, let's do it again.
+You mine one transaction, you mine a couple other blocks, and then you mine the transaction again.
+Now, if there's a reorg, the blockchain undoes your most recent block, and then creates some other blocks.
+That means that your transaction has now disappeared from your point of view.
+
+Speaker 0: 00:10:29
+
+Yeah, yeah, Yeah, okay, I get it.
+So, oh yeah.
+So, yeah, let me try to re-explain that, even though it was kind of clear to me, but maybe if I re-explain that might help one other person out there.
+So, yeah, you're creating a blockchain, obviously, and then The first Coinbase transaction is included in block three, and then the next one is included in block seven.
+But then there's another block seven, and that's the blockchain that the network goes with.
+That becomes the longest chain.
+So now your second Coinbase transaction is deleted from your UTXO set, basically, or your database, and it's not like the one before that is not like automatically restored either.
+So now you lost both.
+
+Speaker 1: 00:11:12
+
+Yeah, you lost both.
+However, somebody else who just starts up a new blockchain, a Bitcoin blockchain, will never see the original second block.
+So they will only see the first block in which you do get the coinbase.
+And as far as they're concerned, it's still there.
+So now you have a consensus failure.
+Because part of the network believes that a coin exists and the other does not and that will explode as soon as somebody tries to spend it.
+
+Speaker 0: 00:11:33
+
+Yeah, or to put it a little bit more accurately, maybe...
+I mean, I think you're saying it technically accurately, but the more normie way of saying it is there's no consensus on who owns which coins.
+
+Speaker 1: 00:11:44
+
+Well, yeah, There's no consensus on who owns that, on whether that specific coin exists.
+
+Speaker 0: 00:11:48
+
+Not so much who owns it.
+Well, that's a technical way of saying it, right?
+
+Speaker 1: 00:11:51
+
+Well, it's not about who owns it, it's that it exists or not.
+So you can spend a coin that doesn't exist.
+It's not about not satisfying the script, but it's just about the coin not existing.
+
+Speaker 0: 00:12:01
+
+Yeah, you're right actually.
+In the real case, some nodes would actually think the coins don't exist at all anymore because yes, I see what you're saying.
+Yeah, you're right.
+Anyways, the important part is that the UTXO set or what, Sorry, why do you not call it the UTXO set?
+
+Speaker 1: 00:12:17
+
+Did you say back in the day was- So this is the part I'm a little vague on, but initially the concept that we call the UTXO set, so a list of coins that exist, is not something that Satoshi invented as such.
+I think we'll cover that again maybe in a future episode.
+But this idea of having a database of which coin exists and you just add and remove coins from it, I think at the time it was not like that.
+It was just a list of all transactions that were still relevant or something like that.
+It was less efficient.
+So, I think in 2018 or 2017, it was refactored into what we would now consider the UTXO set.
+
+Speaker 0: 00:12:58
+
+Okay.
+So, let's just...
+
+Speaker 1: 00:12:59
+
+But this less efficient implementation had the same problem.
+The modern UTXO set would definitely have this problem.
+And my understanding is the original one had two, even though it stored more data than we do now.
+
+Speaker 0: 00:13:10
+
+Anyways, the key point here being that the ownership records that every node holds would start to diverge.
+And if that starts to happen, that is a consensus failure.
+That you could get to a place where you try spending coins and it confirms on your end and it doesn't confirm on the other end and networks start to, it's chaos.
+Like that's, so that's potentially, that was a potential actual risk with this OG Satoshi bug.
+
+Speaker 1: 00:13:35
+
+Yeah, and as far as I know, what did happen was there were two instances of these duplicate coinbases.
+Basically miners losing 50 BTC.
+But I don't think there were cases of also re-orcs on top of that that would have created this mess.
+But maybe there was and nobody noticed it.
+Because the mess would not have been...
+Well, I think we would have noticed it now, yeah.
+
+Speaker 0: 00:13:58
+
+Probably right.
+That would have been very unlucky as well.
+Like, you've got to have an exact re-orc exactly on that block where this exact block happened.
+
+Speaker 1: 00:14:07
+
+Yeah, and because as far as we can tell it only happened twice, it might have happened more often in chains that never survived.
+
+Speaker 0: 00:14:14
+
+Well, no, then we would have the problem, right?
+
+Speaker 1: 00:14:17
+
+Well maybe we are the surviving chain where that didn't happen, but there may have been other chains where it did happen and it didn't survive.
+
+Speaker 0: 00:14:23
+
+Well we would have probably heard it then at some point, don't you think?
+Because then there would have been nodes with these different transaction records, UTXO, set, whatever you want to call it.
+
+Speaker 1: 00:14:32
+
+Yeah, but I mean, if this was long enough ago, maybe they just restarted the computer and just didn't care, but probably didn't happen.
+Fair.
+
+Speaker 0: 00:14:40
+
+All right.
+So this was the, again, this was the OG Satoshi bug.
+And This bug was fixed.
+
+Speaker 1: 00:14:47
+
+Exactly.
+And this is where BIP30 comes in.
+This was introduced in 2012.
+What BIP30 does is very simple.
+It says there shall never be two transactions with the same hash at the same time.
+
+Speaker 0: 00:15:01
+
+At the same time?
+
+Speaker 1: 00:15:02
+
+At the same time.
+As in, if you create a transaction right now, it's not allowed to already exist in the UTXO set.
+
+Speaker 0: 00:15:08
+
+Okay, but it's just an invalid transaction.
+So if the same thing would happen, if the miner would create this Coinbase transaction where he pays himself to the same address.
+The Bitcoin network nodes, my node, your node, would just say, this is not valid, you just wasted your energy, we're going to wait for a valid block.
+Exactly.
+Right.
+
+Speaker 1: 00:15:27
+
+Now, let's say they do that, they make a coinbase,
+
+Speaker 0: 00:15:32
+
+then they spend it, then they can make the same coinbase again.
+
+Speaker 1: 00:15:36
+
+That's no problem.
+So BIP30 does allow that.
+Right, okay.
+So that was great and that worked.
+The only problem is that this rule is a bit difficult to check, because it means that whenever you get a new block, for every transaction in that block, you have to make sure that it doesn't already exist, the transaction itself.
+So right now, whenever you check a block, you go through every transaction and you check that all its inputs exist, so it's spending from something that exists, but you do not check if the transaction itself exists, or at least you don't now because of what we'll discuss.
+But with Bit.30, you would have to do that.
+You'd have to do an extra check for every transaction.
+Like, hey, now that I've checked that all the inputs are valid, or whichever sequence we're going to do, does this transaction exist?
+
+Speaker 0: 00:16:25
+
+Right.
+So that was the case in 2012, for a brief while, at least, after BIP30 was deployed.
+And this sounds like it's an especially annoying or burdensome check because it's so unlikely that it's necessary, especially for all non-coinbase transactions.
+But just technically...
+
+Speaker 1: 00:16:44
+
+It's completely unnecessary in the sense that no miner would be this stupid, but of course if you don't check then they would be.
+
+Speaker 0: 00:16:50
+
+You have to check, but it's burdensome.
+
+Speaker 1: 00:16:52
+
+But it wastes some resources.
+I don't know how much, if it's like 1% or 10%, but it's annoying.
+
+Speaker 0: 00:17:00
+
+And also just in general, you want miners to be able to check the validity of new blocks or all nodes.
+You want them to be able to check for the as soon as possible.
+
+Speaker 1: 00:17:10
+
+Yeah, so every second you can shave off the checking time is better.
+So, bit 34 was introduced, which made this process more efficient.
+
+Speaker 0: 00:17:18
+
+When was this?
+
+Speaker 1: 00:17:18
+
+Same year, just a half a year later.
+That is to say...
+
+Speaker 0: 00:17:21
+
+And was this introduced especially because, before the reason we just mentioned?
+Yes.
+Okay, so it was like a performance improvement.
+
+Speaker 1: 00:17:29
+
+I think so.
+So, the little background is that BIP30 was a relatively simple software that could be deployed very quickly because they realized the problem and they wanted to fix it as quickly as possible so nobody would deliberately exploit it.
+BIP-34 was something that was deployed a bit more carefully, very much like the BIP9 style soft fork.
+So there was some signaling involved, block version number went up and you had like so many percent of the miners had to signal it, et cetera, et cetera.
+So BIP34 was a more thorough solution, but it was also deployed more carefully.
+So what does BIP34 do?
+Well, it makes sure that, well, that was the idea, that the Coinbase transaction is unique by definition by adding the block height to it.
+So every Coinbase transaction must start with the block height.
+And because it must start with the block height, it's going to be different than previous transactions which had a different block height, or previous Coinbase transactions had a different block height, so you won't have the duplicates.
+That is to say moving forward, you don't have to duplicate.
+
+Speaker 0: 00:18:33
+
+Yeah, okay, yeah, this makes sense.
+This way every Coinbase necessarily is unique, like every Coinbase transaction necessarily is unique because it's in a new block that has new block height.
+And therefore every transaction that comes from, that's spent from that coin is also unique.
+So now every transaction has to be unique.
+Yes.
+Okay, yeah, makes sense.
+Yeah.
+Good solution, Shorts, I like it.
+Who came up with this?
+
+Speaker 1: 00:18:58
+
+I think it was...
+I'm not sure.
+
+Speaker 0: 00:19:02
+
+Well, whoever came up with it, congratulations.
+Thank you.
+
+Speaker 1: 00:19:05
+
+I think it was...
+
+Speaker 0: 00:19:06
+
+However, I guess there's another problem you're going to mention about this solution or not.
+
+Speaker 1: 00:19:10
+
+I think the original one was Pieter Wuyle and the second one was Russell O'Connor.
+
+Speaker 0: 00:19:15
+
+Right.
+Okay.
+However, so I guess this is why we're making this episode.
+
+Speaker 1: 00:19:18
+
+No, Gavin Andresen.
+
+Speaker 0: 00:19:19
+
+Gavin Andresen.
+I could have guessed.
+Gavin, you messed up.
+
+Speaker 1: 00:19:25
+
+Well, I don't know.
+I mean, it's just he's the author, so it doesn't mean that he came up with it.
+
+Speaker 0: 00:19:30
+
+It was a joke, but maybe it's a kind of a sensitive joke at this point in time.
+Sure, go on.
+Because there is a problem.
+It introduced a problem.
+
+Speaker 1: 00:19:42
+
+Yes.
+Well, actually, it did not introduce a problem.
+So just having this rule is fine.
+
+Speaker 0: 00:19:49
+
+Okay.
+However...
+Good job, Gavin.
+However...
+
+Speaker 1: 00:19:52
+
+Oh. Exactly.
+So Gavin, whatever it was, he didn't do anything wrong.
+
+Speaker 0: 00:19:55
+
+Okay.
+
+Speaker 1: 00:19:56
+
+However, then in 2015, somebody tried to be smart and said, hey, we have this BIP 34, which means that we don't need to check for BIP 30 anymore.
+We can make it faster.
+So perhaps I said before in the episode, oh this was the reason the performance thing was the reason to introduce it.
+Maybe not.
+Maybe they did it because it was just a more elegant solution and it would prevent mistakes.
+But then a couple of years later, somebody realized, hey, we can actually make this faster by not checking BIP30 anymore.
+Because we know that the blocks must be unique, right?
+
+Speaker 0: 00:20:31
+
+Yeah, like I explained just now.
+I immediately got it.
+Why did it take these Bitcore core developers so long, George?
+
+Speaker 1: 00:20:37
+
+I don't know.
+So in 2015, that optimization was merged.
+And Well, then in 2018, so three years later, somebody realized, oh, oops,
+
+Speaker 0: 00:20:53
+
+that doesn't actually work.
+Wait, wait, wait, sorry, I lost the plot.
+Where are we now?
+What's the year?
+
+Speaker 1: 00:20:57
+
+Well, the year of the fix is 2018, but I guess the year of the realization was late 2017.
+So somewhere, I think it was October 2017, but this wasn't documented, but it kind of follows.
+Somebody realized, oh wait a minute, there are exceptions to this convenient rule.
+Remember that the rule of BIP-34 is that you put the height of the block at the beginning of the coinbase.
+So block number one would have height number one, etc.
+But that rule only applies starting with block, I don't know, 200,000 something.
+
+Speaker 0: 00:21:36
+
+It started being applied in 2012.
+
+Speaker 1: 00:21:39
+
+Yeah, and it started being applied from height number 220,000 or something like that.
+So then the question, and so from there on this rule is correct, but the problem is, and that's what people realize, is that it doesn't apply earlier.
+The rule wasn't active earlier.
+So what is actually in those earlier Coinbase transactions?
+Might there be numbers in those earlier Coinbase transactions, numbers that could represent a block height?
+The answer is yes.
+There were numbers in there.
+So there were older Coinbase transactions that had numbers in there that represented blocks that might occur in the future.
+
+Speaker 0: 00:22:12
+
+Okay, I know what you're saying, but you don't, The word represent is confusing here.
+There were just numbers in there and they could be interpreted as blocks from the future.
+
+Speaker 1: 00:22:21
+
+Yeah, either it was a very smart miner that foresaw that this problem was going to happen.
+
+Speaker 0: 00:22:25
+
+Like let's say, like there could have been an early miner that for whatever reason put the number a million in the Coinbase.
+
+Speaker 1: 00:22:34
+
+Yeah, so as the episode suggests, some miner put the number 1,983,702 in the Coinbase.
+
+Speaker 0: 00:22:41
+
+Right.
+
+Speaker 1: 00:22:41
+
+They didn't actually put that number in there, they were probably just writing their name, and the name, if you map it into how a computer reads it, might have looked like a big number.
+
+Speaker 0: 00:22:50
+
+Right.
+So, that's...
+Okay.
+So, there was a block in, like, say 2009, that starts with the number 1,900,000 something.
+So, by the time we actually get to block number 1,900,000, and that number has to be put in the Coinbase, there's a risk that it was a pretty, that's not gonna happen, right?
+Normally this would not happen,
+
+Speaker 1: 00:23:16
+
+But in theory, somebody could put, would have to put the same number in it.
+
+Speaker 0: 00:23:21
+
+Yes.
+
+Speaker 1: 00:23:22
+
+And then could, if they wanted to, wouldn't happen accidentally, make the rest of the Coinbase identical to that original transaction.
+
+Speaker 0: 00:23:29
+
+Right.
+So, yeah, so it would just have to spend the same amount of...
+Well, no, because there's 50 coins in the original Coinbase.
+
+Speaker 1: 00:23:37
+
+Much more.
+So, Merge looked at this specific transaction, and it turns out that that was a very lucky block.
+So, not only did it get a 50 Bitcoin Coinbase subsidy, which modern blocks don't get, it also got, I think, 50 or so BTC in fees.
+
+Speaker 0: 00:23:55
+
+That's good.
+
+Speaker 1: 00:23:56
+
+Yeah, so that's a very nice little block in the past.
+So if you wanted to reproduce this, your Coinbase transaction would have to create about 107 Bitcoin.
+It would have to spend 107 Bitcoin.
+That is only allowed if there is 107 Bitcoin worth of fees in that block.
+So that's never going to happen accidentally.
+
+Speaker 0: 00:24:15
+
+The other thing that has to happen is that the attacker would have to actually probably pay these fees himself and then burn it in this block.
+
+Speaker 1: 00:24:22
+
+Yes, because he cannot send it to some arbitrary destination.
+He has to reproduce the original Coinbase transaction, which means that his 107 Bitcoin has to go to the original owner of that Coinbase transaction.
+And so maybe this miner, you know, was frozen and wakes up and decides that this is a fun joke because he can just get the 107 Bitcoin back after doing this.
+But the other problem is it would have to be a non-SegWit block, because there was no SegWit back then, and SegWit adds something to the Coinbase.
+Well, you can't add that to the Coinbase, because then it would be a different block.
+So that means all the fees would have to be in non-SegWit transactions.
+There's all sorts of problems with this attack.
+One problem I can think about is that the next miner might be like, hey, there's a lot of fees in that original block, let me reorg it and mine it myself.
+But anyway, so but this could be done.
+And then you would have an identical transaction.
+
+Speaker 0: 00:25:18
+
+Hang on, hang on.
+Maybe first finish your sentence.
+
+Speaker 1: 00:25:21
+
+So if the attacker did that, they would have an identical transaction.
+And this is what people realized back in 2017, 2018.
+That's bad because that is a BIP-30 violation.
+But we are not checking BIP-30 anymore.
+So we should check BIP-30 again.
+That's the solution, basically.
+But it was a realization, like, oh, if we don't fix this, let me, you know, they would have to look at all the other numbers that were in all the transactions and see if this could happen earlier.
+
+Speaker 0: 00:25:50
+
+Okay, also, there could still be nodes that are checking BIP-30, right, in theory?
+
+Speaker 1: 00:25:54
+
+Yeah, that could be very old nodes.
+
+Speaker 0: 00:25:55
+
+Which could be sort of its own problem.
+
+Speaker 1: 00:25:57
+
+All the nodes from before 2015 would check BIP-30, and they would not approve this walk if this attacker did that.
+
+Speaker 0: 00:26:06
+
+Let me sort of cut down, shortcut to, okay, so let's say an actual, let's say just, you know, the classical example, like a state-level attacker that does want to burn a hundred bitcoins just to fuck with Bitcoin.
+
+Speaker 1: 00:26:20
+
+It doesn't have to be a state level attacker like a hundred Bitcoin is there's a lot of money but it's not a state level money.
+
+Speaker 0: 00:26:26
+
+Well hang on we're talking in 20 years from now Sjoerds.
+That's enough to buy North America.
+
+Speaker 1: 00:26:31
+
+Sure okay.
+
+Speaker 0: 00:26:33
+
+So a state level attacker wants to do this, what's the actual specific consequence?
+Would he also have to do the re-org thing?
+
+Speaker 1: 00:26:45
+
+Well, okay.
+So, the question is, first of all, you want to...
+
+Speaker 0: 00:26:47
+
+What's the actual risk?
+
+Speaker 1: 00:26:48
+
+Well, the first risk, and again, this has been fixed, but if it had not been fixed, the first risk is that they could violate bit 30.
+And that means that if you had a node from before 2015, it would not accept the block.
+New nodes would accept the block.
+So you get a chain split.
+And of course, you know, the majority of people would probably be on the modern nodes because you wouldn't be running 25 year old software, but it's still not healthy.
+
+Speaker 0: 00:27:11
+
+I mean, I'm pretty lazy with upgrading, to be honest.
+
+Speaker 1: 00:27:13
+
+Yeah, Well, your computer will force you to, probably.
+The other thing is, then you could have shenanigans.
+You could be talking about this reorg scenario.
+I don't know if that's useful for the attacker or just shoots himself in the foot.
+But there may be other weird things that you can do.
+Like it's not part of the...
+It shouldn't happen, basically.
+So you can try and reason about it, but you just want to prevent that from happening.
+
+Speaker 0: 00:27:39
+
+Okay, so we've got 22 years more or less to do something about this problem.
+
+Speaker 1: 00:27:44
+
+Yeah, We didn't wait that long.
+
+Speaker 0: 00:27:46
+
+What are we going to do?
+Oh, it's solved already?
+
+Speaker 1: 00:27:48
+
+Yes, in 2018, once they realized this problem was solved, and the solution is very simple, as of block 1,983,702, we just checked BIP-30 again.
+
+Speaker 0: 00:28:01
+
+Oh, we're back to checking BIP-30 with all these inefficiencies?
+
+Speaker 1: 00:28:05
+
+Yes.
+We won't now, but we will check it from that block onward.
+
+Speaker 0: 00:28:09
+
+Oh okay yeah that makes sense.
+
+Speaker 1: 00:28:11
+
+Which means we have 30 years to actually solve the problem but if we don't solve the problem we'll just check BIP30.
+
+Speaker 0: 00:28:16
+
+Right okay so in 20 years, so my Bitcoin Core node, well, I haven't upgraded my...
+Your Bitcoin Core node today, if you don't upgrade it, will still start checking for BIP-30 in 20 years from now?
+
+Speaker 1: 00:28:31
+
+That's right.
+
+Speaker 0: 00:28:32
+
+Oh, okay, interesting.
+
+Speaker 1: 00:28:33
+
+So, will your node probably, unless you didn't upgrade before 2018?
+
+Speaker 0: 00:28:38
+
+I'm not sure.
+No, probably I did.
+Yeah, no, I did upgrade since 2018.
+
+Speaker 1: 00:28:41
+
+There are so many security vulnerabilities in old Bitcoin nodes that this is the last of your problems.
+
+Speaker 0: 00:28:47
+
+I might be like three versions behind, but not that bad.
+
+Speaker 1: 00:28:50
+
+That's probably not too bad.
+But it gets more exciting than that because 1,983,702 is not the only block where this happens, it was an earlier block where it didn't happen but it could have or it could not have.
+
+Speaker 0: 00:29:06
+
+Wait sorry, there was?
+
+Speaker 1: 00:29:08
+
+There is block 490,897.
+
+Speaker 0: 00:29:11
+
+Are we talking about the future or the past?
+
+Speaker 1: 00:29:13
+
+The past.
+
+Speaker 0: 00:29:14
+
+Okay, what about it?
+
+Speaker 1: 00:29:15
+
+So this block was another one of those numbers that if you look at the all the coinbase transactions and you just find what number is in there, there were a couple of numbers in there.
+I think one number was so low like 200,000 it was before BIP34 was activated so it wasn't a problem because it was referring to something in the same era.
+But the next number was 490,897, which was in October 2017.
+And that block, if it wasn't for some lucky circumstances, could have already exposed this bug that we just talked about.
+So we wouldn't have had 30 years.
+No, we had two weeks, basically.
+At least the people who discovered this issue discovered it about two weeks before that block.
+
+Speaker 0: 00:30:01
+
+Interesting.
+
+Speaker 1: 00:30:01
+
+So this is like the asteroid coming towards the earth and NASA says oh we found an asteroid coming towards the earth but don't worry it's going to miss us by like at least a distance between here and the moon.
+It's fine.
+The only thing is we found out like two hours ago so if it had not missed us we would be dead and we would not have noticed it.
+
+Speaker 0: 00:30:17
+
+Right, right, right.
+
+Speaker 1: 00:30:18
+
+So this is one of those cases where yes, the bug isn't actually harmful, but if it had been harmful, there would have been only two weeks to deal with it.
+
+Speaker 0: 00:30:26
+
+Well, I mean, the bug could have been harmful if someone wants to exploit it.
+
+Speaker 1: 00:30:31
+
+No. So basically, by looking at the original transaction, they could see that it was not possible to exploit this.
+And the reason is because that Coinbase, yes, you could duplicate it, but it was already spent.
+And so you then need to reproduce the transactions that spent the Coinbase.
+And that is impossible because one of those transactions was spending another Coinbase.
+And that other Coinbase had a number in it, it's like 5 billion or some insane number.
+And we can never get to block 5 billion, at least not in the current code, right?
+Because it stops in 2106.
+
+Speaker 0: 00:31:06
+
+I see.
+
+Speaker 1: 00:31:06
+
+And then you have a hard fork.
+So with a hard fork, you can fix everything basically though.
+Anything after block 6 million or so is you don't have to worry about it.
+So that was good, but it was a close call.
+
+Speaker 0: 00:31:18
+
+With a hard fork you can fix anything.
+You can code shorts on that.
+
+Speaker 1: 00:31:23
+
+I'm not saying you're not introducing a new problem.
+
+Speaker 0: 00:31:25
+
+Are you pushing for a hard fork?
+
+Speaker 1: 00:31:27
+
+No, you can just wait until 2006.
+Right.
+2106.
+
+Speaker 0: 00:31:30
+
+Anyways, okay, we had a near miss in 2017.
+That turned out to not be a real problem.
+Now we got 20 years to either fix this problem or just ignore it because it's kind of already fixed.
+Anything else?
+
+Speaker 1: 00:31:46
+
+Yes, so the fix was shipped in 2018.
+It just basically says, okay, from this block, gonna check bit 30.
+So anybody running a modern node doesn't have to worry too much.
+Except on testnet, I think on testnet, I think on testnet, it's already checking bit 30 now.
+But who cares about TestNet?
+Because TestNet had the same kind of problem.
+
+Speaker 0: 00:32:11
+
+Yeah.
+
+Speaker 1: 00:32:12
+
+And it was fixed in the same way.
+
+Speaker 0: 00:32:14
+
+Okay.
+
+Speaker 1: 00:32:14
+
+And I think in TestNet there was another block like that in block 2,200,000 or something like that.
+
+Speaker 0: 00:32:21
+
+I don't care about testnet.
+
+Speaker 1: 00:32:22
+
+Testnet is already at block 2,500,000.
+So I think it's already checking pip 30.
+
+Speaker 0: 00:32:26
+
+Okay.
+
+Speaker 1: 00:32:27
+
+And there's a little code comment saying like, oh, I'm sure somebody will fix it before then.
+
+Speaker 0: 00:32:32
+
+Oh, I was going to ask, are there others?
+So we got 20 years, are there other solutions?
+Like, is this just it, or do we have other ways out of this conundrum that we find ourselves in?
+
+Speaker 1: 00:32:41
+
+So ideally, you want to have something in every block that we know was not in those blocks before BIP34 activated.
+And there's a bunch of candidates that were mentioned back in the day, but one candidate that I saw on Twitter, I think it was Kelvin Kim that said it, but I don't know if he came up with it or heard it from somebody else.
+And that is to basically make SegWit mandatory.
+And why?
+Right now...
+
+Speaker 0: 00:33:11
+
+Wait, wait.
+
+Speaker 1: 00:33:13
+
+SegWit commitments...
+
+Speaker 0: 00:33:14
+
+SegWit for every transaction mandatory?
+
+Speaker 1: 00:33:16
+
+No, just say for every block.
+
+Speaker 0: 00:33:18
+
+For every Coinbase transaction?
+Yes.
+Yeah, okay, that makes sense.
+
+Speaker 1: 00:33:21
+
+So every block has to commit to SegWit, has to include the SegWit commitment.
+The SegWit commitment is an up-return that refers to the tree of SegWit transactions.
+
+Speaker 0: 00:33:30
+
+Oh, wait, so are you just, oh.
+
+Speaker 1: 00:33:33
+
+So the transactions in the block don't have to be segwit.
+
+Speaker 0: 00:33:36
+
+Oh, so what you're saying is there could still be a block mine that has zero segwit transactions.
+But as soon as there's one segwit transaction in a block, you need the segwit thing in the Coinbase and therefore the transaction ID is different.
+
+Speaker 1: 00:33:48
+
+Yeah, and so right now, every time there is a SegWit block, yes, that's happened automatically.
+
+Speaker 0: 00:33:53
+
+Okay, has there been...
+
+Speaker 1: 00:33:53
+
+But empty blocks or blocks with no SegWit transactions do not commit to SegWit.
+But definitely empty blocks don't.
+However, they can, they just don't.
+Because they don't have to.
+So the change would be to say,
+
+Speaker 0: 00:34:04
+
+okay, you have to...
+Let me ask this question real quick.
+So, because I was going to ask, has there been any block mined that doesn't include any segwit transactions?
+Since segwit is out and that would be empty blocks.
+
+Speaker 1: 00:34:16
+
+Yes.
+
+Speaker 0: 00:34:16
+
+Right.
+Yeah.
+Makes sense.
+
+Speaker 1: 00:34:17
+
+Okay, go on.
+So basically, you know, the difficulty then would just be, okay, when you propose an empty block, which you have to do as a miner sometimes, very briefly, just make sure that it's a segwit block.
+So that would be a fairly simple soft fork.
+But there are other ideas out there.
+
+Speaker 0: 00:34:35
+
+It's probably still like, you know, in the sort of Puritan Bitcoin conservative, you know, which is a good philosophy, It's still kind of a cost to miners, which you're imposing on miners, like now they have to do something extra.
+Like it might still be controversial, I don't know.
+What do you think?
+
+Speaker 1: 00:34:54
+
+I don't know if it's a cost to miners because if they use Bitcoin Core to create the block templates, Bitcoin Core would just do it for them.
+
+Speaker 0: 00:35:01
+
+Well, the cost I'm referring to is you have to upgrade your Bitcoin Core node once in a while.
+It's not backwards compatible is what I'm basically saying.
+
+Speaker 1: 00:35:10
+
+Not for the miners, no, but that's always true for Soft Forks.
+Well, no, it's not always true for Soft Forks.
+Generally soft forks are done in such a way that if you only mine standard transactions, then you're going to be fine.
+But for this case, yes, miners would have to do something, just like they had in the first time it was introduced.
+So yeah, it's not entirely innocent.
+
+Speaker 0: 00:35:31
+
+It seems to me like a very plausible or reasonable solution.
+I'm just pointing out that even that might have some pushback.
+
+Speaker 1: 00:35:37
+
+Yeah, and the other solutions have this same, I think, have the same property, is that every miner would have to do it, or they might lose a block if they mine an empty block.
+
+Speaker 0: 00:35:44
+
+Right.
+
+Speaker 1: 00:35:45
+
+So I think another one was, okay, we just add the block height again, but we add it to a different field, like the lock time of the Coinbase transaction.
+
+Speaker 0: 00:35:54
+
+Because lock time wasn't activated back in?
+
+Speaker 1: 00:35:57
+
+Lock time wasn't used.
+As far as I know, again, you'd have to run a script and check.
+
+Speaker 0: 00:36:01
+
+Well, LockTime was introduced in 2015, right?
+
+Speaker 1: 00:36:05
+
+It's possible, but the field might, the field with the numbers were there.
+They didn't have any meaning, right?
+So you still have to check that they weren't used.
+But that's easy.
+I think this SegWit thing is the simplest one.
+The other option is we can buy ourselves another 20 years or so to block 3,808,179.
+
+Speaker 0: 00:36:27
+
+How?
+
+Speaker 1: 00:36:27
+
+Well, we would have to very carefully study block 1,983,702.
+Well not this block, but the original block that created it.
+And that Coinbase has been spent so it can already be recreated but you have to look at all the descendants.
+So this thing was spent to like around 10 different addresses and those could spend and those could spend.
+And if you can show that for every transaction descending from it, it was also using a Coinbase transaction that cannot be duplicated, maybe you can prove that it, you know, you could write a proof that it can never happen, gives you another 20 years.
+I think that's a stupid exercise compared to the simple software.
+
+Speaker 0: 00:37:04
+
+Well, you didn't figure it out for this podcast, if that's the case or not?
+
+Speaker 1: 00:37:07
+
+I did ask it on Stack Overflow in a comment somewhere, but no, I did not.
+
+Speaker 0: 00:37:11
+
+Sure, do you even do?
+What do you do for this podcast?
+Nothing.
+
+Speaker 1: 00:37:16
+
+Moving on.
+I did actually run a script to check that there are no upreturn transactions before BIP324 activated.
+
+Speaker 0: 00:37:26
+
+Wait, sorry, can you repeat that just for me?
+
+Speaker 1: 00:37:28
+
+There were no upreturn transactions in the Coinbase before BIP324 activated.
+
+Speaker 0: 00:37:33
+
+You did actually check that?
+
+Speaker 1: 00:37:35
+
+Yes.
+
+Speaker 0: 00:37:35
+
+Okay.
+
+Speaker 1: 00:37:35
+
+Which means that you don't even have to commit to SegWit, you just have to put Upperturn in a Coinbase transaction.
+That will be the rule.
+But of course, it's easier to just say SegWit.
+
+Speaker 0: 00:37:46
+
+Okay.
+So far, I think we agree SegWit is the most reasonable, low effort kind of way of doing this.
+I guess you could do Taproot as well, maybe, or no?
+Does it make sense?
+No, just SegWit.
+Taproot is just a subset.
+I'm just thinking out loud.
+
+Speaker 1: 00:38:00
+
+You want to keep it simple?
+So the funny thing is there was in 2019 a proposal...
+
+Speaker 0: 00:38:04
+
+I'm just thinking of soft forks that were introduced after 2015 to make me sound smart.
+But yeah, SegWit is the obvious thing here.
+Go on.
+
+Speaker 1: 00:38:12
+
+Yeah, so there was a great consensus cleanup proposal back in 2019 by Matt Corallo, Blue Matt, which contained a bunch of these very small fixes, kind of similar to this one, but not actually this one.
+
+Speaker 0: 00:38:27
+
+A fix for this specific problem?
+
+Speaker 1: 00:38:29
+
+Yeah, it was not in there.
+
+Speaker 0: 00:38:31
+
+So why do you even bring it up?
+
+Speaker 1: 00:38:33
+
+Because I was curious whether the great consensus cleanup would clean this up.
+
+Speaker 0: 00:38:36
+
+Right, and it doesn't.
+
+Speaker 1: 00:38:38
+
+But it would if you were to revive that proposal you should clean this up too.
+
+Speaker 0: 00:38:42
+
+Okay.
+
+Speaker 1: 00:38:42
+
+Because it also fixes the time warp attack and other things that we've discussed in other episodes.
+
+Speaker 0: 00:38:47
+
+Sure, yeah.
+Okay.
+
+Speaker 1: 00:38:51
+
+That's all I have.
+
+Speaker 0: 00:38:52
+
+Yeah, well, I mean, sounds to me like SegWit is the easy way to go, and also...
+
+Speaker 1: 00:38:57
+
+We have a few decades to figure this out.
+
+Speaker 0: 00:39:00
+
+We can think about it a while.
+All right, thanks, Jors.
+
+Speaker 1: 00:39:02
+
+All right, and thank you for listening to Bitcoin.
+Explained.

--- a/chaincode-labs/chaincode-podcast/2020-01-28-pieter-wuille-part1.md
+++ b/chaincode-labs/chaincode-podcast/2020-01-28-pieter-wuille-part1.md
@@ -1,18 +1,15 @@
 ---
-title: Pieter Wuille
+title: "Pieter Wuille (part 1 of 2)"
 transcript_by: Michael Folkson
 categories: ['podcast']
-tag: ['bitcoin core']
+tags: ['bitcoin-core']
 speakers: ['Pieter Wuille']
 date: 2020-01-28
 media: https://www.youtube.com/watch?v=s0XopkGcN9U
+episode: 1
+aliases: ['/chaincode-labs/chaincode-podcast/2020-01-28-pieter-wuille']
 ---
-
-Chaincode Labs podcast with Pieter Wuille
-
 Part 2: <https://www.youtube.com/watch?v=Q2lXSRcacAo>
-
-# Part 1
 
 Jonas: Welcome to the podcast
 

--- a/chaincode-labs/chaincode-podcast/2020-01-28-pieter-wuille-part2.md
+++ b/chaincode-labs/chaincode-podcast/2020-01-28-pieter-wuille-part2.md
@@ -1,0 +1,114 @@
+---
+title: Pieter Wuille (part 2 of 2)
+transcript_by: Michael Folkson
+categories: ['podcast']
+tags: ['bitcoin-core']
+speakers: ['Pieter Wuille']
+date: 2020-01-28
+media: https://www.youtube.com/watch?v=Q2lXSRcacAo
+episode: 2
+---
+Jonas: We are gonna pick up where we left off in episode 1 with a discussion of lessons learned from the 0.8 consensus failure. We then go on to cover `libsecp` and Pieter's thoughts about Bitcoin in 2020. We hope you enjoy this as much as we did.
+
+John: Ok I have a bunch of questions from that. One is what are the lessons from that?
+
+Pieter: One of the things I think learned from that is specifying what your consensus rules is really hard. That doesn’t mean you can’t try but who would’ve thought that a configuration setting in the database layer you are using actually leaked semantically into Bitcoin’s implicitly defined consensus rules. You can attribute that to human failure of course. We should’ve read the documentation and been aware of that.
+
+John: Would testing have caught this?
+
+Pieter: Probably things like modern fuzzing could’ve found this. Who knows right? There could be a bug in your C library. There can be a bug in your kernel. There can even be a bug in your CPU.
+
+John: In your hardware, anywhere.
+
+Pieter: Exactly. We can talk about the boundary in trying to abstract the part of the codebase that intentionally contributes to consensus but it is very hard to say clearly this code has no impact on consensus code because bugs can leak. I think one of the things to learn there is you really want software that is intended for use in a consensus system where not only you have the requirement that if everyone behaves correctly everybody accepts the right answer but also that everybody will disagree about what is an invalid piece of data in lockstep.
+
+John: That condition is much harder.
+
+Pieter: That’s much harder. It is not a usual thing you design things for. Maybe a good thing to bring up is [BIP66](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-July/009697.html) DER signature failure. You also had getting rid of OpenSSL on the list of things to talk about. Validation of signatures in Bitcoin’s reference code used to use OpenSSL for validation. Signatures were encoded in whatever data OpenSSL expects.
+
+John: Let’s take a step back and talk about Satoshi implementing Bitcoin. Satoshi wrote a white paper and then produced a reference implementation of Bitcoin. In that reference implementation there was a dependency on OpenSSL that was used for many things.
+
+Pieter: Correct. It was even used for computing the difficulty adjustment I think. It was used for signing. At some point it was used for mining.
+
+John: OpenSSL is a very widely used open source library. It has been deployed in many applications for many years. It wasn’t a bad choice to use OpenSSL.
+
+Pieter: I think it was an obvious choice from a standard software engineering perspective. It was a very reasonable thing to do without things we’ve since learned. What this meant that was even though ECDSA and secp256k1 curve have nicely written up specifications it wasn’t actually these specifications that defined Bitcoin signature validation rules. It was whatever the hell OpenSSL implemented. It turns out what OpenSSL implemented isn’t exactly what the specification says.
+
+John: And isn’t exactly consistent across different platforms.
+
+Pieter: Exactly. What we learned is that the OpenSSL signature parser, at the time, this has since been fixed, at the time allowed certain violations of the DER encoding specification which is a way of structured data in a parsable way that ECDSA specification refers to. OpenSSL used the I think now widely considered bad idea philosophy of being flexible in what you expect and being strict in your output exactly because of the inconsistencies it introduced. OpenSSL allowed signatures that violated the spec. This didn’t mean that this permitted forging a signature. Someone without a private key still could not construct anything that OpenSSL would accept. The problem was that someone with a private key might construct a signature that some versions would accept and others wouldn’t. Indeed in one of these permitted violations of DER it had a bound on the size of a length field and that bound was 32 bits for 32 bit platforms and 64 bits for 64 bit platforms. You could construct a signature at the time that says “The length of this integer is the next 5 bytes.” Those 5 bytes would just contain the number 32 or 33.
+
+John: To get a bit more specific. When we create a signature in ECDSA we have two values, a r value and a s value. Together that forms a signature. When we talk about encoding we’re talking about how we put those values into bits that we transmit across the network. DER encoding has a bunch of fields as well as the r and the s fields which are saying this is the length of the thing…
+
+Pieter: It would start by saying “Here is a concatenation of two things and it is this many bytes.” Then it would say “The first element is an integer and it is this many bytes.” Then you would actually have the data. “The next thing is an integer. It is this many bytes and here is the data.” Then Bitcoin adds a signature hash flag at the end but that is not part of the DER thing. This encoding of the r and s values could either say “It is the next n bytes up to 126” or something but if it is more than that it would include a marker that says “The length of the next field is given in the next n bytes.” The maximum length of that indirect size field was platform dependent in OpenSSL.
+
+John: So what do you do about that? You’ve discovered that Bitcoin is inconsistent with itself.
+
+Pieter: In a similar way that 0.7 and everything before it were inconsistent with itself due to this BDB lock issue. This was a much more concrete thing. You’d know exactly that I can construct a signature that these platforms will accept and these won’t. This wasn’t non-deterministic, this was deterministic. It was just dependent on the platform. The problem was fixing this wasn’t just a database update, this was implicitly part of our consensus rules. So what we needed to do was fix those consensus rules. That is what BIP66 was designed to do. The full rationale for BIP66 wasn’t revealed until long after it was deployed because this was so trivial to exploit. We did keep that hidden for a long time. BIP66’s stated goal which was correct in part was being able to move off OpenSSL. Let’s switch to a very well specified subset of signatures which everybody already produces. The signing code that people were using was sufficiently strict apart from a few other implementations this was generally not a problem. There were concerns at the time about miners that didn’t actually do full validation which would have made it even easier to broadcast such a signature on the network and get it included. That was interesting. Again taught us that even when you think you have a specification of what your consensus rules are everybody would’ve thought there’s this document that specifies ECDSA and secp256k1, that is our specification. It turns out it wasn’t.
+
+John: Consensus is slippery and touches everything.
+
+Jonas: When you’re sitting on an exploit like that, when you’re aware that something is open for exploitation how does that change the process and how do you think about coming up with a solution? You have a time constraint I guess.
+
+Pieter: Given it had been there for a long time there are trade-offs like who do you tell? How fast do you move to fix this because moving too fast might draw suspicion, moving too slow might get exploitable. Really these things always need to be considered on a case by case basis.
+
+John: I think that brings us nicely to the third PR or family of PRs that I have on my list or projects that you’ve contributed to which is libsecp. Can you give us a bit of background on what the genesis of that project was and where it came from?
+
+Pieter: It is not actually known I think why Satoshi picked the secp256k1 curve which was standardized but a very uncommon choice even at the time. I don’t dare to say when, maybe 2012, a post on Bitcointalk by Hal Finney about the special properties that this curve has and presumably why it was picked because it had this promise of accelerated implementation. What this was a particular technique that would allow faster implementation of elliptic curve implementation using an efficiently computable endomorphism. I won’t go into the details unless you want me to but it is a technique that gives you a percentage speedup for multiplication. It also makes certain requirements on the curve that not everyone is as happy with. It also gives you a small speedup for attackers but generally you want an exponential gap between the time it takes for an attacker and honest user anyway. Hal made this post saying “I looked into actually how to implement this particular optimization for the curve. Here is a bit of the math.” I think maybe he had some proof of concept code to show it but I was curious to see how much speed up is this actually going to give. I first tried to look at can I integrate this in OpenSSL itself? Because OpenSSL didn’t have any specialized implementation for this curve nor for this optimization technique in general. I started doing that but OpenSSL was an annoying codebase to work with to say it mildly. I thought how about I just make my own implementation from scratch just to see what the effect is. This started as a small hobby project thinking about… To be fair it is a much easier problem if you are only trying to implement one algorithm for one curve compared to a general library that tries to do everything in cryptography. I had the option of picking specific field representation for how are you going to represent the x and y coordinate. I learned some techniques from how other curves like ed25519 were implemented. I used some of those techniques. I started off by only implementing this optimized construction actually. It turned out when I was done it was maybe a factor of 4 faster than OpenSSL which was a very unexpected result. I hadn’t imagined that with fairly little work it would immediately be that much better. I guess it made sense just by being so specialized and being able to pick data structures that were specifically chosen for this curve rather than generic. You get actually a huge advantage.
+
+John: At this point this was still just a …
+
+Pieter: Yes. This was 2013 probably.
+
+John: Just a personal project. You weren’t thinking about it being part of Bitcoin Core.
+
+Pieter: I open sourced this. It attracted some contributions from Greg Maxwell, not Hal Finney, Peter Dettman who is a major contributor to the Bouncy Castle cryptographic library who by now probably came up with half of the algorithms in libsecp. Sometimes incremental improvements, sometimes original research and algebraic techniques to optimize things here and there. That has pushed the performance every time a couple of percent here and there, it adds up. It was assembly implementations for some routines added by people. After a while including lots and lots of testing that was added I think in 0.10. The signing code was switched in Bitcoin Core to it and then 0.12 the validation code was switched to it. This was after BIP66 had activated and we knew the rules on the network are exactly this DER encoding and nothing else. Interestingly by that time this efficient endomorphism GLV optimization was made optional and off by default in libsecp because of potential concern about patents around it. It is kind of ironic that this project started as an attempt to see the benefit was of this optimization and in the end choosing not to use it. But despite that it was still a very significant performance improvement over OpenSSL.
+
+John: Did you feel some urgency after BIP66 to move across to libsecp?
+
+Pieter: Not really. There was until very recently this vague concern that OpenSSL is a huge library with a huge attack surface. It was not designed with these consensus like applications in mind. At least as far as the signature validation parsing went I think at the time we felt that now we understand the scope of what OpenSSL does here and we had restricted sufficiently. We were fairly confident that that exactly wasn’t going to be a problem anymore. It was more the unknown unknowns for all the other things. I don’t know how fast, I don’t remember.
+
+John: To enumerate some of the benefits of switching to libsecp. It is extremely well tested. It has almost 100% code coverage I believe?
+
+Pieter: I think so.
+
+John: It is much faster than OpenSSL.
+
+Pieter: I think OpenSSL has caught up a bit since.
+
+John: There are many things about libsecp that make the API safe for users I think.
+
+Pieter: It is very much designed to be a hard to misuse library so it doesn’t really expose many low level operations that you might want from a generic cryptographic toolkit. It is designed with fairly high level APIs in mind like validate a signature, parse a signature, create a signature, derive a key and so forth.
+
+John: And lots of thought about constant time and avoiding…
+
+Pieter: Yes it was also from the start designed to be side channel resistant or at least the typical side channels you can protect against in software namely not having code paths that depend on secret data, not having memory accesses that depend on secret data. Despite that actually from the start it didn’t actually do that. There was some timing leak in very early code that was probably very hard to exploit. There was some table with precomputed values and you need to pick one of them based on secret data which is a problem. I think what we did was spread out the data so that there’s one byte of every table entry, say there’s 16 table entries, the first 16 bytes contain the first byte of every entry. Then the next 16 bytes contain the second byte of every entry and so on. You would think now it needs to access all groups of 16 bytes and given reasonable assumptions about architectures that generally have cache lines of 64 bytes you would think it is going to access every cache line so there shouldn’t be any leak anymore. It turns out there is a paper that actually shows even in this case you leak information because the first byte and the second byte… things in a cache line there is a very small difference in timing when they are available they can be observed. The fix is actually access every user conditional move construction where you actually read through every byte always.
+
+Jonas: As you talk about the history and certainly you’ve forgotten more about Bitcoin than most of us will ever learn, as you go back and you think about Satoshi’s reference implementation what are things that you would imagine you would want to do from the beginning? Things that are baked into the software that are difficult to shake even now as you’ve made contributions over the years that you would want to have done differently from the beginning?
+
+Pieter: You mean in code design or actually how Bitcoin works?
+
+Jonas: I think either. I think in terms of code design putting most of the code in one file wasn’t particularly helpful from the beginning. In terms of design choices.
+
+Pieter: It is of course slow to change things but I think given enough time if you are just talking about code design questions, if we have agreement we need to move to this other design we can do it whatever it is. You mention of course everything in one file in the 2010 codebase, the wallet and the consensus validation were all in one file including direct calls to the UI. That was really hard to reason about. The wallet tracking which outputs had been spent was actually done through a callback from the script verifier that would tell the wallet “Hey I’ve seen a validation with this input.” This was really hard to reason about. Of course these days there is a lot more complexity so I don’t want to claim that it is today easier to reason about things. Relative to its complexity and how much it was actually doing it was fairly hairy back then.
+
+John: Yeah I think we’ve made enormous strides. There’s a well defined interface between the wallet and the node so we can be confident that it is not involved in consensus.
+
+Pieter: Yes exactly. There is still a lot of work to do there too but I think we are getting there. Your talk about how Bitcoin could have been designed differently, that is a very hard question because you inevitably run into philosophical questions like if it were to have been designed differently would it have taken off? Especially if you go into questions like economic policy. That’s really hard to guess. I think there are lots of things we have learned. The concept of P2SH, what was clearly not present in the original design, it could have been done in a much simpler way if there would’ve been something like P2SH from the beginning. Yet it seems so obvious that this is preferable because before P2SH if you personally have some multisig policy, nobody was using multisig at the time, I guess that was part of the reason. But if you would’ve wanted to use a multisig policy to protect your coins with a device or cold storage key and an online key you would’ve somehow needed to convey to anyone who wanted to pay you to construct this script that includes your policy. That is annoying for multiple reasons like a) that is none of their business, why do I need to tell you “Hey look I’m using a multisig policy, it just for my own protection.” Secondly you would be paying the fees for paying to my complex script. That should not have been a concern of yours either. Lastly everything you put in an output leaks into the utxo set and as we now know the size of the utxo set is a critical scaling parameter of the system.
+
+John: I’ll add fourthly you would have really long addresses which would be kind of annoying.
+
+Pieter: Exactly you would need a standard for conveying that information that would be variable length inevitably if you go for big scripts. I don’t even think that all of these advantages were talked about the time when P2SH was created. I think it was just the last one. We have no address for this, it is really hard to create one. We can make it simpler by hashing the script first. I think the other advantages were things that we’re only realized later, how much of a better design this is. Of course we have since iterated on that, SegWit I think is clearly something that should have been done from the beginning. The fact signatures leak into the txid made it really hard for all kinds of more complex constructions. At the same time Bitcoin was the first thing in its class and it is unrealistic to expect it to get everything right from the beginning. Thankfully I think we’ve learned very well how to do safe upgrades to some of this.
+
+John: I agree entirely that this isn’t really an exercise for faulting Satoshi for the mistakes. But if I could wave a magic wand SegWit from the genesis block would be great because then the block could commit to the signatures, the wtxid whereas now it doesn’t.
+
+Pieter: In SegWit it does. In SegWit there is a coinbase output that contains a hash with the root of a Merkle tree that commits to all wtxids.
+
+John: Right, yes. But you don’t know that until you deserialize the transactions from the block which is a little bit annoying.
+
+Jonas: How do you think about how to spend your time on Bitcoin? There are so many ways to get nerd sniped and so many directions you could contribute to. What are you excited about and then how do you feel the pull of your personal excitement versus the pull of what’s necessary for someone like you to contribute to Bitcoin?
+
+Pieter: That is a good question, I don’t have a good answer. I try to work on things I’m excited about but sometimes this also means following through on something after you’ve lost some of the excitement about it because you have worked on this and people expect you to continue. It is a hard question. I expect this in general in open source to be a problem. There is no set direction and ultimately people choose how to spend their own time themselves. What am I excited about? I’m happy with the progress we’ve made with Taproot review and how that is going. I’m excited to see that progress further. There are some interesting changes people are working on related to the peer-to-peer protocol, things like Erlay that I contributed to. There are too many things to mention.
+
+John: I think Taproot, Schnorr plus Erlay is a good start for things to get excited about. Shall we wrap up there? Thank you Pieter.
+

--- a/chaincode-labs/chaincode-podcast/2020-02-11-jeremy-rubin-ctv.md
+++ b/chaincode-labs/chaincode-podcast/2020-02-11-jeremy-rubin-ctv.md
@@ -4,8 +4,9 @@ transcript_by: Michael Folkson
 categories: ['podcast']
 tag: ['op_checktemplateverify']
 speakers: ['Jeremy Rubin']
-date: 2020-02-11
+date: 2020-01-30
 media: https://www.youtube.com/watch?v=Lqcpk5o1Y2E
+episode: 3
 ---
 CTV BIP review workshop transcript: <https://diyhpl.us/wiki/transcripts/ctv-bip-review-workshop/>
 

--- a/chaincode-labs/chaincode-podcast/2020-03-12-matt-corallo-compact-blocks-fibre.md
+++ b/chaincode-labs/chaincode-podcast/2020-03-12-matt-corallo-compact-blocks-fibre.md
@@ -2,14 +2,12 @@
 title: Compact Blocks and Fibre
 transcript_by: Michael Folkson
 categories: ['podcast']
-tags: ['mining']
+tags: ['compact-block-relay']
 date: 2020-03-12
 speakers: ['Matt Corallo']
 media: https://www.youtube.com/watch?v=0uPDDELGjdo
+episode: 6
 ---
-
-Location: Chaincode Labs Podcast (Episode 6)
-
 # Intro
 
 Adam Jonas (AJ): Welcome Matt

--- a/chaincode-labs/chaincode-podcast/2020-11-09-enterprise-walletsutxo-management.md
+++ b/chaincode-labs/chaincode-podcast/2020-11-09-enterprise-walletsutxo-management.md
@@ -6,6 +6,7 @@ tags: ["payment-batching","coin-selection","rbf","segwit","taproot"]
 speakers: ["Mark Erhardt"]
 categories: ["Podcast"]
 date: 2020-11-09
+episode: 8
 ---
 
 Mark Erhardt: 00:00:00

--- a/chaincode-labs/chaincode-podcast/2021-05-12-matt-corallo-ldk.md
+++ b/chaincode-labs/chaincode-podcast/2021-05-12-matt-corallo-ldk.md
@@ -6,21 +6,19 @@ tags: ['lightning']
 speakers: ['Matt Corallo']
 date: 2021-05-12
 media: https://podcast.chaincode.com/2021/05/12/matt-corallo-13.html
+episode: 13
 ---
-
-Location: Chaincode Labs Podcast (Episode 13)
-
 Matt Corallo presentation at Advancing Bitcoin 2019: <https://btctranscripts.com/advancing-bitcoin/2019/2019-02-07-matt-corallo-rust-lightning/>
 
 rust-lightning repo: <https://github.com/rust-bitcoin/rust-lightning>
 
-# Intro
+## Intro
 
 Adam Jonas (AJ): Welcome back to the office Matt, glad to have you back on the podcast.
 
 Matt Corallo (MC): Thank you.
 
-# Update on LDK
+## Update on LDK
 
 AJ: We are going to start with LDK. Where are we at? What is going on?
 
@@ -28,7 +26,7 @@ MC: If listeners are aware LDK kind of grew out of a project that I started a fe
 
 Murch (M): Let me try to catch up everyone else. You are building a library in Rust and the idea is to make it usable for all sorts of other languages as if it were a native library for those.
 
-# Language bindings challenges
+## Language bindings challenges
 
 MC: Yeah, the core is written in Rust. Then we have different sample implementations, we have a number of different interfaces for it. It is a Lightning library not a Lightning node. Things like how you write the seed to disk, how it gets backed up, that kind of stuff is all dynamic and pluggable, there is just an interface for it. You have to do that yourself but then of course we have a number of different implementations that you might use off the shelf or sample implementations in a number of different languages. We invested an inordinate amount of time into building language binding support that are in a state we are really proud of. It took a lot more work than I ever guessed. It turns out all the language binding systems that exist that we came across in our research are really designed to stub out a function. You have some complicated function that takes a long time to run and you simplify it into a pure function probably, you stub that out into C or some other language and you call that from whatever your host language is. They are really not designed for a full object orientated interface with interfaces that the user might be able to plug into and that kind of thing. And especially, as far as I’m aware, no language binding systems except from the one that we built are really designed to map different memory models. LDK and rust-lightning are written in Rust and Rust has very clear object ownership semantics. Something owns an object, you can optionally have but you generally don’t have a lot of references flying around. You have references for short periods but they have clear ownership semantics. This being the exact opposite of languages like Java, Javascript etc where everything is basically an atomic reference counted pointer, a shared pointer in C++ terminology. It is assumed that everything just takes another reference count to this object. There is no clear ownership semantics anywhere so you really have to do a lot of work to map. If you have some Rust library and then you have Java objects that own these things you really have to map those ownership semantics correctly and do a lot of work with the [FFI](https://en.m.wikipedia.org/wiki/Foreign_function_interface) boundaries. We spent a lot of time building out stuff like that but we are really happy with where we ended up. We do have pretty good Java bindings now, we have Swift bindings, we have C and C++ bindings, we are working on Javascript bindings. We are happy with where we ended up but it took about a full year to really get there.
 
@@ -36,13 +34,13 @@ AJ: Is there ongoing maintenance as you upgrade the library? Is that something t
 
 MC: Yeah over the last few months we’ve gone from having demo applications written in Rust to users working on integrating LDK into their system in other languages, at least in a few cases in Java. When you get the first external people playing with a rich API you find all kinds of stuff. “This API is confusing, this isn’t clear. The easy way to do this is wrong.” We have been doing a lot of work on that front as well over the past number of months to really clean up the API and make sure that the easy way to do things, or the way that you might naively do things if you don’t read the docs closely enough, is also the right way and the safe way to use the library. We have been doing a lot of work on that front. Of course also keeping up with the Lightning spec that changes although slowly. We have a lot of things that we are trying to juggle right now.
 
-# Interoperability of Lightning
+## Interoperability of Lightning
 
 AJ: How do you think about interoperability with the other projects because that is clearly something that is an issue in the ecosystem?
 
 MC: It is interesting, the core of Lightning is pretty robustly interoperable across all the implementations that exist or that are actively maintained. But the edges have ended up very fragmented. There are brand names for all the different things. If you look at [zero value invoices](https://suredbits.com/zero-amount-invoices/). You generate an invoice with a zero value attached to it and some clients will treat that as any value. You enter a value or the sender enters a value. Some clients treat that as zero, some clients fail. That is one thing. There are a lot of these little “features” that have been added to different clients and they may be interoperable, they may not be interoperable. It depends on the UX and what client you are using. There are some issues that have cropped up there but at the same time this is also the experimentation phase of Lightning. You have different clients doing different things and experimenting. Then slowly things go back to the spec. You can look at the push payment stuff, I think the common brand name for it is [keysend](https://bitcoinops.org/en/topics/spontaneous-payments/). That is something that was experimented on, there are a few different designs. A number of clients have adopted now a common implementation of that but also it will probably be replaced with something else that is a little better that ends up in the formal spec. Part of it is that it is kind of a crappy UX right now in a lot of ways and also it is just these features that slowly migrate from experimentation and weird cross compatibility issues towards the spec. People agreeing with “We tested this, we’ve experimented with it, we’ve found something that works really well and now it is in the spec.” Because we’ve had so many other priorities we haven’t been as active in the experimentation area. That is also something where we have a fairly flexible API and you can do a lot of that experimentation at the next level. If you take LDK and use it to build a map you can experiment a lot with different potential Lightning features. That is something we haven’t spent as much time on as we probably should. We will get back to that as we round out some of the language binding features we’ve been working on. We have been keeping up with the spec.
 
-# LDK features
+## LDK features
 
 M: How does it plugin? You run a Bitcoin Core or some other Bitcoin software? You have your business logic somewhere else? That makes calls to the LDK library? You mentioned you have a broad and evolving interface? Have you thought about versioning that already because eventually Lightning will evolve to? How does that work?
 
@@ -62,7 +60,7 @@ MC: That is another area where we have an API, we don’t demand anything specif
 
 M: Bring your own blockchain data.
 
-# Bitcoin not having a spec versus Lightning having a spec
+## Bitcoin not having a spec versus Lightning having a spec
 
 AJ: You have spent most of your time in Bitcoin working on Bitcoin Core. Now you have transitioned to a different kind of project that has a spec which people open PRs to and have conversations about which is very different. Then there is also this environment of multiple implementations as opposed to one reference implementation that dominates the network. What are the pros and cons of that dynamic?
 
@@ -72,7 +70,7 @@ AJ: It might be interpreting that English in a very different way? Does that hap
 
 MC: Yeah and that has also been an issue for Lightning in the past. It has got a lot better but there were a number of issues early on, you still find things occasionally, where if two implementations disagree on the current state of a channel or the rules about what you can and can’t do in a channel they will force close. That can be a relatively critical denial of service vulnerability in the network. If you imagine c-lightning and lnd have understood the English of the spec slightly differently in some context and think the rules of the game are slightly different then a user might be able to forward a payment across any c-lightning to lnd or lnd to c-lightning channel and cause them to close the channel and potentially split the network. Split the Lightning Network such that no one can relay a payment between c-lighting and lnd or lnd and eclair or Electrum and eclair or whatever. It is fraught with these kinds of issues and it is something that is really tough to get right. There are a lot of things to do with Lightning. It is written, there’s this thing, it is working but there are a lot of edge cases and a lot of things that need tuning. Part of it can’t really be tuned until there is real world experience with people running this thing and people testing it, something that is being gathered. Part of it is a lot of work and really hard. Issues like this where you have to make sure that nodes exactly agree on what is going on, maybe you can reduce the likelihood of these kinds of issues with countermeasure strategies. It is a very different world from Bitcoin Core in that sense. With Bitcoin Core you are really worried about issues where you might split the network between old versions and new versions of Bitcoin Core but at least it is the same codebase so you can review an individual patch and say “This in the patch might split between something that does have this patch and something that doesn’t have this patch.” Not “I have to go read some Go code, some C code, some Rust code and some Python code and make sure that they are all doing the same thing.”
 
-# The state of the Lightning Network
+## The state of the Lightning Network
 
 AJ: I guess you have been talking about different vulnerabilities and different denial of service in Lightning. What is the state of the network now? Have we moved beyond reckless? How robust is this?
 
@@ -82,7 +80,7 @@ AJ: Are you observing cheaters on the network? Is that happening?
 
 MC: I think for the most part we haven’t seen much. Certainly occasionally someone might restore an old backup and accidentally broadcast an old state. I am not aware of any cases where someone has performed any of these kinds of long range, poor fee estimation attacks that anchor and such prevents. They are much more complicated, there is lower hanging fruit. I don’t think we have seen that. We also haven’t seen [channel jamming](https://bitcoinops.org/en/topics/channel-jamming-attacks/). It is something that gets talked about on the mailing list left and right and academic papers written about it. It is not like it is not out there. It is not like people aren’t aware of the potential for someone to denial of service attack the Lightning Network. But for the most part we haven’t seen it because why bother? It is a problem, people are working on fixing it. If it did happen payments would get stuck for a while and then people would work around it a little bit. But also it is one of these griefing attack denial of service things. There are a lot of issues to solve but it is also not something that is harming the immediate UX that people have today.
 
-# Eltoo and the punishment dynamic
+## Eltoo and the punishment dynamic
 
 AJ: I wanted to go back to the punishment dynamic. Clearly with [eltoo](https://bitcoinops.org/en/topics/eltoo/) those dynamics change. It doesn’t look like eltoo is going to be around the corner given how hard soft forks are. I would be interested in your take on punishment versus a little bit more forgiving dynamic with eltoo.
 
@@ -92,7 +90,7 @@ M: How would you even push for a punishment in eltoo where update transactions a
 
 MC: That is a good question. I don’t know offhand. It is possible you might have to reintroduce asymmetry, I don’t know if that is necessarily the worst thing in the world. The big win with eltoo is of course is you don’t have to store old states. You can just store one state. Having to store two states is not very different from one state. As long as you don’t have to store n states. Maybe there is a way to do that, I haven’t dug into that kind of thing. You have to have something. You can’t just say “If someone broadcasts an old state the counterparty has to spend onchain fees and a CPFP in order to get to the latest state”. Because again onchain fees can be non-trivial and you are exposed to some amount there. You have to do something but it is unclear exactly how you would require that.
 
-# Regulatory and KYC issues
+## Regulatory and KYC issues
 
 M: I have seen a few times the argument be made that you sort of have to trust your channel partners. They infer from that that the network is going to trend more towards trust relationships, at least for the major channels. It may become overlaid with KYC. Is that something that concerns you?
 
@@ -102,7 +100,7 @@ M: This week there was an [update](https://www.fatf-gafi.org/media/fatf/document
 
 MC: It is not something that we are worried about but it is also not our domain. It is more the domain of advocates. I think it is understood that that’s not really the current policy. As far as I’m aware no regulators have tried to push that as policy. There is uncertainty about it because regulators haven’t clarified that that’s absolutely never going to happen. That’s a question for policy advocates less us developers or potentially even lawyers. There’s a lot of issues with where the puck is going for regulation around Bitcoin payments. A lot of users, certainly almost everyone gets into Bitcoin by buying Bitcoin on some centralized platform. Those are really obvious chokepoints. That’s the key area that people like FATF are going after and targeting. Basically bringing any other named entity that they can under those kinds of regulations. There’s a world where they try to argue that any Lightning node is also bound by those regulations. That’s not really materially different from them arguing that every node is bound by those regulations or that anyone who has a wallet is bound by regulations that say they have to KYC their counterparty. From a technical perspective they can argue that but it doesn’t really change anything. If you are a Coinbase or someone and you are running a Lightning node and FATF says “Any payment you send or receive period including on your Lightning node needs KYC”, that is a problem in of itself. Lightning is unrelated. You see things like decentralized mixing services, regulators would love to shut that down but at the end of the day it is just this pure technical thing that exists. You can’t really go after that directly. The same is true for Lightning, the same is true for Bitcoin broadly, the same is true for decentralized mixers. The real question is what kind of KYC requirements are they going to try to apply to anyone making a Bitcoin transaction and to these exchanges that people buy from? Are you going to be able to withdraw your coins onto your own wallet without having to KYC anyone you ever transact with? Those are big questions. How that applies to Lightning, it could apply to Lightning but so what? It applies to everything and that is a problem in of itself. It is not specific to Lightning.
 
-# Future of LDK
+## Future of LDK
 
 AJ: Where does LDK go from here?
 

--- a/chaincode-labs/chaincode-podcast/_index.md
+++ b/chaincode-labs/chaincode-podcast/_index.md
@@ -1,5 +1,8 @@
 ---
 title: Chaincode Podcast
+hosts: ["Adam Jonas", "Mark Erhardt"]
+source: "https://anchor.fm/s/12fe0620/podcast/rss"
+transcription_coverage: full
 ---
 
 {{< childpages >}}

--- a/chaincode-labs/chaincode-podcast/address-relay.md
+++ b/chaincode-labs/chaincode-podcast/address-relay.md
@@ -1,0 +1,776 @@
+---
+title: "Address Relay"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://podcasters.spotify.com/pod/show/chaincode/episodes/Martin-Zumsande-and-Address-Relay---Episode-20-e1if91d
+tags: ['bitcoin-core', 'p2p']
+speakers: ['Martin Zumsande']
+categories: ['podcast']
+date: 2022-05-13
+episode: 20
+summary: "Martin Zumsande joins us to tell us about the address spam in the summer of 2021 and his interests in AddrRelay and Bitcoin Core development."
+---
+Speaker 0: 00:00:00
+
+In Adromain you also have this distinction between the new and the tried tables.
+So the new tables are for unverified addresses that someone just sent you and you don't know whether they are good, whether there's really a Bitcoin node behind them.
+And the tried table is addresses that you've been connected to in the past.
+So at some point, at least in the past, you know, they were your peers at some point.
+
+Speaker 1: 00:00:19
+
+Right.
+And you also need to make sure that you get some fresh blood in there, so you don't get sequestered into some part of the network.
+And then, I don't know, you go on vacation and your node was offline for a week and you come back and nobody's online anymore.
+You need to constantly keep hearing about new nodes.
+Hi, Jonas.
+
+Speaker 2: 00:00:45
+
+Hey, Murch.
+Glad to get you back in the studio before you rush off to London.
+And we're gonna be talking to Martin today, huh?
+
+Speaker 1: 00:00:53
+
+Yeah, yeah.
+We heard a talk by him yesterday already, so we're kind of prepped.
+
+Speaker 2: 00:00:57
+
+That's better than usual, isn't it?
+
+Speaker 1: 00:00:59
+
+Yeah, yeah, We have a good idea what we'll be talking about already.
+We did a few peer-to-peer topics already earlier with Amitie and Peter.
+But I think we're going to look at different aspects of peer-to-peer this time.
+
+Speaker 2: 00:01:12
+
+Very good.
+Well, Martin's been with us for a couple of weeks.
+We finally dragged him in the studio and hope you enjoy the episode.
+Welcome to the Chaincode Podcast, Martin.
+
+Speaker 0: 00:01:32
+
+Hi, thank you for having me here.
+
+Speaker 2: 00:01:34
+
+Absolutely.
+It's great to have you in the office these last couple of weeks.
+
+## His background
+
+Speaker 2: 00:01:37
+
+So today we want to hear a little bit more about your background, sort of how you got to working on Bitcoin Core, and then some of the things you're working on.
+So tell us, where do you come from?
+
+Speaker 0: 00:01:48
+
+Yeah, I'm originally from Germany, and I'm a physicist.
+I did my diploma and PhD in physics.
+
+Speaker 2: 00:01:56
+
+And what specifically in physics?
+Physics is pretty broad.
+
+Speaker 0: 00:01:58
+
+Yeah, I was doing statistical mechanics for my diploma thesis, like doing mostly simulations already, so a lot of computational work.
+And then for my PhD, I worked in the field of systems biology, which is like a mix of physics, math, and biology.
+So somehow I tried to apply some physical techniques on problems from biology such as bone remodeling or some signal pathways in the cells.
+So that's what I did.
+But that's been a long time ago I left science to work in the industry and I worked as a consultant for banks until I found about Bitcoin.
+
+Speaker 2: 00:02:38
+
+Well, having a physicist who's now spent some time at banks, I can see the progression to something like Bitcoin.
+
+## Getting interested in Bitcoin
+
+Speaker 2: 00:02:45
+
+How did you follow up on Bitcoin Core and how did you start working on it?
+
+Speaker 0: 00:02:49
+
+Well, I got interested in this space at first, not so much technical, but trying to understand how Bitcoin works.
+There was an essay I read that I liked very much and made me feel like I understood Bitcoin better, which was by also a physicist, I think, Michael Nielsen.
+He had a blog post there.
+And that was the first time I thought I really understood Bitcoin on a certain level, of course, and went deeper into it.
+I wanted to really understand how it works at a lower level, at the lowest level, the level of code.
+And I got interested in Bitcoin Core and started contributing the small thing first.
+Also, I still had a job at the same time, so I couldn't do this full-time.
+So I picked some smaller project, reviewed some PR, participated in the review club, which was great, which also started at the same time when I got interested in Bitcoin, and yeah, here I am.
+
+Speaker 2: 00:03:40
+
+Very good.
+I think Waxwing is a physicist, isn't he?
+Is Waxwing a physicist?
+
+Speaker 1: 00:03:45
+
+He's a mathematician, I think.
+
+Speaker 2: 00:03:46
+
+Oh, okay, Well.
+
+Speaker 1: 00:03:47
+
+I think he used to be a math teacher.
+
+Speaker 2: 00:03:50
+
+Cool.
+Well, we'll edit that part out.
+I was wrong about that.
+
+## How to approach P2P
+
+Speaker 2: 00:03:55
+
+So you seem to spend more of your time at Bitcoin Core lately in the P2P area.
+So tell us why that area and what's interesting you there.
+
+Speaker 0: 00:04:07
+
+I think I've been interested mostly in P2P from the start.
+It's just that I have more time now to work on these problems.
+It is the field that interests me most, And mostly because I think it's not only about the code, I'm gonna say in the code, but about the network, like how all these different agents run their own code, some different versions of Bitcoin Core, some other implementations, whatever, they all work together.
+And on a systems level, some behavior comes into play that is larger than just the parts.
+So it all works together, and it needs to be secured.
+There are several ways one could attack Bitcoin Core or the Bitcoin network and making sure that this works well when everyone plays nice together and it's also resistance against attacks.
+That is something that I find really interesting.
+
+Speaker 1: 00:04:59
+
+Yeah, I think One of the interesting things is that the credo is never to trust another node for what they tell you, because they might be lying.
+So on the one hand, you have to make it work locally and you have to have an emergent behavior across the whole set of participants that is not wasteful, but still gets everybody all the information they need.
+I can see the appeal.
+
+Speaker 2: 00:05:26
+
+How do you approach the different trade-offs?
+Because when we talked to, We've had Peter on the podcast talking about P2P.
+We've had a media on the podcast talking about P2P.
+It's seemed very nuanced.
+How do you think about those trade-offs and understanding when you pull this lever, something else pops up over there?
+And also the history and the context of P2P, because some of it in some cases came out of Peter's head, some of it is deliberate.
+There still seems to be some DOS vectors in there.
+So how do you think about all that?
+
+Speaker 0: 00:05:57
+
+Well, I think the one thing is to try to really read the code and not read it once, but read it many times and try to find new nuances.
+Why is that that way?
+If you find something that interests you, and one of the things that you should do if there is something that you don't really understand, but then often you have the urge to say, I'm sure someone has thought about it and I'll maybe think of it another time and let's concentrate on something else for now.
+And I think these exactly are the points where most people do the same and where it's interesting to look deeper and really answer the questions you have yourself and until you know or are sure you have a solution.
+And sometimes, yeah, you found something that some people haven't thought of before.
+And then you maybe create PR to fix this.
+And yeah.
+
+Speaker 1: 00:06:42
+
+So you're saying Bitcoin developers are like peer-to-peer nodes.
+They don't trust what other people have done?
+
+Speaker 0: 00:06:48
+
+Yeah, I mean you should never really trust the code that it works.
+I mean it's not necessarily that someone has written bad code on purpose, but maybe something that used to work once stopped working because of something that was done in another part of the code base and there are many ways that things could go wrong.
+And so I think it's always best to check for yourself how the code works and that way you also find ideas of things to change.
+I think it's sometimes it's good just to read code and try to make sure you really understand it well.
+And that's where you find ideas for ways to improve the code by yourself.
+Sometimes better than going into a code section like with the purpose.
+I'm going to change this now, because this might lead to changes that are not So great.
+
+## The network is changing
+
+Speaker 1: 00:07:31
+
+Yeah, this actually reminds me of one of the topics that came up at BitDevs this week, where we talked about Jameson Lobs' observation that the network appears to get slower because more and more of the nodes are on home connections and core connections.
+So there's fewer slots on IPv4 available for other participants.
+So these magic values that were picked, how many peers people or nodes have, might not scale to everybody being on a broadband connection at home.
+So it's not only that the code and all the Bitcoin core node around it changes, but also the reality of the network changes.
+So it's sort of multivariable emergent behavior.
+
+Speaker 2: 00:08:15
+
+Yeah, it will continue to emerge because we continue to try to encourage people running their nodes on Raspberry Pis in remote locations.
+And what may be good for decentralization may not be so great for bootstrapping and initial block download and things like that.
+
+Speaker 0: 00:08:29
+
+Yeah, and some things just happen because people choose different ways to participate in the Bitcoin network.
+For example, I just recently was really surprised to see that there are like so many nodes using Tor right now.
+So I think there are even if you look at some statistics website, there are bit nodes, there are even more peers in the network that are using Tor than that are using IPv4.
+
+Speaker 1: 00:08:50
+
+So reachable nodes.
+
+Speaker 0: 00:08:52
+
+Reachable nodes.
+And that is something like a very new development.
+I don't think it was like this three or four years ago.
+
+Speaker 2: 00:08:57
+
+I feel like that's the Umbral effect.
+
+Speaker 1: 00:09:00
+
+Yeah, Raspi, Blitz and Umbral and a few other of those home node packages are configured to automatically only connect to Tor.
+I think it's part of it is that it is not trivial to puncture NAT, local area network and open up the ports.
+And if you have a Tor connection, you basically do that automatically.
+You are configured to receive from outside.
+So I think that might have something to do with it.
+And also that people that run Lightning nodes, especially don't want to reveal their IP address.
+Because It sort of is a hot wallet.
+
+## What's the purpose of the Address Manager (AddrMan)?
+
+Speaker 1: 00:09:33
+
+So Adderman, what's the goal of the address manager?
+
+Speaker 0: 00:09:36
+
+The goal of the address manager, I would say, is to have a good variety of peers to find to connect to.
+So you don't want to have all your peers be from the same IP range.
+Or you want to have a good variety there.
+You also only have a limited amount of addresses you can save.
+You don't want to have a system where it can overwhelm you like write up your disk.
+So you also need to have like a limited amount.
+So you have like a restricted number of addresses that fit there.
+And in Adromain you also have this distinction between the new and the tried tables.
+So the new tables are for unverified addresses that someone just sent you and you don't know whether they are good, whether there's really a Bitcoin node behind them.
+And the tried table is addresses that you've been connected to in the past.
+So at some point, at least in the past, you know, they were valid peers and they were your peers at some point.
+
+Speaker 1: 00:10:25
+
+Right.
+And you also need to make sure that you get some fresh blood in there.
+So you don't get sequestered into some part of the network and then, I don't know, you go on vacation and your node was offline for a week and you come back and nobody's online anymore or things like that.
+So you need to constantly keep hearing about new nodes.
+
+Speaker 0: 00:10:43
+
+Yes, and that means that old nodes will be overwritten at some point.
+If you haven't heard from them for a long time, they will be like new nodes that have a higher probability of actually being there on the network still.
+They will get a preference and the old one might be replaced by them.
+
+## Peering differences to LN nodes
+
+Speaker 2: 00:11:00
+
+I think there's a big difference between something like this and the Lightning Network is that these ephemeral connections between Bitcoin nodes.
+I was surprised when I first booted up a node to watch those connections turnover and find them in your logs, as opposed to Lightning, which is much more like you want to establish yourself as a good member of the community and consistent.
+And like, unless you're going on chain, those are pretty permanent connections.
+
+Speaker 1: 00:11:21
+
+Right.
+Especially since you want to talk about a channel you have with them, you would be permanently peering with those.
+But with Bitcoin peers, it's, it's very exchangeable.
+You just need somebody that talks to you, right?
+So on the one hand, you do want some persistence because you don't want to give an opportunity to an attacker to completely replace all your peers and eclipse you.
+But on the other hand, you do want some mixed fruit.
+So you keep being well connected to the whole Bitcoin network.
+
+Speaker 0: 00:11:48
+
+And there is one important thing that is different from the Lightning Network in Bitcoin.
+You don't want to be the network public.
+So you don't want your peers or anyone else to know which nodes you are currently connected to.
+Right.
+That is something that is, I think in Lightning Network, it's being published, but at least for the public nodes and in Bitcoin Core, this is something that nobody should be able to get this information out of you.
+
+## Ethan Heilman's talk on Network Partitioning Attacks
+
+Speaker 2: 00:12:10
+
+Yeah, I think one of the clearest explanations of the trade-offs here was Ethan Heilman give a talk at the residency and there's a video, we can put that in the show notes, where he talks about just sort of like, I mean, it's really in the context of Eclipse attacks, but he really dives into the new and tried table and the different considerations there.
+
+## Addrman and eclipse attacks
+
+Speaker 2: 00:12:27
+
+And then there's a wiki page on the DevWiki that goes into how that's evolved over the last seven years since that paper came out, seven years?
+So anyway, if you're interested in more reading, there's stuff there.
+
+Speaker 0: 00:12:38
+
+Yeah, it's a great article.
+
+Speaker 2: 00:12:39
+
+So we did a couple episodes with Amiti 15 and 16, that was in October.
+And then Peter joined for that for episode 16.
+We covered a little bit of AdderMan and AdderRelay.
+But those are some areas that you're also spending some time into.
+So why those areas of the code?
+
+## AddrRelay and the role of node addresses
+
+Speaker 2: 00:12:55
+
+What is interesting there?
+And yeah, and why spend so much time?
+
+Speaker 0: 00:12:59
+
+Yeah, I mean, I'm very interested in AdderRelay.
+It's different than the other types of relay like blocks where you need proof of work, transactions where you spend some Bitcoin, whereas for an address to relay you don't really have to do any kind of work to relay it.
+But we still need those.
+Nodes need addresses to find other nodes to connect to.
+So it's on the one hand, it's easy to spam the network with addresses.
+On the other hand, it's important that Address Realize still works as good as possible so that nodes have a good variety of peers to connect to, that they can find peers quickly and to get all of these different goals and make them work together.
+And that is something I find really challenging and interesting.
+
+## Getting connected to the network
+
+Speaker 1: 00:13:38
+
+So maybe we can briefly give an overview of how nodes get addresses in the first place.
+If you start with a fresh node, how do you get connected to the network and how do you hear more about other peers in the network after?
+
+Speaker 0: 00:13:51
+
+Yeah, there are different ways of getting addresses.
+Like for a new node in the network, they would query the DNS seeds.
+Those are like centralized seeds that are run by Bitconners and they will give you a small number of addresses that will help you bootstrap.
+They are not meant to be a source of addresses forever but ideally just once when you are new to the network they will give you something to start with and then you build up your own address database and use that in the future.
+But for that to be possible you need more ways of relaying addresses to the network and there are two ways I would say.
+
+## Self-announcements
+
+Speaker 0: 00:14:24
+
+One of them is the address gossip relay.
+So basically once a day a node will self advertise its address to the network, send it to its peers, and those peers will take it, pick it up, and add it to their address database, but also will relay it a bit further to some of their peers, usually two, sometimes between one or two.
+And this helps an address propagate over the network, But there's like a certain system for this, some algorithm in place that makes it sure that it doesn't go on forever.
+We don't want to spend the network with a given address.
+So this will only work for like 10 minutes or so.
+And after that it will stop.
+And maybe on the next day we try again, But yeah, that is the gossip relay.
+And that is how nodes self-advertisements relate to the network.
+
+## Address spam in summer 2021 and peer distribution
+
+Speaker 2: 00:15:06
+
+So we've seen even within the last year, people try to mess with that.
+I know that Peter and Amiti will be feeling over this in their episode, but what did you observe and how are we addressing that going forward?
+
+Speaker 0: 00:15:16
+
+Yeah, actually, that was in last summer, There was suddenly a huge spike in the traffic of addresses being relayed and it was really interesting to see this unravel in real time.
+It was some kind of attacker who would use a botnet to spam the network with addresses that were not its own, They were just randomly generated IPv4 addresses.
+They had a number of nodes that did that.
+They connected to random peers, send them like 5,000 addresses, and disconnected, and did that again to some other peers.
+And there were like maybe 30, 40 peers doing this at the same time.
+And this was going on for quite a long time, like for two months or so.
+
+Speaker 2: 00:15:49
+
+And what's your theory?
+Research, harming the network, what's the motivation?
+
+Speaker 0: 00:15:54
+
+Yeah, I can only speculate because I think it is not known.
+
+Speaker 2: 00:15:58
+
+Could have been you.
+You don't have to speculate.
+It could have been you.
+Yeah.
+You seem to know a lot about it.
+
+Speaker 0: 00:16:03
+
+Yeah.
+There are different theories.
+I mean, the attacker, they might have had the intention to attack the network, to just, they might have had the intention to do harm to the network, make it impossible for new nodes to find peers.
+But that's just one theory.
+And it's also possible that these were researchers that were people who wanted to analyze the topology of the network because they did this in a very special way.
+They didn't send huge chunks of addresses that would only reach the victim that would receive them and the victim wouldn't propagate them any further.
+What they did was they split these up into very small packages with up to 10 addresses and they sent a lot of these small packages.
+So what this did was this made use of the address propagation algorithm in Bitcoin Core because Bitcoin Core, when it would receive up to 10 addresses in a package, they would distribute them to the peers and send them further along.
+So the attackers, they might have had the intention to use this in order to find out how many peers their victim was connected to.
+So you can do this.
+I mean, you need one attacker node that sends the addresses and you need one detection node that would also connect to the victim and just see how many addresses get relayed to this node.
+And you can do the math there and you can figure out this node, our victim node has 100 connections or something.
+
+Speaker 1: 00:17:20
+
+You talked about this yesterday to us already, so I understand I think how it works now.
+Every time a node receives an announcement of addresses with up to 10 addresses, For each address separately, they'll randomly pick two peers to forward it to.
+So if you send say 500 packages of 10 addresses and a node has a hundred peers, they'll randomly decide for each of those 5,000 addresses which two peers to relay that to.
+So now if there's another peer connected to the attack node, this receiver or observer node would probably get some 50 addresses.
+
+## Correction: The peer would not get addresses-divided-by-peers addresses, but 2×addresses-divided-by-peers addresses as the addresses get forwarded to two peers each.
+
+Speaker 1: 00:17:59
+
+If there were only 10 peers connected to the attack node, they'll receive 500.
+So the observer will basically get n divided by a number of peers of these randomly generated addresses forwarded.
+And that way, while an attacker could measure the peer degree of the node, right?
+
+Speaker 0: 00:18:16
+
+Yes.
+The thing that is, it's called in network science, I think it's called degree distribution, which says like how many peers have how many other peers that they are connected to and to make a distribution out of that.
+And that is an important measurement to show about the topology of a network and that different ways that peer distributions can be.
+And there could be a power law, there could be like very random, like very evenly distributed.
+And maybe the attacker just wanted to know how it is for the Bitcoin and peer distributions.
+
+Speaker 2: 00:18:45
+
+Yeah, that's interesting.
+I mean, I'm trying to think of the value of that.
+One, we mostly see them in Lightning.
+You see the Lightning network visualized and sort of cool, and you can understand the interconnectivity and you can see how it grows.
+There's also the idea of, there's got to be heuristics associated with nodes that are configuring their peers and not using the defaults.
+And so a node that has a thousand connections is some sort of flag as to what it might be.
+It might be a spy, it might be a miner, it might be just, there's a reason that it would have more connections.
+So I don't know, I'm just sort of thinking about why someone would do this.
+
+Speaker 1: 00:19:18
+
+It could be a fingerprinting.
+
+Speaker 2: 00:19:18
+
+We haven't seen a paper come out yet associated with it, as far as I can tell.
+
+Speaker 0: 00:19:21
+
+I mean, actually, there is a paper, not by the attacker, but by a team in Karlsruhe.
+They are a team of researchers there.
+
+## Estimating the Node Degree of Public Peers and Detecting Sybil Peers Based on Address Messages in the Bitcoin P2P Network by Matthias Grundmann
+
+Speaker 0: 00:19:27
+
+And they actually have a note that monitors the whole network and probably put the link there in the show notes.
+They also published a paper on archive about this and they were actually in a position because they are connected to most nodes to calculate the degree distributions.
+And this is something I think I find really interesting because this is something really positive that can come out of this because the redistribution, it doesn't really reveal privacy because it doesn't say who is connected to who, but it does give a good estimate how the network looks like.
+And this is something that Bitcoin developers or researchers can use in simulations of the network, because if we understand how the networks behave, it's much more easier to simulate the dynamics on it in some agent-based model, for example.
+And so I think this is something, I don't know if the attacker wanted to know this, but it's definitely something that the Bitcoin research community can make use of.
+
+## Simulating the network
+
+Speaker 2: 00:20:15
+
+I want to hear a little bit more about simulations.
+And you've done some simulations for Adderley, but you also have a prior history of science and simulations.
+And I'd love to hear sort of how you think about creating simulations and using that past experience.
+Is there any crossover to creating simulations for Adderley?
+Yeah.
+How do you go about it?
+
+Speaker 0: 00:20:33
+
+Yeah, I think there's definitely, I've done a lot of simulations in the past, but it's something I would want to pursue much deeper in the future, because I think for a lot of decision, if we want to change some things, for example, in address relay, change a little thing there, we can say that makes sense locally.
+We can understand why it should be good, but we are not really sure what this will do for the network.
+
+Speaker 2: 00:20:54
+
+I mean, there's lots of things.
+There's early, there's transaction rebroadcast, there's, you know, the list goes on and on.
+It goes back to my original question of how you think about when you pull a lever and something pops up over there.
+If you're changing how the network interacts, those variables can cause unintended consequences.
+So having simulations to go along with the code review obviously gives you more confidence.
+
+Speaker 0: 00:21:15
+
+Exactly.
+And I think it would be great if there was some agreed upon or like widely used simulation framework so that each time I want to simulate something that interests me, like that I know about it, I wouldn't need to worry about creating a realistic degree distribution.
+So it would be good to have that out of the box.
+Just take one of the realistic scenarios and see how this affects the simulation.
+
+Speaker 2: 00:21:37
+
+Yeah, I know that, you know, Suhas has his simulator.
+Gleb has his simulator.
+The Carnegie Mellon team.
+
+Speaker 0: 00:21:43
+
+Yes.
+
+Speaker 2: 00:21:43
+
+Obviously, there could be some shared nodes there.
+
+## Requesting addresses from peers
+
+Speaker 2: 00:21:46
+
+So there's a third way that nodes on the network learn about addresses.
+And what's that third way?
+
+Speaker 0: 00:21:52
+
+That way is the get other message.
+So when a node makes an outgoing connection, not for inbound, just for outgoing ones, we ask them, we send this get other message to them once, and then they will answer this with a huge chunk of addresses, up to a thousand addresses.
+And those addresses, they randomly pick from the other man.
+And yeah, so that gives, they are not filtered for recency or something.
+So they might be a bit older.
+They might be, they're also being cached right now.
+So with the get utter message, we would only send out one set of thousand addresses to our peers within 24 hours.
+So they are something, yeah, a little bit more long living ones.
+
+Speaker 2: 00:22:32
+
+But there's a grab bag there.
+You have maybe some junk in there, maybe some stuff that's in the tried table, and maybe some actual connections that the node would be paired with, right?
+
+Speaker 0: 00:22:42
+
+Yeah, but there is not really a selection for this.
+We just get random addresses that we just would send away.
+In a getAddress response, we would just send random addresses.
+
+Speaker 2: 00:22:53
+
+Do you think it should be preselected?
+
+Speaker 0: 00:22:54
+
+Yeah, I think it would make sense, because for example, in many nodes, they would have a lot more addresses in the new table than in the tried table.
+So that would mean that we're also like in a get other message, we would have a larger percentage of notes on a new table.
+And the new tables, they are not really filter for quality.
+So I think it might make sense to think about like including a certain percentage of addresses from the try table that we know are quality and are good, and are actually a piece on the Bitcoin Core network, and include them in a get-out-of-response network.
+
+Speaker 2: 00:23:28
+
+And what circumstances would you actually ask for these messages?
+So you have the bootstrapping mechanism through DNS seeds, and you have the gossip.
+And so it's sort of like that in-between state of, I know about a few, and I'm going to do some connections, and I'll go ask for some samples.
+Is that sort of the best?
+Is that the best use of...
+
+Speaker 0: 00:23:46
+
+I'd say it's currently being done just once.
+When you start a new connection to outbound peer, you just ask them once for this big chunk at the beginning of the connection.
+And then never again while the connection lasts.
+
+Speaker 1: 00:24:00
+
+So if you were to restart and reconnect to the same outbound peer again, you would ask again.
+
+Speaker 0: 00:24:06
+
+Yes, but if you do this within 24 hours, you would get the same response because we don't want to be able to make use of this to scrape our Adorama database to be able to see all the nodes that are in there.
+
+Speaker 1: 00:24:20
+
+So and obviously, since we don't trust any of our peers, we're very paranoid.
+We add that only to our new table, right?
+So we get a big chunk of a thousand new addresses from each outbound connection, add that to our new table.
+And if we ever need later some more outbound connections, or with our feeler connection every two minutes, we would try some of the new tables and potentially move them to tried.
+
+Speaker 0: 00:24:44
+
+Exactly.
+The distinction between new and tried it makes a lot of sense because whenever we would make an outbound connection we would toss a coin and with a probability of 50% we would pick one address from the new table, just one, whatever it is, or we would pick one from the tried table.
+So if our new table was overwhelmed by spam or something, we would still have a 50% chance for each try to pick one from the try table, which is probably not affected by this.
+So even if for some reason our new table was junk, we would still have a way to find peers in a reasonable amount of time.
+Well, if we have some errors in the try table, if we don't have done we are out of luck.
+
+## Walking through first connection of a node
+
+Speaker 1: 00:25:25
+
+So if you're a completely new node, you would connect to a DNS seed.
+How much do you get from a DNS seed?
+Is that like just a few connections or is that a thousand?
+
+Speaker 0: 00:25:35
+
+It's just a few.
+I think it was reduced at some point in the past recently, but it's under 50 I think.
+
+Speaker 1: 00:25:41
+
+Okay, so I'm a new node, I connect to a DNS seed, I get under 50 addresses from a DNS and they are basically tried addresses.
+Right.
+And not new addresses.
+
+Speaker 0: 00:25:51
+
+They are tried for the DNS.
+So the DNS is internally.
+They have a crawler which tries to connect to Bitcoin core nodes and will only give those that actually exist on the network.
+
+Speaker 1: 00:26:03
+
+So we're a little less paranoid towards DNS seeds.
+But that's kind of makes sense because we're completely new here and we don't know that we can trust.
+
+Speaker 0: 00:26:10
+
+But we still store these in the new table, in our new table.
+So we don't just believe the DNS seed, if they are good, we just put them to tried.
+
+Speaker 1: 00:26:18
+
+And then of course, the node would make eight outbound connections to blocks only connections and a feeler connection would start going through the remaining new and then each outbound connection would give us 1000 new addresses again.
+And so very quickly, we would build up some stock of new addresses in our new table.
+
+Speaker 0: 00:26:35
+
+Yes and all the let's say 10 nodes that we connected to when we disconnect them we would also like promote them to the try table because now we have been able to connect to them.
+
+Speaker 1: 00:26:46
+
+Right Although we do not get any new addresses from blocks-only relay connections, right?
+
+Speaker 0: 00:26:51
+
+Right, but I think the block-only connections themselves that we connect to, their address will still be promoted to Trite.
+
+Speaker 1: 00:26:59
+
+Yeah, makes sense.
+
+Speaker 2: 00:27:00
+
+Yeah, I mean, as I listen to this and as I'm sort of catching up on my reading, it just seems so nuanced.
+
+## Coinscope paper
+
+Speaker 2: 00:27:06
+
+Like, getAdder messages were taken advantage of by, in the Coinscope paper, where they used specific timestamps that were proliferated through the network to understand network topology.
+And then Gleb added the cached responses, because otherwise you could scrape the Scrape Adderman if you just kept querying.
+So it's like-
+
+Speaker 1: 00:27:24
+
+I seem to remember that there was something that made sure that you never share more than 30% or 23%-
+
+Speaker 2: 00:27:30
+
+23%, yes.
+
+Speaker 1: 00:27:32
+
+23% of your address.
+
+Speaker 2: 00:27:34
+
+And Peter doesn't claim full responsibility for that, but I'm sure we can look up the code.
+
+Speaker 0: 00:27:38
+
+I think it was introduced by Peter.
+Maybe he found it from somewhere else.
+
+Speaker 2: 00:27:42
+
+That's right.
+
+Speaker 1: 00:27:44
+
+Illuminati.
+Cool.
+Hopefully that gets cut.
+
+## Being a Bitcoin Core contributor
+
+Speaker 1: 00:27:50
+
+All right.
+
+Speaker 2: 00:27:50
+
+I want to talk a little bit about just what it's like to be a Bitcoin Core contributor and sort of how you think about spending your time, what kind of code review you pick up, how you look for ways to contribute.
+
+Speaker 0: 00:28:02
+
+Yeah, I think there are many different ways of being a Bitcoin Core contributor.
+And I think every person has to find a way that works best for them and for their interests.
+But what I personally like is I don't want to spend all of my time on projects like the Multi Index Adderman and I want to spend a lot of time on review, reviewing other things because that's the way you learn especially if you're a relatively new contributor.
+I think that is important to not get lost in some like esoteric area and spend all your time there, but also get to know other parts of Bitcoin Core better.
+And something that I personally really like is just look at the list of issues.
+Maybe there's some intermittent failure in some functional tests and just try to see what has happened, try to find a fix, make a small PR there.
+And yeah, this can take some time, but it's usually not a huge project.
+You can do this like one evening maybe, and yeah, you fix some small bug there.
+And that is something I really like.
+And you also learned something about some part of the code base that was not familiar to you before.
+
+Speaker 2: 00:29:08
+
+What's the difference between doing this on nights and weekends and having the opportunity to do this full time and making this your regular job?
+Like, How does it change your approach or how do you pace yourself?
+Or I mean, you're a few months in, so what has that transition been like?
+
+Speaker 0: 00:29:22
+
+Yeah, I think for me personally, before I didn't really have the energy to do large projects because I was just doing this on the side.
+So I just did a small review there and a small PR there, like changing smaller things.
+Now that I have more time, I'm concentrating on larger things like multi-index project is one of them, but I would also try to review larger PR and more complicated PRs. So recently I've become interested in the indexes and there's a large PR by Russ and I'm currently trying to review that, which is, it takes a lot of time because it's a large change.
+And yeah, I want to spend more time on more complicated changes.
+
+Speaker 2: 00:30:01
+
+We have an Ack Russ t-shirt we have to get in your hands then.
+I don't know if we have your size, but cool.
+Thank you for sitting down with us and telling us about your days on Bitcoin.
+
+Speaker 0: 00:30:10
+
+Yeah, it was great.
+Thank you very much.
+
+Speaker 2: 00:30:25
+
+So, any takeaways from our conversation?
+
+Speaker 1: 00:30:28
+
+I thought that the Adderman spam was really interesting.
+The spam attack that was trying to either leverage the exact behavior of Bitcoin Core on what it will relay to learn the node peering distribution, but maybe also just didn't know exactly what was gonna happen and then didn't get all their addresses relayed as wanted.
+Right.
+That was an interesting thing there.
+
+Speaker 2: 00:30:53
+
+It must have been a government op.
+Didn't read the code close enough.
+
+Speaker 1: 00:30:58
+
+I don't know.
+And I just find it fascinating how much a little change at the local level changes the global emergent behavior.
+
+Speaker 2: 00:31:06
+
+Yeah, which is why we have our best physicist on the case.
+Something happens over here and something else happens over there.
+
+Speaker 1: 00:31:12
+
+So quantum entanglement.
+
+Speaker 2: 00:31:13
+
+That's right.
+Yeah, it was great to have Martin in the office these last couple of weeks and yeah, I really enjoyed the conversation with him.
+He's a really approachable guy and I mean, he's been working sort of moonlighting on Bitcoin now for a couple years, but really excited to see him working full-time with a grant through Rink.
+So very good.
+We'll try to get this out soon and get into the studio again probably in the next couple weeks.

--- a/chaincode-labs/chaincode-podcast/assumeutxo.md
+++ b/chaincode-labs/chaincode-podcast/assumeutxo.md
@@ -1,0 +1,554 @@
+---
+title: "AssumeUTXO"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://www.youtube.com/watch?v=knBHvzKsIOY
+tags: ['assumeutxo','bitcoin-core']
+speakers: ["James O'Beirne"]
+categories: ['podcast']
+date: 2020-02-13
+episode: 4
+summary: "Next in the studio, we caught James O'Beirne, who until recently was a co-worker of ours at Chaincode. We talked to James about his experience at the Chaincode residency, his most recent project AssumeUTXO and how he champions and effects change in Bitcoin Core."
+---
+Speaker 0: 00:00:00
+
+Bitcoin is a very complex piece of software and it's very difficult to review for correctness.
+Even people who are really experienced with the code base still have a really hard time determining, in some cases, whether a change is safe or not.
+
+Speaker 1: 00:00:25
+
+Hi Jonas.
+Hey Jeanne.
+Hi Carly.
+
+Speaker 2: 00:00:27
+
+Hi guys.
+
+Speaker 1: 00:00:29
+
+We have Carly in the studio.
+Carly is our producer and she's been helping us with the episodes.
+
+Speaker 2: 00:00:34
+
+Yeah, it's been a lot of fun.
+It's been really great working with you guys and getting to meet all of the wonderful guests that you guys have had on.
+
+Speaker 1: 00:00:41
+
+Great to have you here.
+
+Speaker 2: 00:00:42
+
+Thank you.
+And who do you guys have up next?
+
+Speaker 1: 00:00:46
+
+Well, this week we talked to James O'Byrne who until very recently was a co-worker here at Chaincode Labs.
+I first met James a couple of years ago back in 2017, 2018 at a conference in Stanford and then a meetup in San Francisco.
+And it was obvious from when I met him that he was very passionate about Bitcoin and enthusiastic.
+And he was so enthusiastic he applied I think the very first day that we opened applications for the residency in 2018.
+So he came to the residency in 2018 and then went on to join Chaincode and he's been a friend and a co-worker for the last two years.
+
+Speaker 2: 00:01:22
+
+I love that.
+What did you guys talk about?
+
+Speaker 3: 00:01:24
+
+We talked a little bit about how he decides the projects that he works on and his most recent project which is Assume UTXO.
+And then we talked a little bit about how he sort of advocates and affects changes in Bitcoin Core.
+
+Speaker 1: 00:01:36
+
+Peter Dallas House, Founder and CEO of Podcast.
+We really love talking to James and we hope you enjoy the episode.
+We'll be back at the end.
+Hi James.
+James M.
+Duffield Hey James.
+Hi. Welcome to the podcast.
+Welcome.
+
+Speaker 0: 00:01:50
+
+Thanks, it's great to be here in our conference room.
+
+Speaker 3: 00:01:55
+
+Well thanks for making the trip.
+We're going to talk about a few different things today.
+We're going to talk about what you're currently working on.
+We're going to talk about the vision quest that brought you here today.
+And so maybe why don't you go back to not the beginning, but the start of the new beginning.
+Sure thing.
+To Chaincode.
+
+Speaker 0: 00:02:15
+
+Sure thing.
+Yeah.
+Well, let's see.
+I came to Chaincode in the winter of 2018.
+I think it was February 1st.
+And I had been talking to John previously because we had collaborated to some extent on a few things in the repo and I had met him in California at a conference out there and had told him that I'd like to apply to the residency.
+
+## 2018 residency
+
+Speaker 0: 00:02:43
+
+And So he encouraged me to do so.
+I did that and somehow got in.
+And so I showed up in New York during the winter of 2018 and started the residency, which was a lot of fun.
+Through that, got acquainted with Chaincode and that led to a full-time position.
+
+Speaker 3: 00:03:10
+
+That was also the crypto winter of 2018, I believe.
+
+Speaker 0: 00:03:13
+
+Correct.
+
+Speaker 1: 00:03:13
+
+Oh yeah, we were coming off that hot 2017 bull run.
+
+Speaker 0: 00:03:19
+
+Yeah, yeah, Mixed emotions.
+But it was a really great time.
+The residents were all awesome.
+The sessions that we had were really interesting because they were very, it was a smallish group.
+It was maybe 15 total, I think.
+Maybe a bit more than that.
+
+Speaker 1: 00:03:41
+
+It was two sessions of two weeks and six or seven in each, I think.
+
+Speaker 0: 00:03:47
+
+Oh, is it that small in terms of people there?
+Okay.
+
+Speaker 1: 00:03:49
+
+Pretty small.
+Yeah.
+Select, exclusive.
+
+Speaker 0: 00:03:54
+
+Yeah, no, everybody there was great.
+And so we had some really great sessions.
+Very interactive, very Socratic.
+Yeah, it was a lot, It was intense.
+And I'm kind of first and foremost, I think of myself as like a carpenter, but instead of wood, it's like software.
+So at a certain point, I kind of tuned out and was just ready to start coding.
+But it was awesome.
+One of the things that I think about a lot when working on Bitcoin is that it's really easy to get hung up on how many smart people are here and you can get in your own head about like what can I actually contribute?
+It's a really easy rabbit hole to kind of spiral down because there are incredibly talented people working on Bitcoin.
+But what you've got to realize is that there are different kinds of smart.
+Everybody has different skill sets.
+I kind of like putting one foot in front of the other and having consistent engineering hygiene and trying lots of things and iterating quickly.
+And that makes me really good at some things, it makes me really not good at other things.
+And I think what's cool about development of Bitcoin is that there is actually space for a lot of different approaches.
+
+Speaker 3: 00:05:21
+
+As a carpenter starts to think about what he's going to build, how do you decide what to work on and what kind of angle you're going to take on a project like this?
+
+Speaker 0: 00:05:33
+
+I think before you know anything, you just have to jump in and start doing things.
+
+## Choosing what to work on
+
+Speaker 0: 00:05:40
+
+And I don't mean necessarily opening PRs and things of that nature.
+But I think cloning the source code and then playing around with it, making modifications to it, is really important just to get to know the code base, watching the way that reviews work.
+But fundamentally, it's all about, where the bottlenecks are, whether that's in terms of a feature set or the performance or resource usage or vulnerabilities.
+Everything is kind of like looking at what the lowest hanging fruit is and then kind of going from there.
+So I came in not necessarily knowing what I was going to work on.
+I came in having made a change to the level DB wrapper that we use and having worked on the test suite a little bit, but I think there were a whole lot of dimensions of Bitcoin that I, or Bitcoin Core that I just wasn't familiar with.
+I think the first thing I started to work on was like the fork detection framework.
+
+## Fork detection framework
+
+Speaker 0: 00:06:55
+
+And the idea there is that we want to have some kind of logging or alert system if Bitcoin sees a heavy work fork that's been going on and hasn't been resolved because that means that your node might have been partitioned somehow.
+And nominally we have ways of doing this but they're kind of broken so and they're still kind of broken And that has to do with balancing considerations around DOS and kind of the way that we do the bookkeeping around header validity.
+So anyway, I had started to work on that but that was kind of stalling and it didn't look like it was going anywhere.
+And frankly, It's a cool project and it was a good way of getting introduced to Bitcoin Core in a formal way, but I think the marginal utility of that is kind of low.
+So I started thinking about what really mattered to me in terms of where did I think the important work was in core.
+
+## Initial block download (IBD)
+
+Speaker 0: 00:08:06
+
+That naturally led to the duration of the initial block download because I think That's kind of a sticking point for a lot of people who want to participate in consensus and want to run a node that they transact with because that's really the only way that you kind of reify the rules that you're using Bitcoin under.
+So it's an important thing to.
+
+Speaker 3: 00:08:31
+
+I'd like to challenge that a little bit.
+
+Speaker 0: 00:08:33
+
+Sure.
+
+Speaker 3: 00:08:34
+
+Don't you think if someone has set up the hardware or just gotten their ducks in a row to actually participate, that they're just going to wait for whatever it takes to do the initial block download?
+The speed of which, I mean I hear the phone instance and I hear just usage or outdated hardware, or the case may be we want to enfranchise as many people as possible.
+But if you've set it up and you've started the process, can't you just wait a little bit longer?
+Like, is that really an area of optimization that we need?
+
+Speaker 0: 00:09:11
+
+Yeah, you certainly can.
+And that's the right question to be asking.
+In my experience, there are a lot of people who are on the margin there.
+For example, I have a friend who is a very diligent user of Bitcoin and he's very privacy conscious But every time he's gone to download the chain and use Bitcoin QT, he gets kind of hamstrung and he's stuck waiting days and he's turning his laptop on and off.
+And so subsequently, that kind of user is pushed towards using something like say Electrum, which has a different security model than Bitcoin QT.
+So yeah, I think there are a lot of hobbyist users out there who are going to buy, say, a Raspberry Pi and set it up and wait the four or five days or whatever that it takes to sync.
+But I think appealing to those users who are maybe casual users of Bitcoin or maybe more than that, but they're kind of deciding between getting the whole blockchain or using Bitcoin under a different security model.
+And that's kind of on the margin.
+So I think those are important people to go after.
+And the other thing to keep in mind is that the blockchain is just going to keep growing.
+So there's linear growth there.
+And I think there has to come a point where we say, okay, we have to stem this somehow, because this thing is going to, if we want this to keep going on forever, IBD time can't scale with forever.
+So we needed to truncate somehow.
+
+Speaker 1: 00:11:01
+
+Okay, so let's talk about IBD, initial block download.
+What is a node doing when you switch it on for the first time?
+
+Speaker 0: 00:11:10
+
+Well, I think the first thing it does is check to see if it's got any data.
+And If it doesn't, then it tries to find peers.
+If it doesn't know any peers right off the bat, it'll consult these DNS seeds that are run by various people and it'll get a random set of peers.
+
+## DNS seeds
+
+Speaker 0: 00:11:31
+
+It'll connect to those peers and it'll basically ask them, I think, what the best block that they know about is.
+Is that right?
+And so in doing that, your node then gets the headers chain, which is basically like an abbreviated version of the blockchain.
+That's kind of the vital information, the vital metadata about blocks without the transaction data itself.
+And once it has all that, it figures out what the most work valid headers chain is, and then starts the initial block download process, which is where it's actually obtaining the data in the blocks, the full blocks themselves.
+Reassembling the blockchain, which basically amounts to building a few indexes, the most important of which is the UTXO set, which is kind of its own data structure.
+
+## UTXO set
+
+Speaker 0: 00:12:33
+
+And so at the end of all that, you end up with this set of unspent coins, which you can then use to decide whether an incoming block is valid or invalid.
+And that whole process takes, at the moment, anywhere from four hours, if you've got a really good internet connection and really good hardware, to kind of an unbounded amount of time, depending on your hardware and bandwidth.
+
+Speaker 1: 00:13:00
+
+Okay, so you start by getting this headers chain, which is the block headers, and that contains the proof of work, so you can, just from that small amount of data, 80 bytes per block, you can figure out which chain has the most work.
+At this point you're not validating transactions, so you don't know whether it's a valid chain, but you know that it's got the most work.
+And then you go back and download the blocks.
+And as you're downloading blocks, you're validating them and building this UTXO set, which is a set of coins, a set of unspent transactions.
+So that takes a long time.
+It takes a long time to download that data.
+There's IO there because you're writing to disk, and there's computation there because you're validating the signatures.
+And the blockchain is getting bigger all the time.
+So if you do this in a year's time, it will take longer.
+So what are some of the strategies that we've had so far before us?
+We're going to talk about assume UTXO, but before we get there, what are some of the strategies that we've had to make this take less time?
+
+Speaker 0: 00:14:06
+
+Yep.
+So the first I'm aware of, and correct me if there's something we did before this, but That signature verification that we have to do for each block, you can to some extent parallelize that.
+
+## Parallelized signature validation
+
+Speaker 0: 00:14:22
+
+And so one of the things that we do is we have kind of a thread pool of signature verification processes, so that gets parallelized.
+Another thing that we do is called Assume Valid.
+
+## Assume valid
+
+Speaker 0: 00:14:39
+
+And I actually didn't know about this until I came to the Chain Code Residency.
+I was taken aback when I learned about it as I think most people are and should be because it's a very unintuitive idea and it should kind of raise the hair on your back if you're a dyed in the wool Bitcoiner And you're like, hey, wait a second, how does this thing actually work?
+So what assume valid does is there is a block hash hard-coded in source code.
+And if your Bitcoin client sees a headers chain that contains that block hash, it will assume that all of the signatures in all of the blocks underneath the block designated by that hash are valid.
+And so it'll skip signature verification.
+And traditionally signature verification is the most costly part of initial block downloads.
+So that saves you quite a bit of time.
+So the natural question is, how does this not somehow dilute the security model of Bitcoin.
+You know, you're trusting the developers, I think would be the catchphrase.
+The reality is that This works because Bitcoin source code is the trust model, right?
+That's what you're trusting when you run Bitcoin, is the source code that your binary is built from.
+And Basically, when you're evaluating a change to Bitcoin, that's obviously going to affect consensus in one way or another.
+That change could potentially be doing anything.
+It could be short-circuiting some kind of validation that might permit the spend of a certain coin that doesn't exist.
+It could be doing any number of things.
+And all AssumeValid does is it basically makes part of the review process a sort of commonly agreed upon attestation that the software has previously validated this particular chain.
+It doesn't really dictate what the right chain is because Let's say there's a massive reorg where somebody secretly forked, started working on a fork at some point before that assume valid mark, that alternate fictional chain could still potentially overtake the chain that's been deemed assume valid.
+It's just basically Bitcoin users coming together and saying, hey, look, yeah, this is the chain that we've all previously validated.
+We know it's valid.
+And it gets reviewed like any other piece of the code.
+
+## Different than checkpoints
+
+Speaker 1: 00:17:31
+
+And so this is different from checkpoints.
+A hard-coded checkpoint in the source code because if there's a competing chain with more work, you can reorg to that chain and you'll get into consensus with that longer, more work chain.
+Whereas with a checkpoint, it precludes that.
+A checkpoint would hard-code the exact chain that you would have to follow.
+
+Speaker 0: 00:17:57
+
+Right, right.
+So that really is the developers of software dictating what the only allowable chain is.
+Whereas this just says, this is sort of a public attestation that, hey, we've all previously validated this chain, we know it's valid.
+And so This kind of change is interesting because when you think about it, it's from a threat model standpoint, it's kind of a nice thing to have because Bitcoin is a very complex piece of software and it's very difficult to review for correctness.
+Even people who are really experienced with the code base still have a really hard time determining, in some cases, whether a change is safe or not.
+And so when you kind of crystallize your security assumptions in a place where almost everybody can review it.
+
+## Updating assume valid value in the code
+
+Speaker 0: 00:18:51
+
+So for example, the way that we update the assumed valid value, because we do that typically with every release, is somebody will post a modification of that value, and then a number of people will chime in on the pull request and say, yeah, so I've, you know, I use the node that I previously provisioned with the initial block download process, and I ran this RPC command, and it told me that this hash that you mentioned in the source code is actually in my chain.
+So I agree to this.
+And that's something that you don't have to be an expert in C++ to be able to do.
+You don't even necessarily need to be a software engineer to do that.
+So the use of this technique allows you to get way more widespread review over a pretty security critical change.
+
+Speaker 3: 00:19:51
+
+Do you find non-software engineers actually contributing though?
+That assumption seems to work if actually other people are doing it.
+
+Speaker 0: 00:20:03
+
+Yeah, I think not enough people are at the moment.
+But you definitely do see people in the Bitcoin community who are not involved in this sort of day-to-day development of Bitcoin Core.
+They pay attention to those pull requests.
+And they'll chime in and they'll say, yeah, I ran this RPC command and this matches up.
+So it really brings more people into the fold than otherwise would be on something where many, many people should be paying attention.
+Because I could post a pull request tomorrow that claims to be some kind of optimization to the UTXO set, and it could contain some vulnerability.
+And the number of people who are currently able to find that vulnerability is very, very limited relative to the number of people who can run an RPC command and say, no, no, no, this doesn't match up with what I have.
+
+Speaker 1: 00:20:55
+
+Yeah, and it should also be noted for the mountain men who, sorry, and mountain women, we don't know, preclude any people who live on mountains.
+But you can switch off this feature and validate every signature from Genesis to the tip.
+
+Speaker 0: 00:21:12
+
+Yeah, exactly, very important.
+
+Speaker 3: 00:21:15
+
+So does that mean we're going to transition to assume UTXO and how you arrived at that solution?
+
+## Assume UTXO
+
+Speaker 0: 00:21:20
+
+Yeah, we can do that.
+So I was very concerned with this IBD thing.
+And I thought, how cool would it be if we could cut that time down substantially?
+And even maybe cut it down enough so that you could at some point run it on these really underpowered devices and devices with not great internet connectivity.
+So I spent a little bit of time tinkering with doing small things like trying to make logging asynchronous and just these little optimizations.
+I thought even if I eke out 10% to 15% reduction of this time, it's not going to make a big dent.
+So what are some of the bigger ideas that might help me get this time down?
+And I think I first heard Alex Morcos mention this.
+But the idea of using some kind of a UTXO snapshot to bootstrap a node came up at some point.
+And I thought, oh, that's kind of an interesting idea.
+I don't think it'll necessarily work or sort of be acceptable from a security standpoint, but it sounds like it'll be fun to implement.
+I was looking for an excuse to get to know the code base better anyway.
+So I said, okay, well, I'll come up a little prototype and just see how it works.
+And so I did that.
+And throughout the course of doing that, I became increasingly convinced that this was basically just the spiritual continuation of AssumeValid.
+And so the idea of this is basically that, like AssumeValid, you could hard code the hash of the UTXO set at a certain point in time, at a certain block height.
+And if you hard code that expected value there, you can then have the user upload a serialized version of the UTXO set that hashes to that value.
+And you can then initialize all the data structures in Bitcoin that are necessary for operation based upon that snapshot.
+And then in the background, you can do the regular old initial block download.
+But meanwhile, you're able to transact kind of as a, you know, as sort of a fully validating node.
+You know, you can see incoming blocks and you can judge their validity and send transactions.
+And yeah, so I implemented this and found that, in terms of security model, it didn't really differ from AssumeValid and shopped it around to a few people.
+And to my surprise, the conclusion was, yeah, this looks pretty good.
+On top of that, in just the preliminary testing I did, the results were great in terms of trimming down the IBD time.
+I think the latest numbers are something like an hour and a half from start to finish to get up and running on my computer.
+So pretty good results so far.
+
+Speaker 1: 00:24:44
+
+OK, So let's just dig in a bit into how it's different from AssumeValid and why you get that significant performance improvement or lower time to sync to the tip.
+With AssumeValid, you get the headers chain, you download all the blocks, and then you're building this UTXO set, but you're not validating signatures as you build up to the AssumeValid block.
+And that building of the UTXO set itself is quite expensive.
+Maybe you can talk a little bit about why that is and the coins cache and flushing to disk and that kind of thing.
+Whereas with AssumeUTXO, you don't need to build that UTXO, so you get a snapshot.
+And so you just fast forward through the first 500,000, 600,000 blocks, whatever it is, the height of the assumed UTXO block.
+So maybe just a bit about where you're saving time when you do this.
+
+Speaker 0: 00:25:44
+
+The UTXO set is probably, other than maybe bandwidth, probably, and signature validation, probably the biggest bottleneck in doing initial block download.
+I guess maybe we never defined what the set itself is, but it's basically a mapping of outpoint, which is the transaction ID and index, and then valued by the unspent coin itself, which you can find at that outpoint location.
+And we reference this thing when we're validating incoming blocks because we want to obviously verify that the coins being spent in the block are valid spends.
+And then we want to actually update the set with the new unspent coins that are made available by that block.
+This gets tricky because the UTXO set is about three and a half gigs right now.
+And on some platforms that can fit into memory.
+And so access to that sets very fast.
+On other platforms, we're limited by memory, and so we have to basically write out part of that cached disk and kind of selectively page in and out the parts that we're using at the moment into working memory.
+So Depending on your platform, it can get really expensive to do operations on this set when it gets big.
+And that's indeed where a lot of the time is spent when you're doing initial block download on, say, a machine that has 2 gig of memory and maybe an old spinning disk.
+
+## Platform and memory considerations
+
+Speaker 0: 00:27:19
+
+You spend a lot of time flushing the in-memory coins down to disk and then maybe reading coins that you haven't found in your in-memory part of the cache from disk.
+So with Assume-UTXO, when you're given this serialized snapshot, and you can just load it in from a certain point in the height, a certain point in the chain, You've foregone maybe doing a lot of disc writes and reads.
+
+## Criticisms
+
+Speaker 3: 00:27:56
+
+What criticisms have you received thus far?
+
+Speaker 0: 00:28:01
+
+I think a lot of people read it and they are initially very skeptical, which I completely understand because I was skeptical and you should be skeptical.
+It sort of seems like a too good to be true kind of thing.
+The tricky part is that conceptually, it's much easier to sneak in, say, an illegitimate unspent coin than with assume valid.
+So For example, if you could convince someone to accept an AssumeUTXO hash that they had constructed specifically, it's very easy for an attacker to then serialize a modified version of the UTXO set that matches that hash, and then basically convince someone to accept an illegitimate spend.
+Oh, and I guess it's worth noting an important part of the proposal is that unlike In AssumeValid, you cannot specify the AssumeUTXO hashes through the command line.
+This is a pretty intentional...
+I think that would just be a huge foot gun because then you could have someone...
+You could pre-format the BitcoinD command and trick somebody that way.
+Okay, short of the malicious command line that you might give somebody, what you would have to do is modify the source code somehow to say, accept that malicious, assume UTXO value.
+The thing to keep in mind is that if you can modify somebody's binary, then you're cooked in the first place.
+Because if you can modify their binary, it's much easier to just add some little conditional into the coins cash code that accepts their spend or does any variety of things.
+And so in actuality, this doesn't open the potential for any attacks because we're still relying on the threat model of not being able to have your binary modified?
+
+Speaker 1: 00:30:03
+
+I think there's a maybe more philosophical, subtle argument against, which is kind of a slippery slope argument that we want validation to be quick and IBD to be quick.
+And taking a shortcut like this is kind of kicking the can.
+And if people come to rely on this as the only way to validate the full chain, we might get ourselves into a position where it actually is impossible to fully validate the full chain.
+Ethereum might be there at this point already.
+And fastest way to do the IBD is to just not validate at all.
+Super fast.
+
+Speaker 0: 00:30:43
+
+Yeah, no, and That's a good line of thinking.
+I think the thing is that when we introduced pruning, we kind of went through this.
+Obviously, if you run a prune node, that means that you only keep around a certain number of the most recent blocks.
+And so, well, obviously, if we don't want to use disk space, then everybody should run a pruning node.
+And at that point, nobody's serving blocks.
+I guess this is a little bit different in the sense that, yeah, if everybody's starting in, assume UTXO mode, and not back validating the chain, which is a sort of mandatory part of the current proposal.
+Yeah, it's worth pointing out that if you are using Assume UTXO in its current incarnation, you're doing a background validation from scratch.
+And so I think that kind of alleviates that concern.
+But there are people who argue that if you're willing to buy into the Assume UTXO security model before you have done the back validation, then why even do the back validation?
+And there are a lot of people who have thought a lot about this and still sort of hold that opinion.
+But I think the nice thing is that if we all agree that that's the case, then it's a pretty simple matter to make the background validation optional or disabled at some point.
+But for now, we can be conservative and still do that.
+
+## Championing a big change in Bitcoin Core
+
+Speaker 3: 00:32:16
+
+Peter Dalmaris So we were covering the arc of your JNCO journey, and I guess I'd be wondering, what is it like to champion something that's such a big change and just so different?
+And what can you do yourself?
+And what do you need others to do to get something like this into Bitcoin Core?
+
+Speaker 0: 00:32:35
+
+Initially, I didn't really think about this as a big change, but in hindsight, I guess it is.
+I think The best thing you can do is just to try and be very communicative, try and kind of at every opportunity provide motivation for why this is a good thing, why it makes sense.
+I have taken the approach of trying to break this change up into a number of small constituent PRs and just get those steadily merged so that the notion of progress doesn't become this binary thing about whether the giant PR is merged or not, you can have some incremental progress.
+I think everybody feels a little bit better about that.
+But yeah, I think in Bitcoin development, one of the really hard parts of it is socializing your work.
+It's definitely difficult given the slow pace of development, which is of course merited.
+I think effective communication and just being very clear about your motivations and demonstrating why it's worthwhile change.
+
+Speaker 3: 00:33:48
+
+Just to be clear to the listeners, how did you go about socializing this?
+You did a work in progress or a draft implementation and you started carving off pieces, or You did a draft up front.
+How did you get it out?
+
+Speaker 0: 00:34:04
+
+Yeah, so I did the draft implementation, and that was the first artifact I had.
+And I spent a little bit of time polishing that up and making the commits work semantically.
+And I posted that along with a pretty lengthy description.
+After that, maybe a few weeks after that, I let it hang out for a little bit.
+I then made a mailing list post and solicited feedback from the Bitcoin dev mailing list.
+I used that feedback to then build what, in hindsight, probably should have just been a BIP, but it was a frequently asked questions document that I posted on GitHub.
+And I asked a few people to review that.
+And some of that feedback I actually posted in the same repo as the frequently asked questions document.
+So after that, I started just proposing parts of that big draft PR.
+And while that was going on, I guess I did some more informal stumping.
+I went on a few podcasts and you blackmailed me into doing a few talks, which I should thank you for.
+
+Speaker 3: 00:35:22
+
+All done, yeah.
+
+Speaker 0: 00:35:25
+
+So, yeah, it's a multifaceted thing and kind of any way you can shill your change, it's probably good.
+
+Speaker 1: 00:35:35
+
+Thanks, James.
+
+Speaker 3: 00:35:36
+
+Thanks, James.
+
+Speaker 0: 00:35:37
+
+Thank you guys.
+
+Speaker 1: 00:35:43
+
+Okay, I really enjoyed that talk.
+What did you think, Janice?
+
+Speaker 3: 00:35:46
+
+Yeah, I really liked the conversation about IBD and the assumed valid conversation.
+Those were my two highlights.
+
+Speaker 1: 00:35:52
+
+And we're certainly going to miss James here in the office.
+Yeah,
+
+Speaker 2: 00:35:55
+
+it was great that you guys got to sit down with him before he took off for his next adventure.
+
+Speaker 1: 00:35:59
+
+Good luck, James.
+We'll see you here.
+
+Speaker 2: 00:36:01
+
+Good luck, James! Bye!

--- a/chaincode-labs/chaincode-podcast/block-building.md
+++ b/chaincode-labs/chaincode-podcast/block-building.md
@@ -1,0 +1,731 @@
+---
+title: "Block Building"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://podcasters.spotify.com/pod/show/chaincode/episodes/Block-Building-with-Clara-and-Murch---Episode-18-e1dmitu
+tags: ['research', 'mining','bitcoin-core']
+speakers: ['Clara Shikhelman']
+categories: ['podcast']
+date: 2022-02-01
+episode: 18
+summary: "Postdoc Researcher Clara joins Murch to discuss their block building research. They cover their proposal, which outlines suggested improvements to the current Bitcoin Core block building algorithm using candidate sets"
+---
+Speaker 0: 00:00:00
+
+The idea is we want the set of miners to be an open set where anybody can enter and exit as they wish.
+And if we now had obvious optimizations that people had to implement to be as competitive as possible, That would make it harder for new miners to enter this place.
+Hey, Murch.
+
+Speaker 1: 00:00:32
+
+Hey,
+
+Speaker 2: 00:00:35
+
+Clara.
+
+Speaker 1: 00:00:38
+
+Hi. Welcome to the Chaincode Podcast.
+Clara, for you, your first episode.
+We're so excited to have you here.
+
+Speaker 2: 00:00:43
+
+I'm also very excited to be here.
+
+Speaker 1: 00:00:45
+
+And today we're going to talk about block building.
+So maybe you could start us off a little bit about, Claire, how did you get to Chaincode?
+Like, what are you doing here?
+What are you spending your time on?
+Tell us a little bit about yourself.
+
+Speaker 2: 00:00:57
+
+Okay.
+So my background is in mathematics.
+I have a PhD in math.
+I was working on graphs and probability.
+And during my PhD, also got really interested in this whole Bitcoin space.
+And then I decided to pursue it as a postdoc.
+So I spent some time at Berkeley and at Caltech, but I felt like I need to be in a place where people are really into Bitcoin.
+And here I am.
+
+Speaker 1: 00:01:30
+
+So how does a mathematician get into Bitcoin?
+Because we need more of them.
+
+Speaker 2: 00:01:35
+
+So I think that there are a lot of really, really fascinating questions inside the space.
+And as a mathematician, I felt like I want better motivations for the questions I'm answering.
+And more, I think people in applied math might also think this way.
+So I think people just need to know that There are really cool questions here waiting to be solved.
+
+Speaker 1: 00:02:04
+
+And what kind of cool questions are you pursuing?
+
+Speaker 2: 00:02:06
+
+So the block building one that we will discuss later, it's a very clean algorithmical question.
+It's very similar to knapsack.
+It's very classical kind of optimization, things that people were working on for a while.
+So it has a new context and it's nice to look at it from there.
+I'm working a lot on the lightning network.
+So there's a lot of economy and other things coming in, but at the end it boils down to network or graph theory.
+So there's very, very nice questions that have to do with optimization and evolution of random graphs and similar things.
+
+Speaker 1: 00:02:54
+
+It sounds like we're going to have to record another episode.
+
+Speaker 2: 00:02:58
+
+We might.
+
+Speaker 1: 00:02:59
+
+OK, so those are the kinds of problems you're currently working on?
+
+Speaker 2: 00:03:02
+
+Yes.
+
+Speaker 1: 00:03:04
+
+Okay.
+So yeah, we'll look forward to getting that on tape at some point soon.
+Tell me maybe like this specific problem of block building.
+Why were you attracted to this?
+
+Speaker 2: 00:03:12
+
+So It's very clear, I think, to anybody that comes from the algorithmic world that what's happening now, it's a straightforward, greedy algorithm.
+And In most cases, this would not be the optimal solution.
+So when somebody from math or CS sees a not optimal algorithm happening, it scratches.
+
+Speaker 1: 00:03:46
+
+Got it.
+And merge.
+So from a Bitcoin perspective, why does this matter?
+Why are we spending our time on this?
+
+Speaker 3: 00:03:52
+
+So what you don't want is that there is a huge amount of potential for somebody to do better than everybody else, Because that will mean that they can make more money building blocks than other people and can get an undue amount of reward for the same work.
+So what we want Bitcoin Core to do is to out of the box do very well, maybe optimally, but reasonably well, that there is no huge advantage for somebody else to come in and Find a proprietary solution that that blows everything else out of the water.
+So One of the reasons to look at block building carefully is to make sure that there is no such hidden potential there.
+
+Speaker 1: 00:04:37
+
+That makes sense.
+It's hard to get miners to upgrade but it seems like they probably make their own patches and you know try to get an edge.
+So writing their own custom software is, you know.
+
+Speaker 3: 00:04:48
+
+You'd think that they'd be super curious to tickle out the last little bit.
+But on the other hand, blocks have been not full.
+And at one satoshi per byte, Even if the block is full, that's 10 milli Bitcoin in reward.
+Right?
+
+Speaker 1: 00:05:04
+
+Today, but you know, a year ago, people were all, fees were all the rage.
+
+Speaker 3: 00:05:09
+
+Sure.
+And in two more years, we'll have another halving.
+And in a few more years, it'll get into the range of a full block at min relay fee where it's interesting.
+I mean, for 20 years.
+So if you already know how blocks are built and where fees and block subsidy come from, That's what we'll cover in the first section.
+Sure.
+And you might want to skip that, we'll put something into our show.
+
+Speaker 1: 00:05:35
+
+Well, I'm excited to talk about this.
+Actually, this one I'm sitting out, so I'm just gonna let you two talk, and then we'll wrap it up.
+
+## Building a valid block 101
+
+Speaker 2: 00:05:47
+
+So, before we talk about building the blocks, we need to understand what are the Lego pieces we're putting into the block, right?
+
+Speaker 0: 00:05:57
+
+So blocks contain transactions.
+Blocks are limited in a number of ways.
+They have to be valid, and they cannot be bigger than 4 million write units.
+
+Speaker 2: 00:06:09
+
+Now, for example, I do know what are the limits on the block, but what are my options?
+Where are the transactions?
+What do I know about the transactions?
+
+Speaker 0: 00:06:19
+
+Right.
+After somebody submits a transaction to the network, the transaction gets validated by every node that sees it.
+And then after validating, they forward it to their peers.
+So to see whether a transaction is valid, a full node will look at what pieces of Bitcoin exist, look at their local copy of the UTXO set, and see that the transaction only spends funds that are still available for spending.
+And eventually those unconfirmed transactions will land in the mempool of a miner and miners will pick from the mempool a block template of unconfirmed transactions that they're trying to build a valid block from.
+
+Speaker 2: 00:07:04
+
+Cool.
+So now we know that we have the mempool, it has this unconfirmed transactions, and then we want to build a valid block.
+So a valid block is of limited size, and we also have some rules into which transactions can go into the block.
+
+Speaker 0: 00:07:25
+
+Right, so you cannot include invalid transactions.
+Well, you can, but it makes an invalid block.
+And transactions have to be in the correct order, right?
+You cannot spend funds that don't exist yet.
+So if you, for example, have a transaction that spends funds from another unconfirmed transaction, the parent transaction has to go first to create the outputs that the second transaction then uses in its input.
+
+Speaker 2: 00:07:51
+
+Are there other ways that the transaction can be invalid?
+Well signatures obviously.
+
+Speaker 0: 00:07:58
+
+Right, so it could be just generally malformed.
+It could spend funds that don't exist, as in like just some made-up pieces of Bitcoin.
+You could have the problem that there's two transactions that spend the same funds, which basically falls under the same rule.
+The first transaction consumes the existing unspent transaction output, and then the second one doesn't have the ability to spend them again.
+You could have an invalid script or invalid signature, or you could have a transaction that spends the same funds twice in the transaction itself.
+So if you naively just check that a transaction only spends one set of inputs and no other transaction does, you might miss that you spent the same funds twice.
+So I don't know the whole set of rules by heart, but there's a bunch of them.
+
+Speaker 2: 00:08:49
+
+So, in this space of block building, I think we'll mostly focus on the limit on the block size and only spending available UTXOs or existing UTXOs.
+
+Speaker 0: 00:09:04
+
+Maybe one more comment.
+There's a special transaction that has to be in every block, which is the coinbase transaction or the generating transaction.
+It's the one that goes first in the block and that can collect a transaction fee and create new bitcoins.
+And after that, a miner may include zero to a full block of transactions, and they can pick any transactions they want, as long as they follow these rules that They're not spending any funds that don't exist yet and so forth.
+It's completely up to the miner to pick what they want to include, but generally is the goal of the miner to collect as much money as possible.
+So we expect miners to build the most profitable block.
+
+Speaker 2: 00:09:46
+
+So how would they do that?
+
+Speaker 0: 00:09:48
+
+Well, currently we assume that most miners are using Bitcoin Core and Bitcoin Core has a function called get block template.
+Get block template will look at the full nodes mempool, the queue of unconfirmed transactions.
+And for each transaction in the mempool, it has stored the size and fees of all of its ancestors plus itself.
+
+Speaker 2: 00:10:14
+
+What do you mean by ancestors?
+
+Speaker 0: 00:10:17
+
+Right.
+So we had previously mentioned, if there are transactions that depend on each other by one transaction first creating a transaction output that another transaction in the queue is spending they have to go in that order, right?
+Because the output has to exist before it can be an input for another transaction.
+So any transactions that topologically precedes another transaction, we call an ancestor.
+
+Speaker 2: 00:10:44
+
+Okay, so For each transaction, we're looking at all of the other transactions we will need to include in the block beforehand for the block to be valid.
+We sum up the weights of all of these transactions, we sum up the fees of all of these transactions, and from this we discover how many satoshis per bit we will get from this whole...
+
+Speaker 3: 00:11:07
+
+Per byte.
+
+Speaker 0: 00:11:08
+
+Per byte.
+Or better yet, per Vbyte.
+Because Segwit's been active.
+
+Speaker 2: 00:11:14
+
+Yay Segwit! Right.
+
+Speaker 0: 00:11:17
+
+Note that this ancestor set fee rate for the transaction does include all the ancestors and the transaction itself.
+The observation here is that the transaction with the highest ancestor set fee rate, including that and all of its ancestors will be the most profitable next step in building a block template.
+
+## The current getblocktemplate algorithm
+
+Speaker 2: 00:11:38
+
+Given these rules for blocks, there is a current algorithm that gives us a block template, right?
+How does it work?
+
+Speaker 0: 00:11:49
+
+Yes, so the call get block template, it uses the mempool, which is already a list of all the unconfirmed transactions with its ancestor set information.
+And then it just looks at which ancestor set will give me the most fees per VBYTE and includes that first.
+And then it updates all the other transactions that are impacted by this ancestor set getting confirmed, recalculating their ancestor set information, and then pops the next one from the top.
+It does that until nothing fits into the block anymore, block template is done.
+
+Speaker 2: 00:12:26
+
+Or until the mempool is empty.
+
+Speaker 0: 00:12:28
+
+Yes.
+Okay.
+
+Speaker 2: 00:12:30
+
+So in general this is a greedy algorithm.
+At every step, we look at a transaction, what would we need to put in to have this transaction in the block, what are the dependencies, we choose the optimal one, looking at its ancestors, put it into the block, and then continue with this question.
+So, are we happy with being this greedy?
+
+Speaker 0: 00:12:58
+
+So, this works pretty well, actually.
+It's also very fast with having pre-calculated all the ancestor sets for the unconfirmed transactions in the mempool already.
+It has two small things, or maybe not quite so small things, where it does not necessarily find the optimal solution.
+So A, it's a greedy algorithm and it does not find the optimal block in the sense that it doesn't necessarily fill the last few vbytes in the block.
+If it just has collected some stuff already and nothing else fits anymore, it won't go back and shuffle the tail end a little more to get the last few satoshis.
+
+## Child pays for parent
+
+Speaker 2: 00:13:37
+
+Given the current algorithm, it also motivates some wallet behavior.
+
+Speaker 0: 00:13:45
+
+As many of our listeners are probably familiar with, there exists a concept called child pays for parent.
+And this leverages the dependency between a parent transaction and a child transaction that a child paying a high fee rate can only get included once its parent is included, because it spends an output that the parent creates and as we have said before already, you cannot include the child unless all of its inputs exist.
+So when you have multiple of these situations in parallel, where say one parent has three child transactions that all pay more fees than the parent, you would have three separate ancestor sets that each compete to be the best ancestor set to be included in the block.
+And you can get now situations where the three children taken together with the parent would have a greater fee rate than what is currently being included in the block, but we would not notice because we evaluate them separately.
+We noticed that if we could search in the mempool data for constructions where this is the case, we actually can find sometimes constellations in which we change what block template would be built and make blocks more profitable for miners by including these sets of transactions together first.
+
+Speaker 2: 00:15:12
+
+The current algorithm just looks at child, parent, parent's parent, and so on and so forth.
+So in some sense it's very one-dimensional, right?
+Just one above the other above the other.
+
+Speaker 0: 00:15:28
+
+Well, you can have multiple parents.
+So it's a DAG or a Directed Acyclic Graph.
+Yes, it's fairly one-dimensional because you basically just look at a transaction with all of its ancestors.
+
+Speaker 2: 00:15:41
+
+So in the current algorithm, we're just looking at a transaction and all of its ancestors.
+
+## Is there something better?
+
+Speaker 2: 00:15:47
+
+In what we are suggesting to do, we want to do something slightly more complicated where we look at sets of transactions and all of their ancestors, right?
+Because we can't put transactions without all of their ancestor set, but our starting point would not be a single transaction, but we could have many transactions.
+
+Speaker 0: 00:16:14
+
+Essentially, you can think of what we're searching for as an overlap of multiple ancestor sets, right?
+So if you have a single child that pays for its parent, you would want to combine it with the ancestor set of another child of the same parent.
+So they need to have some overlap in their ancestry, they need to be connected in the graph in some way, but the overall situation is such that through the shared ancestry their set fee rate for the whole set of transactions is higher than for any of the individual ancestor sets.
+
+Speaker 2: 00:16:49
+
+That sounds great, but as we know, one of the main things that we want from a block building algorithm is for it to run quickly.
+
+Speaker 0: 00:17:01
+
+Yes, so especially in the moment after a new block is found, we want miners to be able to switch over to building the succeeding block as quickly as possible.
+And miners often build an empty block template intermittently because they don't know for sure which transactions they can include until they have evaluated the parent block.
+But we want them to be able to switch over as quickly as possible to a full block at the next height.
+
+Speaker 2: 00:17:29
+
+So let's talk implementation a bit.
+
+Speaker 0: 00:17:32
+
+As you might imagine, if you have all the ancestor sets for every transaction, you have a very clean list of things that you need to look at.
+For every single transaction, you just look at all of its ancestors.
+That's O of N in the size of transactions.
+To find what we call candidate sets, these overlaps of multiple ancestor sets that could be even more profitable to include, we need to essentially search the power set of graphs of transactions that are connected.
+So what we do here is we look at one transaction that has a high fee rate and then we cluster all of the transactions that are connected to it either via child or parent relationships.
+I'll be referring to this construct, the maximal set of connected transactions as a cluster.
+And then in this cluster, we want to find the best subset, best as in the highest set fee rate.
+Obviously, we can only include sets of transactions for which all the ancestors are included.
+So we're looking at some overlap of ancestor sets and we call this a candidate set.
+
+Speaker 2: 00:18:44
+
+So this candidate sets could be ancestor sets as we've seen in the current algorithm, but because we're allowed to traverse up and down from child to parent to parent back to child, we get a more complicated structure.
+But to keep the block valid, we need to make sure that at the end, whatever we're trying to put into the block has all of the ancestry.
+
+Speaker 0: 00:19:11
+
+Exactly.
+Right.
+So, as you might imagine, This is no longer searchable just in the order of the size of transactions, because now we have to essentially search through the power set of all the transactions in every cluster.
+That explodes very hard in the complexity, and that gets us in trouble with, we want us to run really, really fast.
+Our idea is we would continue to quickly build a fairly good block using the ancestor set based block building that we have already.
+And then we would perhaps in the background have a second process that searches for a more profitable block using these candidate sets that we have been discussing.
+
+Speaker 2: 00:19:57
+
+But of course we don't actually need to look at the power set of all the transactions.
+So the first thing we need to remember that a lot of subsets of transactions are just not allowed into the block.
+So we definitely want to focus our search on subsets that are valid.
+Even when we focus ourselves only on valid subsets, we can also do things a little bit in a smarter way.
+
+Speaker 0: 00:20:29
+
+Right, yeah, There's a few nifty little tricks that we found while we have been writing our research code for this.
+We start our search in the cluster by a number of initial candidate sets, and since we have them already, we just initialize with the ancestor sets that exist in the cluster, which is for every single transaction in the cluster, we have already a starting set.
+The next observation we had was when we have an ancestor set in a cluster that has fee rate x, any leave in the cluster, as in any childless transaction in the cluster, that has a lower fee rate than that, can never lead to a better candidate set than this.
+So, if you have a transaction A that pays 5 satoshi per byte, that has a child which pays 4, you will never get a better candidate set by including this child with 4 when you already have something that pays 5 satoshi per byte.
+
+Speaker 2: 00:21:30
+
+I think an important point to make is that when we're thinking about fee, we're talking about effective fee rate.
+So we're not interested in fee that this transaction would give us.
+I again remind our listeners that we're talking about fee per vbyte?
+
+Speaker 0: 00:21:48
+
+Yes, I might accidentally say fee, I always mean fee rate, and always specifically the fee rate of a set of transactions that if we include them together would be the highest across all the unconfirmed transactions still in our mempool.
+So we have two optimizations so far.
+One is, obviously we don't have to search the whole power set of transactions in the cluster.
+We can limit ourselves to only searching the valid subsets.
+And we can do that by starting with the ancestor sets in the cluster, and then expanding from the ancestor sets by adding additional ancestor sets to that.
+So specifically, if we have a set of transactions, maybe just a single transaction that doesn't have any unconfirmed parents, we would add the ancestor sets of each of its children to create new candidate sets to add to our search list.
+And we basically just go through our search list greedily.
+We first evaluate the candidate sets with the highest fee rates, expand from those again.
+But since we start with all the ancestor sets in the cluster already, we can very quickly use the leaf pruning that I mentioned to cut down on transactions that we never have to look at.
+So every time we find a better candidate set in the cluster by expanding it, for example, by including a second child for a parent and getting a higher set fee rate, we actually reduce the search space at the same time.
+So very quickly on this cluster we'll find one single best candidate set and have evaluated all possible combinations, either by dismissing them or by having actually evaluated them.
+And then we just remember this as the best possible candidate set in a cluster of transactions.
+Now, if we look at a mempool, a mempool can have up to 300 megabytes of transactions, and we don't really want to traverse all of that immediately.
+Really we only want to look at the relevant transactions.
+So what we do is we sort all the single individual transactions by their fee rates, and we only start clustering even on the transactions that have the highest fee rates.
+So we basically move down from an infinite fee rate and pick the single transaction with the highest fee rate, search for its cluster, look what the best candidate set in that cluster is, check out what the set fee rate for that candidate set is, and then we resort the whole cluster into our list of data that we need to look at, at the fee rate of the best candidate set in that cluster.
+Then we use for example a heap for that and we bubble up the next transaction or cluster by highest fee rate.
+And if a transaction bubbles up, we cluster it and sort it into the heap as the cluster.
+If a cluster bubbles up, we pick its best candidate set because now we know across all of the mempool, this is the set of transactions that has the highest possible fee rate, and we can just include it in our block.
+When we include a candidate set into our block, we naturally need to remove it from the cluster, and we have to update all the transactions in the cluster to forget these as unconfirmed ancestors, and therefore like have new ancestors set fee rate, ancestor size, ancestor fee, and we put them back into our list of single transactions.
+And we only look at them again if any of those single transactions bubble to the top by fee rate before we fill the block.
+And that's a few of our optimizations so far, I guess.
+
+Speaker 2: 00:25:45
+
+Yeah, and I guess that if we would have other pre-calculations, we could have made things quicker.
+Because we're starting now only with the Ancestry sets for each transaction, but we could have pre-calculated such clusters or something like that.
+
+Speaker 0: 00:26:05
+
+Well, the downside of pre-calculating all the clusters is that we would have to cluster all the 300 megabytes of mempool potentially, when in the end we actually want to only include about one megabyte.
+
+Speaker 2: 00:26:18
+
+Right, but we get to do it to some extent in our off time.
+We don't do this when we build the block and we're in a hurry.
+
+Speaker 0: 00:26:26
+
+Oh absolutely, we should be pre-calculating the whole block Actually, not just cluster information.
+The cluster information is somewhat ephemeral anyway.
+As soon as you pop the best candidate set out of the cluster, you have to recluster and research for the best candidate set, right?
+So Just pre-calculating the clusters is sure a little benefit, but actually just pre-calculating the whole block template in the background on a loop, say every time we add new transactions or every minute or so, and then having something at the ready when the user calls getBlockTemplate would be maybe interesting.
+Of course the problem is when a new block gets found and when we want to have a new block template quickly, it might be slow to do all the candidate set search on every cluster and all that.
+
+## How easy would it be to guess the next block?
+
+Speaker 0: 00:27:20
+
+So we should, when it's supposed to be as quick as possible, we should use the ancestor set based approach and respond with that first.
+
+Speaker 2: 00:27:31
+
+I wonder how easy it is for us to guess what's the next block we're going to see.
+So to calculate both the block we want to mine now and the block we will want to mine once we'll hear about the block.
+Because if everybody's using the same algorithm, I know what's going to be in the block I'll see pretty much.
+So I have a good guess at least.
+
+Speaker 0: 00:27:55
+
+You have a very good guess, but I think especially for transactions that were just broadcast on the network, you don't have a good guess whether the miner has it already included in the block template.
+Even if the mining pool operator has seen it already, they give out templates to all the mining machines only whenever the mining machine has exhausted the template they're working on.
+So even for like 10-20 seconds after the pool operator has built a new block template, the machine will maybe still work on traversing the extra non-space for that block, for the previous block template.
+So there is a little bit of a latency between a new block template being created and that actually being what mining machines work on, so you could be missing some transactions and that would not be a huge problem.
+You would just not have them in your look ahead block template.
+But you might also have some transactions that are precious to the miner, because say they also have a wallet business on the side and they prioritize the transactions of their customers or they have an accelerator service and include some transactions that are actually not in the very top of the mempool but maybe would be in the lookahead block.
+So even if you have the lookahead block, you can't really use it until you've evaluated that it has no conflicts with the previously found block.
+
+## Do we have a better idea than initially mining an empty block?
+
+Speaker 2: 00:29:27
+
+Do we have a better solution than mining on an empty block in the beginning?
+Should we guess a block and take the risk that it won't be actually valid or should we go for an empty block?
+
+Speaker 0: 00:29:42
+
+I guess at this point the transaction fees make such a small part of the total block reward.
+And the total block reward of course consists of two parts.
+There's the block subsidy, which is the newly minted coins, and there are the transaction fees from the transactions included in the block.
+And we had a period of six and a half months earlier this year where we did not have an empty mempool.
+There was always a queue of transactions trying to get confirmed.
+But since mid-June roughly, we've had ample block space, mostly because there was a huge shift to more efficient output types getting used, and the hash rate reduction that happened after China banned mining was quickly regenerating, so we had faster blocks for some time, and faster blocks means more block space, of course.
+So those two things together, I think, led to us essentially having abundant block space all the time, which meant that the fee rates have been very low for the past five months.
+And whereas in the first half of the year, the reward was about one-sixth transaction fee, in the past half year it's been more like maybe less than 5%, 2 or 3%.
+The risk of having an invalid block and losing the newly minted coins is probably going to outweigh the reward of including transactions in the block.
+
+Speaker 2: 00:31:14
+
+But we can expect sometime in the future a sharp threshold moment or just a threshold moment as the block reward is having after, give or take, four years.
+
+Speaker 0: 00:31:29
+
+One thing that miners could do is that they keep a stash of their own transactions that they don't broadcast to the whole network and only use for their own block templates and the moment that a new block is found they include those.
+The problem is if they always include them in their block templates, they would leak because people see what block template they're building.
+So I haven't thought this through enough to make sure that it's a viable idea, but I think that empty block mining will remain a thing.
+What we want to do is to make block validation as quickly as possible, and then to make block building as quick as possible so that there's as little delay as possible between a miner hearing about a new block and starting to mine a new full block.
+
+Speaker 2: 00:32:18
+
+I do find the concept of a miner having secret transactions, so to say, that they keep on the side.
+Where did they hear about these transactions at all?
+
+Speaker 0: 00:32:30
+
+Oh, I mean, for example, they could have payouts to their pool contributors or there is one mining pool that was closely associated with a wallet service for a while.
+You could just beat those.
+But on the other hand, That seems a little far-fetched because if you have a wallet service, people want to transact.
+They don't want to wait for that transaction to go through.
+
+Speaker 2: 00:32:54
+
+So actually as a mining pool, if I want to pay the miners, It does make sense to, instead of mining on an empty block, mining on my rewards if I'm paying out of previous block rewards, because I know there's not going to be a conflict.
+These are fresh coin, just minted.
+Nobody could have touched them besides me.
+Do we see this behavior?
+
+Speaker 0: 00:33:19
+
+I don't think we see that very much.
+I'm also kind of expecting that given there's very frequent payments of small amounts to people, I would expect that mining pools would eventually adopt lightning as a withdrawal means to their pool contributors.
+I've taken a lot of time to say that.
+I expect empty blocks to remain nothing.
+
+Speaker 2: 00:33:44
+
+Cool.
+
+## Empty blocks and SegWit
+
+Speaker 2: 00:33:45
+
+How often do we see empty blocks?
+
+Speaker 0: 00:33:47
+
+Not that often anymore.
+We actually saw a fairly sharp decline in empty blocks when SegWit happened, because SegWit required miners to update their software.
+And for a long time, miners had been running older software, and all the efficiency improvements in the peer-to-peer layer and block building and stuff like that suddenly came to pass in the software upgrade.
+And we saw two things.
+We saw especially that there was a lot fewer mini blockchain forks where there was latency and or validation was slower and two mining pools found blocks at the same height And that was especially because the compact block relay happened between whatever they were running and SegWit.
+And then I think also a little bit faster block validation and build.
+
+Speaker 2: 00:34:45
+
+So this is what we have on our plate now, but we're already talked a bit about what might happen in the future, but We also have a few thoughts about What else can we do to make block building even better?
+
+## How to improve on the candidate set algorithm e.g., linear programming
+
+Speaker 2: 00:35:02
+
+So there is linear programming solutions that solve, to some extent at least, the other problem we've talked about with blocks.
+
+Speaker 0: 00:35:18
+
+The optimal use of all the available block space.
+
+Speaker 2: 00:35:21
+
+Right, because sometimes when you're doing greedy things, you, so a very crude example would be, I can fit two kilos into my knapsack.
+And thanks for everybody who giggled because they know what's the knapsack problem.
+So you can put two kilos in your knapsack and you want to put as many items as you want.
+You have one item who weights a kilo and a half and two items that weight one kilo.
+So if you're greedy, you take the kilo and a half item and can't fit anything else.
+If you're not as greedy, you look at it and say, okay, I can take the two items that weight one kilo each.
+So this is a problem that our current algorithm does not solve, but by using linear programming techniques could be solved.
+Downside of this techniques that they have a tendency to be slow, although it's unclear that they have to be, and this is something we definitely would like to look into.
+
+Speaker 0: 00:36:42
+
+So basically by running linear programming we would be able to find out how close to the optimal solution we can get with just a candidate set-based approach.
+
+Speaker 2: 00:36:55
+
+Any other thoughts on the future?
+
+## Why should Bitcoin Core have better block building?
+
+Speaker 0: 00:36:58
+
+Maybe we should touch on why it's important that Bitcoin Core has really good block building.
+The idea is we want the set of miners to be an open set where anybody can enter and exit as they wish, especially the entering is interesting obviously, and if we now had obvious optimizations that people had to implement to be as competitive as possible, that would make it harder for new miners to enter this place.
+
+Speaker 2: 00:37:32
+
+So I would like to comment that even if now the mining fees from transactions are not a crucial part, in the future they either will become something important or mining won't make sense.
+As the block subsidy is going down, the fees become more and more important.
+And so in the future, this would carry a lot more weight.
+
+Speaker 0: 00:38:01
+
+Yeah, definitely.
+Even if we're thinking right now, this week we just crossed 90% of all bitcoins being in circulation.
+In 2036 it'll be 99%.
+In, I think, 2046 it'll be, or 2050, it'll be 99.9. And as the block subsidy keeps halving, even just a regular full block at minimum fee rate will eventually have more fees than new coins.
+I think that's reached by 2060 with one Satoshi per VBITE and four million white units.
+
+Speaker 2: 00:38:38
+
+I think this is already something Satoshi mentioned in the white paper.
+
+Speaker 0: 00:38:44
+
+I mean that's a far, far future but we're trying to build a system that lasts for multiple decades.
+So we have to think about the long-term incentives.
+
+## How to compare different block building techniques
+
+Speaker 0: 00:38:55
+
+So Clara, tell me, we had an idea how we should be measuring whether our candidate set-based approach makes sense and is a good improvement.
+Can you tell us a little more about that?
+
+Speaker 2: 00:39:09
+
+So there are a few ways we can compare different block building techniques, one of which is just looking at a certain mempool and then saying which block building algorithm will do better, which is a valid point of view, which we're exploring.
+But another very interesting thing to look at is what happens if, say, 2% of the miners use our new algorithm while the rest are using the old one.
+And for this we want to use a simulation, of course, that does the following.
+So we have snapshots of the mempool.
+And then at any moment we know that a block is built.
+We're going to flip a coin that tells us are we going to use the old algorithm or the new algorithm.
+And then a block, we build a block, we update the mempool, there's new transactions coming in, again find a block, flip a coin, and decide.
+Some of the listeners might be familiar with Monte Carlo and things like that, so if this is where your mind went, you are absolutely correct.
+And by doing this, we can compare how much can a miner gain when they move to the new algorithm, especially in an environment where the old algorithm is still running.
+This might also affect the changes, how quickly will the algorithm be taken by the other miners, because If you can already do much better by being the only one that does it, that's a very nice incentive.
+
+Speaker 0: 00:41:06
+
+Right, and then there's also the aspect, it's hard to say how it will affect how wallets build transactions when there's new behavior in how blocks are being built.
+So when we actively search for situations in which multiple children or descendants bump an ancestor together, this might lead, for example, to people crowdsourcing a withdrawal from an exchange with 200 outputs to get it confirmed a little quicker.
+We wouldn't be discovering that right now at all with ancestor set-based block building, but we would discover that with candidate set-based block building, and then maybe if there's a few, two, three, four percent of the miners already using that, people might start to say, all right, I'll chip in and try to spend it already and together we'll get withdrawal confirmed more quickly.
+And that would be the incentive for miners to switch over and start using the new block building algorithm for mining.
+
+Speaker 2: 00:42:08
+
+We already see this sort of crowdsourcing behavior in the mempool.
+
+Speaker 0: 00:42:14
+
+So We found a few interesting clusters when we were analyzing mempool snapshots.
+We have this data set where we have when a new block came in, the node took a snapshot of what was currently in their mempool and we can then compare what we see in the block and what was available for block building and that's what we use to build our alternative blockchains in this Monte Carlo approach and We found some curious clusters already with over 800 transactions where there's a lot of children spending from the same parent and stuff like that.
+So there is some of that going on already, but currently of course mining doesn't exploit that so people aren't doing it on purpose.
+It's just people that are, I don't know, withdrawing from a broker and the broker has such a volume that they pay out to a hundred people at the same time and five of them are immediately try to spend it at the same time but they're competing with each other because it's getting evaluated as five separate child pays for parent attempts whereas we would be evaluating it as a single descendants pay for ancestor constellation.
+So we do the Monte Carlo approach, we run that alternative blockchain that we're building a few times with say 2% of t miners using our new algorithm already.
+What do we do then?
+
+Speaker 2: 00:43:37
+
+And then we compare how better did the miners that use the new algorithm did comparing to the ones that use the old algorithm.
+So that's another viewpoint for comparing these two algorithms.
+So we already have some data available, there's more coming up.
+
+Speaker 0: 00:44:01
+
+Yeah, we published a thing about basically comparing one algorithm with another algorithm at a specific height for every block.
+Now we're doing the let's build a whole blockchain instead because that's more fair because we won't reuse the same transactions again.
+Say there's a constellation for a candidate site that should get preferred, we would be including it maybe for multiple blocks in a row if we don't build in a whole alternative blockchain.
+
+Speaker 1: 00:44:33
+
+Maybe just sort of to wrap things up, I have two questions of listening to that episode.
+The first one is, if you can get more fees into this current block, doesn't that just pull fees from a future block?
+
+Speaker 2: 00:44:45
+
+Well, if there aren't a lot of transactions in the mining pool, that is the whole current mining pool can fit inside of a block, you don't need any sophisticated algorithm.
+You just need the block to be verifiable and have the transactions in the correct order, and you send it off.
+It doesn't matter what you're doing.
+Our algorithm becomes important only when you want, only when there is actual competition for block space.
+And in that case, you're assuming there are more and more transactions coming in.
+So yes, you're taking the transactions now, but there's going to be more transactions later on for the next block.
+
+Speaker 3: 00:45:27
+
+So it's kind of fun how it works out.
+We want people to build the best possible blocks and we want for example to have these constellations of multiple children to bump a parent together and it turns out that if a minor does find these constellations they also make more money.
+So if there's only one miner out of 20 that adopts this, they'll make more money than the other 19, and other miners will also adopt this new algorithm.
+
+Speaker 1: 00:45:58
+
+That's a nice incentive.
+And then my other question is, obviously, mining is a cutthroat game.
+And so when you're talking about the speed of serving these block templates and these optimized blocks, where's the edge of speed versus the optimization of the fees?
+
+Speaker 2: 00:46:18
+
+So in some cases, you'll find miners even mining empty blocks in the beginning.
+So you can think about it as a stepped process.
+You start with an empty block, then you use the quickest algorithm that gives you a good enough block.
+And then after a while, if you haven't found a block, you look for a better block.
+And you can think about other algorithms even better than what we're proposing now that are even slower using linear programming or something like that, that would also be like the third block template that you serve if you find that you have enough time.
+
+Speaker 3: 00:46:57
+
+What happens when you run a mining pool is that you don't create one black template and then your miners are working on that for the whole duration until the block is found.
+You keep updating that as more transactions come in.
+So you're constantly re-computing the block template anyway.
+If some of those happen to just have a little more fees a little later after you switch to a new height.
+I don't think sure it might not be mined on in the first half minute or so but generally if it's transparent it'll just snap into place.
+
+Speaker 1: 00:47:32
+
+Makes sense.
+So this sounds better in every way.
+When do we see it in the wild?
+
+Speaker 3: 00:47:39
+
+Well, careful asking around a little bit what might need to happen for such an algorithm to get integrated into Bitcoin Core seems to indicate that there might be either a need to make it run separate and The architectural challenge of that would be easy, or if you want to integrate it properly into the mempool.
+Mempool is such a central part of how everything fits together in Bitcoin Core, that would be a pretty invasive change.
+
+Speaker 1: 00:48:16
+
+So I'm a little bearish on the timeline okay all right very good well thank you both for your time enjoy the conversation and we'll look forward to getting Claire on soon again thanks Thanks.
+
+Speaker 3: 00:48:30
+
+Thanks.
+
+Speaker 2: 00:48:45
+
+You

--- a/chaincode-labs/chaincode-podcast/lightning-updates-stratum-v2.md
+++ b/chaincode-labs/chaincode-podcast/lightning-updates-stratum-v2.md
@@ -1,0 +1,826 @@
+---
+title: "Lightning updates / Stratum V2"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://podcasters.spotify.com/pod/show/chaincode/episodes/Steve-Lee-and-Lightning-updates--Stratum-V2---Episode-23-e1ofl4j
+tags: ['lightning', 'zero-conf-channels', 'stratum-v2']
+speakers: ['Steve Lee']
+categories: ['podcast']
+date: 2022-09-28
+episode: 23
+
+---
+Speaker 0: 00:00:00
+
+Hey Jonas.
+
+Speaker 1: 00:00:00
+
+Hey Merch.
+What are we up to?
+We are back.
+
+Speaker 0: 00:00:03
+
+Who are we recording today?
+We have Steve Lee in the office this week.
+He is the head at Spiral.
+Yeah.
+He's done a lot of open source development.
+He talks to a bunch of people.
+He's also the PM for the LDK team.
+So we're going to talk Lightning, the challenges that are open with Lightning, and maybe a little bit about other projects in the space.
+And I want to touch a little on Taproot.
+
+Speaker 1: 00:00:28
+
+Yeah, totally.
+We talked, again, not just about lightning, but sort of weighted into Stratum V2 and that new spec that's coming out and the project around there.
+So great way to get back into the swing of things.
+We've been taking a little bit of a break here.
+Welcome Steve.
+Let's just sort of dive right into it.
+So maybe we can start a little bit with where is LDK these days and what you're thinking about and then we can maybe move into more specific topics from there.
+
+Speaker 2: 00:01:01
+
+Thanks for having me on.
+Yeah.
+Great to see you guys this week.
+
+## Lightning Dev Kit
+
+Speaker 2: 00:01:03
+
+Let's start with LDK.
+So the Vyral team and other contributors have been working on it now for about two and a half years.
+Last year in the spring of 2021, we got our first real adopter of it.
+The LDK had matured enough to get ready for someone to adopt and BlueWallet to date had been non-custodial for on-chain but custodial for Lightning and they wanted to move to non-custodial for Lightning.
+They successfully integrated it on their iPhone app and their Android app by August of last year.
+And it's actually in the App Store, but it's still not the default experience.
+So I thought I'd share some lessons learned, like why isn't it the default experience yet.
+The good news is, LDK worked exactly as the LDK contributors had planned, and it was great to have a first adopter be able to get it working.
+But the biggest problem for Blue Wallet is that the channel management is still manual.
+Like an end user has to set up their channels, manage the liquidity, etc.
+Wallets like Breeze and Moon and Phoenix have demonstrated that if you do that automatically, it's a much better user experience.
+So I think one lesson learned for everyone in the Lightning space is that we need more LSPs, we need LSPs that are available for any wallet to integrate with, and we need an LSP spec.
+And so The good news there is that there are a lot of people working towards that, both the spec and commercial LSP services.
+
+## Zeroconf Channels
+
+Speaker 2: 00:02:21
+
+So that's one lesson.
+There's a few other features that Blue Wallet was hoping for out of LDK and we've delivered with them.
+One is zero confirmation for Lightning channels and not only did LDK implement that, but it's actually part of the Lightning spec now and LND and CLN support that as well.
+So that's an improvement in the past year.
+
+Speaker 1: 00:02:39
+
+That's really just on first use?
+Yeah.
+
+Speaker 2: 00:02:41
+
+I mean, how it impacts the user experience is that if you're like onboarding a brand new user, you install the wallet, you can't receive money right away.
+So to get, you need to inbound liquidity and a channel opened to you.
+If you have to wait for six confirmations, wait an hour or so, not a great first time experience with an app or a product.
+So zero-conf makes it instant.
+And the trust model there is such that it's reasonable to take the risks of, I mean, zero-conf in general has security risks on lightning and specifically with the relationship between a wallet and an LSP.
+I think most people consider that a reasonable risk to take for the UX benefit.
+
+Speaker 0: 00:03:18
+
+So the idea is that usually users first want to receive, not send.
+And by having the Toribird channel, the LSP basically just trusts them for whatever amount they're going to receive.
+But since the channel isn't confirmed yet, it's not really lost.
+And if so, it's just pushed to the other side at the point when it gets confirmed.
+
+Speaker 2: 00:03:38
+
+That's right.
+And so that was one change they wanted to see that's been made.
+So I think, you know, all wallets are gonna be able to take advantage of that moving forward.
+
+## Rapid Gossip Sync
+
+Speaker 2: 00:03:46
+
+Another was that the way that they initially implemented or integrated LDK into their wallet, they did the pathfinding, like finding a route to do a payment on the server still.
+They weren't doing it on the phone.
+They did it that way because of performance reasons, because one of the most resource-heavy activities in Lightning, in Lightning Protocol, is doing pathfinding.
+You have to download the entire Lightning graph onto the phone.
+And so a feature that the LDK project worked on in the past year was just announced within the past week or so called rapid gossip sync and let me actually first start by saying what's the problem with doing it on a server?
+The problem with doing it on a server is whoever controls that server has all the payment data.
+So you know a company that has thousands or millions of users they have millions of users entire payment history and which has obvious privacy implications.
+
+Speaker 0: 00:04:38
+
+And not only that, they also control the routes, so they could, for example, take a route that earns more fees and things like that.
+
+Speaker 2: 00:04:44
+
+Yeah, that's a good point.
+You're trusting for that as well.
+So now let me describe Rapid Gossip Sync, which also actually has that drawback to what Mark just mentioned.
+With Rapid Gossip Sync, it's intended to enable client-side, like in a phone, pathfinding in a performant way.
+Right now the entire Lightning network graph is on the order of 60 megabytes.
+So the problem with mobile development is you can't guarantee that your app can run in the background.
+So ideally you could just download this data over time continuously in the background, but that's not possible.
+So if a user hasn't opened your app for days or weeks or even months when they go to open it, it might take dozens of seconds or even, I've used some wallets that take minutes to sync before you can use it.
+I'd call that a showstopper user experience for mainstream adoption.
+With Rapid Gossip Sync, What we've done is filter out a lot of the gossip protocol information that's not necessary for pathfinding and also compress it.
+And we've been able to squeeze that 60 megabytes down to like two megabytes and measured it at like 0.4 seconds to download and process on the client to be able to do routing.
+So we believe it will be performant enough that even if it's been like a month since you've opened the app, the user won't even notice that's happening and by the time they wanna send a payment, it just worked.
+The one caveat is what Mark mentioned earlier, trusting the server to not withhold graph data.
+So a trade-off here is that whatever server's serving up the Rapid Gossip Sync, if it wanted to, like let's say it were being run by the LSP it could selectively choose certain data withhold to optimize the routes going through nodes that it controls to maximize its fee revenue.
+So that's a trade-off with it that exists as well even if you're doing in the cloud.
+So I think what's important for Bitcoin and the deployment of this is have good reasons to trust the server that you're downloading it from And ideally it's independent from any money-making, lightning infrastructure provider.
+
+Speaker 0: 00:06:34
+
+When you do rapid gossip sync and you push basically a skeleton of the graph to the mobile phone, is there a way to backfill, pad the route between a receiver and the mobile phone that I just learned more about neighbors of my route or something like that.
+There was a very early blog post by Rusty years ago where he talked about beacons for when the lightning network gets immensely large.
+Does something like that happen, or is that basically in there already because the skeleton prunes for the most important channels and routes and nodes?
+
+Speaker 2: 00:07:12
+
+Well, just to be clear, so what Rapid Gossip Sync does today, it is the entire network graph.
+It just eliminates a bunch of data from the gossip protocol that's not necessary for that.
+So it's not a subset of the graph.
+Again, there could be a malicious server that prunes things out, but the way the code's written and the way it's intended to be run, it's the full graph, but it does remove like signatures and a bunch of unnecessary information so that the client can't prove to itself that it's the complete graph.
+That's the trust.
+Now in the future, So I mean, an open question is if, yeah, the Lightning network grows a thousand fold over the day, is it still gonna be practical to download to the phone?
+There's reasons to believe yes, but I mean, still to be determined.
+But a lot of the information that's been eliminated to make it faster is literally redundant information.
+
+Speaker 0: 00:08:04
+
+I see, I see.
+Yeah, I miss it.
+
+Speaker 2: 00:08:05
+
+And then another part about that too is it would be possible to use Rapid Gossip Sync but also download all the gossip data, do both so that you can sort of check on the server that's serving that up to sort of police it.
+That's gonna be a question of, or so to do a payment, you're not dependent on that, but to sort of double check its work, you could do that.
+That's just a question of like, is it worth the bandwidth and what's that cost gonna be to that user?
+
+Speaker 0: 00:08:29
+
+Yeah, especially on a mobile.
+
+Speaker 2: 00:08:31
+
+We'll have to see how that plays out.
+I think it's really good to have this infrastructure in place, though, to be used.
+But that was another request by Blue Wallet, and I believe they're experimenting with it right now.
+I know some other wallet developers, too, that are experimenting with it.
+So I look forward to seeing actual performance data and actually trying out prototypes and real wallets using this to just confirm that it really is performant.
+I think it will be based on our data so far, but it'll be nice to see the end user experience.
+
+## How does LDK pick priorities?
+
+Speaker 1: 00:08:55
+
+So just as you think about your roadmap, a lot of this feature set is influenced by people who aren't able to use it in the way that you hoped they would use it?
+Is that sort of the idea?
+And how's it being informed on BlueWallet and whatever else?
+
+Speaker 2: 00:09:10
+
+Yeah.
+So I'd say more generally, how does the LDK project pick its priorities, what it works on?
+Two huge inputs.
+One, you already mentioned, users.
+And the users of LDK are other developers building apps and wallets.
+So we certainly listen to all of our existing users.
+We're also listening though to prospective users that have maybe looked at LDK and given feedback as to why they're not proceeding with it or what they want to see before they do.
+I'll speak to that in more detail in a second.
+We also, of course, it's compatible with the Lightning specification and protocol specification.
+So, LDA contributors work with LND and CLN and Eclair and other Lightning protocol developers on both making sure that we're standard but also working on protocol improvements.
+Like Lightning has a long ways to go to improve security and privacy and scaling in UX.
+So we're working with other implementations as well.
+That's the two big areas that influence what we work on.
+Let me go a little deeper on what we've been hearing from mobile wallets that wanna use LDK.
+Blue Wallet, they did a great job of taking the LDK API, integrating it, so have other wallets as well.
+But there's another category.
+
+## LDK Lite
+
+Speaker 2: 00:10:10
+
+What I've observed, developers who have experience with Lightning tend to understand the LDK API and use it, and they understand why they want to use it, and they make good use of it.
+I think other developers who might have Bitcoin experience but haven't done Lightning yet might find LDK API to be a bit intimidating.
+Either perception or reality or a mix of both, but I think the perception's definitely there, and it is a powerful API, and arguably a bit overwhelming if you're just learning Lightning.
+So a sub-project within LDK that was undertaken a few months ago, tentatively named LDK Lite, although we're still trying to figure out how to refer to it, is really just intended to create a much simpler API for mobile wallet developers to get started.
+But one that could be used in production and one that we think, you know, for those that aren't super familiar with LDK, it is not one instance of a lightning node implementation.
+It's a toolkit to allow you to build a Lightning Node.
+And so it allows you to pick any recipe you want, which is super powerful.
+But there happens to be one recipe for mobile that I think will satisfy many mobile wallets.
+So we're going ahead and building that recipe to simplify the API down to pretty much like send and receive.
+It's a little bit more complicated than send and receive, but sort of our aspiration is to make it as simple as send and receive.
+And so that's being worked on right now and hopefully will be available within even weeks for early testing.
+And I think that is going to be really well received by a lot of mobile wallet developers that I've spoken with to get them going much faster.
+Then for some of them, they'll be able to launch a product with it.
+Great.
+Others will find that it just doesn't give them enough flexibility that they want and then they can use the more powerful LDK API.
+
+Speaker 0: 00:11:48
+
+But it's a good stepping stone to get there and to familiarize yourself with the problems.
+What's the interface?
+Is it like broken down to the level of create invoice, receive payment, pay invoice and create invoice?
+Or is it?
+
+Speaker 2: 00:12:01
+
+It's pretty much that simple.
+I mean, it also includes like creation of channels, but the hope is to utilize LSP spec that's being built out so that even if a wallet developer wouldn't even have to like manually create their own channels, they could just use the LSP spec.
+So even the wallet developer in that case wouldn't be doing all of the channel management work.
+Also probably like you know a transaction history or payment history AP call to get that data.
+
+## Will LSPs be needed forever?
+
+Speaker 0: 00:12:25
+
+Right.
+You've been mentioning LSP's Lightning Service Providers a lot.
+Would you say it's accurate that as a mobile wallet, you basically are always contingent on a service provider because most nodes will not want to have a channel with you?
+As a mobile client, you're offline most of the time.
+Is that still the case or is there something in the future that will change that?
+
+Speaker 2: 00:12:47
+
+No, I think that's the case, you know, for both the offline concern that you mentioned and also just, you know, mainstream users I don't think are gonna wanna manage their own channels.
+That feels much more like a hobbyist or someone running a small lightning routing business kind of interface.
+
+Speaker 1: 00:13:03
+
+But that couldn't be simplified as in there's, you know, there's, there's optimization around the edges for something like that, as in your home node could be providing those services for you.
+And then you're using, I mean, the ride, the lightning Zeus sort of family of remote control kind of way.
+
+Speaker 2: 00:13:18
+
+Yeah, so that's all true.
+So I don't think there's not one solution that any of us could say that's going to be for everyone.
+I'm bullish on the umbrellas and my nodes and running a mall server at home.
+I'm actually bullish on that.
+But today it's very much a hobbyist environment.
+But I think that can become mainstream.
+But let's define mainstream.
+Like think like a home run success over the next five to eight years would be 100 million people in the world having something like that.
+Like basically, you know, a Bitcoin bank in their home.
+I think the bill of materials for that gets down to like five or ten dollars, super cheap, and it gets integrated into other home device products that people buy.
+So it's just a very simple experience.
+But a home run success there is like 100 million people having that, which would be amazing.
+That's not billions, that's not the world.
+There'd be many people probably in emerging markets and stuff that aren't gonna have that at home.
+So we also need to think about running a note on your phone as well.
+And basically giving mobile phone users the most trust-minimized solution as we can.
+I'd say that's the goal of Spiral and I think that the K Project.
+So today it's true, there's several servers or services on servers that are needed to build out a wallet and a Lightning wallet, maybe like five or six different types of services that are needed on servers.
+There's a roadmap and a path to keep eliminating those or reducing those and shifting the intelligence to the phone.
+We just talked about one, rapid gossip sync is a way to shift not everything to the phone, but it does reduce trust because it's a privacy win.
+LSPs and providing liquidity, I think it's going to be hard, except for the home node case to do.
+So what's important is having a spec, having lots of alternatives.
+And ultimately, I imagine a wallet developer will connect to multiple LSPs so that the wallet doesn't become dependent on one LSP.
+And some wallets might have an interface that even exposes that to the end user so the end user can choose their LSPs as well.
+So reducing switching costs and making that very frictionless, I think it's important for Bitcoin.
+Because we don't want to end up in a state when one company is the LSP.
+
+## Validated Lightning Signer
+
+Speaker 1: 00:15:19
+
+Maybe moving on, the next topic would be, and I'll reference Paul Etoy's Three Hats Problem blog post, which he talks about the sysadmin just having too many responsibilities and too much power.
+And so he does point to the validated lightning signer as a possible solution there.
+And that's something you've been pretty involved with.
+So can you tell us more about, yeah, what's going on there?
+
+Speaker 2: 00:15:41
+
+Yeah, I'll talk about the project and just some of the, I just keep learning more and more about this project, its potential applicability, so I'm happy to share what I've been learning.
+There's a project called Validating Lightning Signer, VLS.
+Spiral has been funding it.
+We're on year three now, so a little over two years we've been funding this project.
+Two developers, Ken Sedgwick and Dev Random, who have both been in the Bitcoin space for a long time, they applied for a grant a little over two years ago, and the premise of their project made a lot of sense to me.
+And the premise of VLS is that we want to improve security, and because Lightning introduces more security threats than on-chain Bitcoin because you need to have your keys connected on a computer that's connected to the internet, how can we mitigate those risks?
+And certainly one way is to separate the keys and signing from the rest of the Lightning node and everything else you might be running on that server to produce the attack surface.
+So I think some folks have maybe thought that it's as simple as just putting the keys on a separate computer and signing, but that would be blind signing, which I believe is a showstopper.
+It's just simply not there.
+
+Speaker 0: 00:16:49
+
+There's no benefit there.
+If it blindly signs everything, then it might as well be part of the signing software.
+
+Speaker 2: 00:16:55
+
+Yeah, because the node that's sending the transactions for it to sign can just send old states and the unintended recipient, et cetera.
+So there needs to be a smart signer, and part of that intelligence is that it needs to run a mini Lightning state machine, and it needs to understand the Lightning protocol, and that's what VLS is.
+So it is another implementation of Lightning, but it doesn't implement the peer-to-peer aspects or pathfinding routing.
+Most of the components of Lightning, it does not implement.
+What it does implement is signing transactions and keeping track of the state of all the channels.
+
+Speaker 0: 00:17:32
+
+Basically, it solves a standard problem that we have in wallet service businesses, where you want to disintermediate the signing power from other processes in the business.
+And you would especially like to lock up the keys in something where they can't be extracted, but you need a way to lock down a very small, minimal interface so that it actually only signs the things that it's supposed to.
+So you need something that is able to check the policies or some sort of core set of rules that determines whether or not it should sign.
+
+Speaker 2: 00:18:03
+
+That's exactly right.
+That project is implemented on the order of a couple dozen policies.
+So like you just said, so there's the notion of setting policies, policy enforcement, and whoever deploys the VLS project can configure that.
+You also alluded to putting on a machine where it's difficult to extract the keys, so it's intended to run on HSMs as well.
+Like, it can run on regular computers.
+VLS is quite very compact.
+It's written in Rust, and it has a very small footprint.
+So it's intended to run in all kinds of environments, anywhere from like enterprise server equipment, enterprise HSMs,
+but it can also run on mobile phones, and it can also run on hardware wallets and embedded systems, where the requirements are around like 500k of base.
+
+Speaker 0: 00:18:48
+
+So just to repeat and rephrase, HSMs are hardware security modules, which are hardware devices that have this very minimal interface, where you, for example, just can ask, sign this, but you can't ask, give me the key.
+And the key lives inside of the hardware security module and nobody has access, not even the sysadmin.
+And then basically VLS is an operating system to run an HSM.
+
+Speaker 2: 00:19:12
+
+Yep.
+So let's talk about a few applications.
+So the one we've been speaking about is like enterprise.
+And so what this can enable is you can have an access control that's different for your primary infrastructure and then a different set for these keys.
+And so your IT admin is gonna have access to most of the system, but they don't need to have access to the HSM running BLS and the keys.
+That could be the CEO or CFO or some designated group that's different.
+That's clearly one application.
+Another is Blockstream has a product called Greenlight, and One configuration with Greenlight is to enable mobile wallets and for a non-custodial mobile wallets.
+To be non-custodial, the key has to be on the phone.
+And like we just talked about, there needs to be secure signing, not blind signing for it to be actually secure and actually non-custodial.
+So Blockstream is using VLS as part of their Greenlight solution, and I'm super happy that they're super supportive of the project as well.
+Any project that Spiral funds, we obviously think it's a good idea for the space, but we also love to see others funding it as well, so that there's a good diversity of funding.
+I think in the case of, you mentioned Paul and his company wrote a blog post recently about VLS.
+I think they're interested in a couple of different use cases.
+One is in the enterprise separating the keys like we talked about, but they'd also are envisioning a world in which their end users have a very small, cheap hardware device, which they're building, which can run VLS on it, so that their end users, like the stack work users, are able to have a non-custodial wallet.
+
+Speaker 0: 00:20:44
+
+Essentially what this does is, so for on-chain transactions we have hardware signers or hardware wallets.
+What VLS allows you to do is to essentially have a hardware signer for Lightning, which was notoriously difficult before because Lightning has so much more state and different things it needs to do.
+It's not just a small transaction that you sign.
+
+Speaker 2: 00:21:05
+
+Yep.
+That's right.
+
+Speaker 0: 00:21:06
+
+And Paul had a prototype in this blog post.
+Have you heard more about that since it's been a few weeks, months?
+
+Speaker 2: 00:21:12
+
+Oh, no update in the past few weeks, but yeah, I'm excited.
+I really liked their company and he has tons of great ideas, so I hope they're successful.
+I guess maybe the last thing I'd say about the VLS project and I continue to learn more and more about its applicability and here's an example.
+So to date, Lightning has always only supported single signature wallets, meaning like if Mark and I have a channel together, we can only use a single signature wallet for each end of our channel.
+But there's work being done right now to make it so that multi-sig can be enabled.
+First step of course is getting Taproot implemented and activated in the network.
+That was done late last year.
+And now the Lightning implementations are starting to integrate.
+There's a number of different ways to improve Lightning because of Taproot and LND and CLN and LDK and Neclare are all making changes now to support Taproot, including Musig2, which will enable N of N wallets.
+And then there's a protocol called Frost, which will enable threshold signatures on Taproot and in this case on Lightning.
+So for example, you could have a 2 of 3 wallet that's not only your 2 of 3 wallet for on-chain funds, but also lightning channels.
+So that's super exciting.
+We can go deeper on that too.
+I think it's really exciting but let me just link it back to VLS.
+If you fast forward to this future where you have a two of three wallet on Lightning, there's three keys, three separate computers of those keys, and if you want to receive or send money, you need to have two signers.
+Only one of those can be your full Lightning node.
+So how does the other signer securely sign without trusting the other key?
+Well, it needs to be running VLS, or it needs to be running something like VLS, but there's really no other project that does that today.
+So another really cool application, and frankly, just necessary application of VLS, is any kind of multi-sig lightning channel.
+
+## FROST and ROAST
+
+Speaker 1: 00:23:01
+
+I was just quickly looking up roast versus frost.
+
+Speaker 2: 00:23:04
+
+They're very similar.
+Roast is necessary if you want a lot of keys and signers.
+So there's some applications where perhaps like Fetament where you might want a hundred keys or a hundred signers like a hundred out of a hundred and fifty or something And Frost would have performance.
+Not really performance, I mean, it's kind of performance issues, but denial of service attacks would be problematic because with Frost, if just one of the signers goes offline, you have to start over.
+It's an interactive signing process.
+With Roast, it addresses that.
+So for like a two or three wallet, Frost should be perfectly suitable.
+
+Speaker 1: 00:23:40
+
+And there's other applications for Frost as well.
+
+Speaker 2: 00:23:43
+
+Yeah, I'm really excited about frost.
+So I mean, not only does it give you, you know, beautiful multisig, threshold multisig, and on your on-chain footprint is only one key and one signature, it also allows much better recovery options for a wallet.
+
+## Recovering a FROST wallet
+
+Speaker 2: 00:24:00
+
+So let's imagine you have a two of three wallet and block is building out a non custodial wallet and their product conception they're gonna have a key on a server a key on a hardware device and control the customer and a key on the Customer's phone Something that most everyone does is lose your phone.
+So if you have a two, three wallet, you lose your phone and one of the keys is on the phone.
+What do you do?
+How do you recover?
+The traditional way is you rotate your keys and you basically create a new wallet.
+You sweep all the funds into the new wallet, you know, but that's a bit of a hassle.
+It takes time and it costs money too.
+
+Speaker 0: 00:24:32
+
+It also reduces your privacy.
+It's horrible.
+You combine all your funds.
+
+Speaker 2: 00:24:36
+
+And then you add in Lightning.
+So if you have a wallet that's both on-chain and Lightning, you're having to close all your channels, re-opening them.
+And today that might cost a few dollars, but in the future that could cost dozens of dollars or more.
+So I mean you might spend $50 on your hardware wallet and then like you lose your phone and you're spending another $70 just to rotate the keys.
+Getting back to Frost, a really beautiful thing about Frost is that you can rotate the keys with no on-chain footprint, no on-chain transaction.
+
+Speaker 0: 00:25:04
+
+You can reconstitute the threshold quorum.
+
+Speaker 2: 00:25:06
+
+Right.
+Using two of three as an example and losing your phone, you can take the other two keys, the secret shares and frost, and produce a new set of three.
+Now the security consideration is you have to securely delete the two original keys.
+
+Speaker 1: 00:25:22
+
+Toxic waste.
+
+Speaker 2: 00:25:24
+
+Toxic waste.
+If you don't then you know the attacker or and if you lose your phone I mean you might have lost your phone or it might have been stolen right But if someone were able to get that key and if one of the other two original keys are obtained, you'd be in trouble.
+So you need to be confident that the original two keys are deleted.
+So I think there's gonna be certain products where that's a reasonable assumption and other situations where it's not.
+If you've got three individuals involved where each have a key and there's not a lot of trust between them or just minimal trust then that's probably not a good idea to trust that the other two co-signers deleted their old shares.
+But if you have a product in which the software is written by one wallet author and you're the only individual, that seems like a reasonable trade-off to me.
+And it gives you the benefit of much faster, simpler, cheaper replacement keys.
+
+## Taproot adoption
+
+Speaker 0: 00:26:18
+
+Now it sounds like that would be a really nice wallet, but it would only make sense if it only launched with taproot outputs.
+You wouldn't want to go back to older output, less capable output types.
+Is there a holdup with that?
+
+Speaker 2: 00:26:32
+
+Yeah, that's a great question.
+And for people familiar with when Segwit was activated, it took years for Segwit adoption to occur.
+People actually receiving with the Segwit, and then specifically native Segwit receiving deposits and spending.
+We're seeing a similar dynamic with Taproot.
+Taproot was activated last fall.
+If you look on chain, it's very little usage.
+Some pundits on Twitter are mocking it, making fun of it.
+I remain quite bullish.
+I think there's very clear user wins in the future, but it takes a long time.
+And what actually one sort of chicken and egg problem right now is if you have a wallet that wants to take advantage of the features we just mentioned, it needs all of the money received to be taproot enabled.
+So when you're depositing funds into this wallet, you can't use a legacy address.
+If you do, you can't use Frost and you can't use these features.
+If a wallet were to launch today and only receive taproot, the big problem is that there's many exchanges that don't yet support sending to a taproot address.
+The address format is called BEC32M.
+And with like,
+
+Speaker 1: 00:27:39
+
+I think that's probably contested at this point, but it's certainly possible that it's pronounced that way.
+
+Speaker 2: 00:27:45
+
+Some people possibly on this podcast say Besh32M.
+
+Speaker 0: 00:27:49
+
+You know, Peter has an EPA description of how it's pronounced.
+
+Speaker 2: 00:27:53
+
+But what, how it was pronounced.
+I mean, it's those familiar with Segwit and BEC32.
+Original intention of BEC32 was that it would be forward compatible with Taproot or any other future SegWit version.
+Unfortunately, a very remote isolated bug was found.
+It was important to fix though, and that was fixed.
+And that's what BEC32M is.
+Now, what that means for wallets and exchanges is a very simple change.
+It's a few lines of code for them to be able to recognize a BEC32M address and send to it.
+I think the most important message here for wallets and services in the space, if you hear clamoring for supporting Taproot, step one is very simple.
+It's just a few lines of code change and you only need to support sending to Beck32M to really unlock the rest of the ecosystem to do innovation.
+Later, you can support receiving this and adding Taproot and Frost features, you know, but that's the prerogative of each service.
+
+Speaker 0: 00:28:50
+
+Yeah, I mean, when you adapt receiving to pay-to-Taproot outputs yourselves, it's totally up to you, but if you support sending to Bash32m addresses, it would just help everybody else to be able to move forward and have these cool things.
+And we know already that almost all Lightning projects are working on getting paid to Taproot channels.
+If you want to fund Lightning channels, you'll have to be able to send to pay to Taproot.
+If you want to send to users of these new wallets, if you want to enable your people to withdraw, you'll have to be able to send to Taproot.
+And even the critics agree that Taproot will be useful down the road.
+But it's like this two line code change.
+So if you did now or do it then when you actually are forced to.
+
+Speaker 1: 00:29:33
+
+So someone willing to take the hidden fees and just create a service that just takes all the addresses and turn it into a commit?
+
+Speaker 2: 00:29:40
+
+I know of folks that have been exploring that and there's a couple ways to, a forwarding service almost, And there's a couple of approaches.
+One would be this sort of like semi-custodial or temporarily custodial service, which I think is what you were just describing.
+There's a variation of it that's purely non-custodial as well, puts a little bit more onus on the end user and their wallet.
+It's almost your wallet would receive the legacy, or you know, funds at the legacy address.
+Those funds would be like in a holding pattern, and then the end user would have to like, hit a button to approve to sweep them into Taproot addresses, or maybe it happens automatically for them, but then they'd become sort of used, all of the Wallace features would become usable once the funds are in that.
+
+Speaker 0: 00:30:21
+
+I think another signal that people that are interested in moving Taproot forward can provide is if you just move more of your funds into Taproot addresses already, you're sending a signal that it has been used and that people should get ready to be able to send it.
+
+Speaker 2: 00:30:36
+
+Also a rumor has it people are working on a website which will have all the information needed to upgrade sending to VEC30.
+
+Speaker 1: 00:30:43
+
+That's what this podcast is all about, Spreading rumors.
+
+Speaker 0: 00:30:46
+
+Yeah, you must be well connected to hear such rumors already.
+
+## Future of the Lightning Network
+
+Speaker 1: 00:30:49
+
+You've been working on lightning now for two plus years and I think the big criticism of lightning is there are Certainly lots of things to polish up But there are also some problems that we just don't really have any ideas of how to solve.
+And so now that you've been steeped in this world for the last couple of years, how do you feel about the way things are progressing?
+What's actually needed?
+What kinds of expertise and skills that we need to add to the ecosystem, etc.?
+
+Speaker 2: 00:31:13
+
+I remain very bullish and optimistic about Lightning.
+Those that might be concerned, you just need to have patience.
+There's a lot of known problems.
+Like if you look at the user experience, you create a list of all the known problems.
+But what heartens me is that for nearly all of those problems, there's a credible known solution and many of them are actively being worked on.
+The reason it takes so long though, is that first you have to change the Lightning specification and you have to define that, so that takes a period of time.
+Then you need to update the Lightning implementations, that takes a period of time.
+Then you need to update all the wallets that use those Lightning implementations.
+So most important changes are a multi-year effort, not too dissimilar from on-chain Bitcoin, maybe a little bit faster, but it is a multi-year effort.
+So I'm very bullish.
+If you look at all the problems around user experience, security, and privacy, I think there's pretty credible solutions that are going to happen for all of that.
+Scaling is the one that in my mind remains unsolved.
+And when I say scaling, I think Lightning is going to deliver two to three orders of magnitude more scaling over on-chain Bitcoin.
+Like we'll achieve that.
+But to extend that to billions of people around the world and maybe like machine to machine interactions and a million payments per second type of scale.
+I don't see the technology roadmap to achieve that today.
+That doesn't mean it can't occur, But I still remain optimistic even with that being a problem because number one, there could be technological breakthroughs that allow the sharing of UTXOs with really good properties.
+Or maybe we entertain the block size debate again in the future.
+Or even if neither of those pan out, there are many complementary Layer 2 technologies such as Fediment and even just full-blown custodial payment systems that can all complement each other.
+
+Speaker 0: 00:32:53
+
+I think originally this problem was stated as Lightning scales payments but does not scale users because users still need channels.
+And I think we can restate it a little bit in lightning does not scale channels and channels if we can make them be usable by many different users we can still scale users even though each channel needs a huge exo.
+
+Speaker 2: 00:33:13
+
+Yeah I agree with that and so the scaling thing I think that's a luxury problem that we hope to have in five years in the sense that let's fix all the other known things.
+And then if the only problem we're left with at that point is scaling, then I think other options will develop.
+
+Speaker 0: 00:33:28
+
+It also feels like a classical problem like the internet.
+Back then we had dial-up and today we're like, oh my internet's a little slow today but I'm downloading a 4k movie and up streaming data through a server and stuff like that.
+It's just something that we can continue to fail at fully solving for a long time and fail at it better and better.
+
+Speaker 2: 00:33:49
+
+I think Jonathan also asked about how can people get involved or where help is needed.
+Like Spiral itself grew from four full-time engineers to seven that are working on LDK.
+I know Blockstream has been hiring a lot of developers on CLN.
+So seeing an increase in a ramp up of protocol developers and implementations, super important.
+There's also many dozens of wallets that are in development that are lightning enabled Bitcoin wallets.
+So because they're in development, it's probably not broadly known that a lot of these are happening.
+But, you know, I think over the next few years, we're going to see more and more of those launch.
+And it'll be exciting to see many different recipes out there to see what's usable, what's not, what gets traction, what doesn't.
+
+## Stratum V2
+
+Speaker 2: 00:34:25
+
+Maybe we could give a few minutes to Stratum v2.
+For folks that are not familiar with what Stratum is, this is, we're switching a new topic on Bitcoin, mining.
+So in the mining space there's a protocol between mining pools and miners that's called Stratum.
+It's been around for about a decade, you know, it's a protocol predominantly used in the space.
+It certainly has gotten the job done.
+There's been a lot of mining and billions of dollars earned the past 10 years, but as you can guess with something that was sort of hacked together 10 years ago, people have observed ways to improve it.
+So for those following along maybe like four years ago or so, you might have heard Matt Corallo defining something called BetterHash and Jan and Pavel from Brains working on Stratum V2.
+The three of them got together about three years ago to merge their ideas into one proposed protocol, and that's what's referred to as Stratum V2.
+About a couple years ago, Spiral funded a developer, Fi3, to start implementing this.
+Because what's existed the past few years is that Brains, as a company, they support Stratum V2 in their pool, in Slush Pool, and they have stratum v2 firmware that can run on bitmain miners.
+So that's existed and there's some mining done today with that configuration, but there's not been an independent implementation or like a reference implementation of stratum v2 for the space.
+That's what Spiral started funding a couple of years ago.
+So I'll give a quick update on where that specific project's at.
+One, there's several funders of the project now.
+In addition to Spiral, Galaxy is funding a developer for the project, and Foundry is also funding a developer for the project.
+So it's great to have significant mining companies that are seeing the merits of Stratum V2 and funding it.
+The project itself is healthy, has several developers, lots of good momentum.
+And in fact, this fall, potentially within even weeks, there'll be several different pilot projects that will be done by some of the companies that I just mentioned and testing out some of the configurations because there's actually several different configurations for Stratum V2 because Stratum V2 can support existing equipment that's running Stratum V1 firmware.
+You don't have to upgrade the firmware, but to do that, you need to run a Stratum V2 proxy that you, meaning the miner, would run that Stratum V2 proxy, which just simply translates the messages between that firmware and the pools.
+
+Speaker 1: 00:36:46
+
+And a lot of miners are already running proxies so it's not that crazy yet.
+
+Speaker 2: 00:36:50
+
+It will be, it'll be an additional step, you know, step for miners.
+So there's a couple reasons they would want to run this.
+One is if they have Stratum V1 firmware equipment and they either can't or don't want to upgrade to Stratum V2 firmware, that's a reason they need to run the proxy.
+Another reason to run a proxy or really just a server at their farm is if they want to do their own transaction selection.
+And so That's, I mean, I didn't really speak to the benefits of Stratum v2, but I think the most impactful one and what Bitcoiners at large will really care about is that up until now, only the pools can do transaction selection.
+And so Stratum v2 enables miners to do transaction selection or even another third party, which is something I just recently learned.
+So another third party could run a future version of Bitcoin D and then the pool nor the miner would actually be doing the transaction selection.
+It would be up to that third party.
+
+## OFAC and mining
+
+Speaker 2: 00:37:45
+
+So it just provides a lot more configuration options and flexibility, which I think is important, not only for the sort of maybe obvious reasons for decentralization, there's orders of magnitude more minors than there are pools, but with some of the recently highlighted and emphasized censorship concerns, One reason I'm realizing that pools might want to adopt Stratum v2 is that perhaps they don't want to be selecting transactions.
+It would actually reduce the pressure they face from regulatory bodies.
+So that might lead to more rapid adoption of Stratum v2 by pools than I had anticipated.
+
+Speaker 1: 00:38:19
+
+Yeah, let's just sort of spell that out because I think that's a really important point and should be emphasized.
+So, if there is a transaction that's on OFAC or an address that's on an OFAC list and that is sent through a US pool that starts to get very dicey for the pool.
+And so we, you know, we,
+
+Speaker 0: 00:38:37
+
+well, people are still debating the exact legal implications and all that.
+
+Speaker 1: 00:38:42
+
+Maybe, but if the pool is not in charge of those, that transaction selection, it makes it very clear.
+
+Speaker 0: 00:38:46
+
+It makes it easier, but there is still, so pools generally are created to revenue sharing, and they're still paying people for mining a block that includes it, so there is several different facets and shades to this.
+Definitely it'll get easier to explain if transaction selection happens at a different layer than the pool?
+
+Speaker 2: 00:39:05
+
+Yeah, all evidence I've seen is that OFAC transactions have not been censored by pools or miners.
+
+Speaker 1: 00:39:12
+
+There was talk,
+as far as, Marathon was very explicit that they were going to do that and now this is reversed.
+
+Speaker 2: 00:39:20
+
+There's also open source tools that have been developed that have been monitoring this for at least a year and a half.
+And based on that tool and that data set, there's been no censorship of OFAC transactions.
+So I think that's good news.
+And I'm not aware of the OFAC organization requesting that or asking that.
+But nevertheless, for the future health of Bitcoin at that layer, it's best to have more options and more configurations.
+And Stratum V2 definitely delivers that.
+I guess to me what's exciting is three years ago I struggled to see exactly what the adoption path would be because I thought pools might resist.
+Now I think that pools might welcome this.
+
+## Other benefits over Stratum
+
+Speaker 1: 00:39:59
+
+I would say the other benefit we haven't mentioned is the encryption piece, which maybe you want to go into because that's.
+
+Speaker 2: 00:40:05
+
+So Stratum v2 enables this transaction selection and being moved around, but it can still be done by the pools.
+Orthogonal to that, other benefits are just simply one is just way better security.
+Something that has been demonstrated by Matt Corallo is that you can relatively easily hijack hash rate.
+
+Speaker 0: 00:40:21
+
+Yeah, BTP attacks.
+
+Speaker 2: 00:40:23
+
+Yeah, because the Stratum protocol is used today, there's no authentication, no encryption.
+So Stratum v2 just adds basic encryption and authentication.
+So that's another benefit.
+And again, miners can get that whether they're using Stratum V1 firmware or Stratum V2 firmware, it's very flexible and configurable in different ways.
+Another change to Stratum V2 is it's just a more efficient protocol.
+Stratum V1 uses JSON, It's super verbose.
+Stratum v2 is binary, so it's much more compact.
+Also with, I mentioned that the SV2 proxy that is software a miner can run, that proxy connects to each ASIC machine in the farm using what's called a standard channel and then use the group channel to speak to the pool.
+So it's able to condense all of the channels that are basically all the traffic from all the machines that are farm into one channel that's much more efficient.
+I'd like to see more benchmarking data, but my hope is that there's much more efficiency gains.
+What it can enable in the future is mining operations that are in more remote regions that have worse internet connections that today would take a material hit to profitability and revenue because of latency concerns.
+And if we can, you know, so if it is, I don't know what the numbers are, but let's say it's 10 times more efficient, all of a sudden, what might have been a material hit to the profits of a mining operation become negligible, and we'll see more decentralization through that mechanism as well.
+
+Speaker 0: 00:41:48
+
+That sounds great.
+Super.
+Thank you for coming in.
+
+Speaker 2: 00:41:51
+
+Thank you so much.
+
+Speaker 1: 00:41:59
+
+What did you think?
+
+Speaker 0: 00:42:01
+
+Well, we entirely prepared too much.
+He brought all the topics already in his mind.
+
+Speaker 1: 00:42:04
+
+I know.
+That's all right.
+He is thinking about Lightning very deeply, and I like the idea of a technical PM thinking about the user experience more in Lightning.
+
+Speaker 0: 00:42:13
+
+I think it's also nice to get someone that has an overview because they talk to so many people.
+And that way sort of compounds many different questions and challenges that different teams are working on.
+And just him saying that all of these problems already have people working on them Sounds really fun.
+
+Speaker 1: 00:42:30
+
+I think the optimism bled through, especially at the end there, which is heartening because a lot of times this is sort of a doomsday podcast, especially when it comes to lightning, all the things that are broken.
+
+Speaker 0: 00:42:39
+
+Sure.
+And also with the current discourse on the interwebs, I think it's nice to have a long term perspective on things.
+Sure.
+
+Speaker 1: 00:42:46
+
+What's the current discourse on the interwebs?
+I try to stay off as much as possible.
+Lightning is broke.
+
+Speaker 0: 00:42:50
+
+It's a failure.
+It's around for seven years and not every human on earth uses it yet.
+
+Speaker 1: 00:42:56
+
+Yeah, you gotta stay off the Bcash forums, I guess.
+We hope to do some more recordings soon.
+Hopefully not every few months, but hopefully we'll get something out.
+
+Speaker 0: 00:43:04
+
+Yeah, we'll have a few more people coming from New York soon, so let's record them.
+
+Speaker 2: 00:43:08
+
+All right.
+
+Speaker 1: 00:43:09
+
+Hope you enjoyed it and we'll see you soon.
+Bye.
+
+Speaker 0: 00:43:15
+
+And I'll see you next week.
+Bye, bye.
+Have fun here.
+Have fun here.
+Have fun here.
+Have fun here.
+
+Speaker 2: 00:43:23
+
+Have fun here.

--- a/chaincode-labs/chaincode-podcast/modularizing-the-bitcoin-consensus-engine.md
+++ b/chaincode-labs/chaincode-podcast/modularizing-the-bitcoin-consensus-engine.md
@@ -1,0 +1,93 @@
+---
+title: Modularizing the Bitcoin Consensus Engine
+transcript_by: Michael Folkson
+speakers: ['Carl Dong']
+categories: ['podcast']
+tags: ['build-system']
+date: 2020-12-15
+media: https://podcasters.spotify.com/pod/show/chaincode/episodes/Carl-Dong-and-Modularizing-the-Bitcoin-Consensus-Engine---Episode-10-enra84
+episode: 10
+---
+AJ: Do you want to talk about isolating the consensus engine?
+
+CD: Sure. More recently I have dove into the codebase a little bit more. That started with looking at Matt’s async ProcessNewBlock [work](https://github.com/bitcoin/bitcoin/pull/16175) and playing around with that. Learning from that how do you make a change to the core engine of Bitcoin Core.
+
+## Matt Corallo’s PR on async ProcessNewBlock
+
+https://github.com/bitcoin/bitcoin/pull/16175
+
+AJ: Can you talk about that PR a little bit and what it would do?
+
+CD: Basically right now when we process new blocks from a peer we block everything. That is bad in software that is supposed to be performant and also it is bad for embedded systems or systems with less processing power. The basic gist of it is that asynchronous ProcessNewBlock allows us to be able to process new blocks somewhat asynchronously. I looked into that a little bit. One of the things that I had talked about with Matt and Cory a few years ago was very interesting, which was modularizing our consensus engine. Capturing what our consensus engine is right now, as ugly as it is with warts and all, and seeing if we can perhaps physically separate it from the rest of the codebase. Obviously those are much future steps.
+
+## Carl’s De-globalize ChainstateManager PR
+
+PR: https://github.com/bitcoin/bitcoin/pull/20158
+
+PR review club on this PR: https://bitcoincore.reviews/20158
+
+CD: Right now one of the major problems with the consensus engine is that we have so much global mutable state. Having global mutable state is really bad because when you are looking at a function you consider its inputs to just be its parameters and what class it is a member of but you don’t consider that global mutable state can influence the execution of functions and macros greatly. For something as important as our consensus code we should probably modularize it so that it relies on less and less global mutable state and be able to work nicely. After we have modularized it perhaps we can separate it out. Perhaps into a library like people said about libconsensus a few years ago. Perhaps do something else. That is the first step. This is why recently I’ve been working on this PR to de-globalize a class called ChainstateManager. ChainstateManager was introduced as this manager class that manages multiple chain states. Basically chain states encapsulate our view of a chain and the UTXO set and blocks.
+
+M: For example if there are stale blocks or two competing chain tips, they would have multiple chain states.
+
+CD: That would be one chain state, one chain but two block trees. I think that is what it is. I will explain why there might be multiple chain states. We have multiple chain states in the case of [assumeutxo](https://github.com/jamesob/assumeutxo-docs/tree/2019-04-proposal/proposal). ChainstateManager was introduced for assumeutxo where we will have multiple chain states that are progressing. The active one may switch between one or the other. That’s why we have a chain state. If you look at what our consensus engine encompasses, it encompasses ChainstateManager and all of the objects that it owns and references. That is what I am trying to encapsulate and trying to de-globalize. Because before we had this one `gchainman` that was referenced from everywhere in the codebase. That was getting to be a mess. Also one of the things that is interesting for people who are into the nitty gritty of C++ is that global variables cannot be instantiated with things that are determined after main starts. That is why we have had some very weird ways to initialize these global variables where we initialize an empty one globally and then in main we want to make sure as soon as possible to initialize it with actual contents. There is like a three, four phase initialization. We also initialize it differently between bitcoind and bitcoin-qt and our test code. The combination of having a three, four phase initialization and those means you can have discrepancies between the test code and the main code when you are initializing stuff. It leads to a lot of bugs that are very hard to reason about.
+
+M: Because it is so hard to reproduce.
+
+CD: Yes exactly.
+
+AJ: Nice callback. This is a lot of code that you are changing. The PR that we are talking about is PR 20158. It is 82 commits and 800 lines of sensitive code. How do you test this? How do you structure this for code review? How do you make sure that we’re not breaking Bitcoin?
+
+CD: The mantra stands of getting it to work in a hacky way is very easy but getting it to work in a nice way… Especially if you are needing review from others, it is much harder. I had this working a long time ago but because of how much of the code I was touching I needed to structure it in a way so that every commit made a lot of sense. The review experience that I wanted for this was for reviewers to be able to look at every commit and be like “This is trivial. This is trivial. This is trivial.” By the end they’re like “I just reviewed a bunch of trivial commits.” In aggregate they do something big. This is why I have this piece of paper at home, I think I threw it in the trash, I should have kept it, where I mapped out all the calls within our codebase that relates to ChainstateManager. It looked like a tree and I started pruning the tree from the bottom up. From the bottom these are direct references to `gchainman`. I just said “If you are referencing gchainman then you should probably take in a parameter that is chainman and use that instead.” I basically pruned the tree all the way up and each commit prunes one node all the way up to the top where I remove `gchainman` and all of its things. In the middle I saw that one of the things that could lead to problems is the notion of the active chain state. Most of these functions, what they reach for is the chainman’s active chain state. Now you are passing in a parameter that is chain state but you have no idea which chain state this is. This could be the active one, this could be the inactive one. To make sure I put in a lot of review only assertions. I put in all these assertions that were like “Let’s assert that this chain state that is being passed in is the active chain state.” I put all of these in so that reviewers can run the code themselves and see that there was no assertion error and nothing failed. In the end I have one quick [scripted diff](https://github.com/bitcoin/bitcoin/blob/dca80ffb45fcc8e6eedb6dc481d500dedab4248b/doc/developer-notes.md#scripted-diffs) to get all of them out. Scripted diffs were really helpful during this, especially with large refactors like this where you’re like “I’m inserting a parameter. Oh no it is being called from 30 different places.” Being able to do a scripted diff is not only easier for me to rebase, it is also easier for reviewers because they can just look at the sed script and be like “Ok that makes sense.”
+
+## Consensus engine
+
+AJ: Can I ask some more meta questions? This path is littered with dead bodies of people who have tried to encapsulate our consensus engine. First of all consensus engine seems very deliberate. That phrase is not something that I’ve heard before. Where does that come from?
+
+CD: It comes from the need to not say “consensus critical code.” Because people have a very specific understanding of consensus critical code and people have very differing understandings of consensus critical code. Is LevelDB part of consensus critical code? They might have different answers.
+
+AJ: It was in [0.8](https://github.com/bitcoin/bips/blob/master/bip-0050.mediawiki)
+
+CD: Exactly. That’s for sure.
+
+AJ: The reason that is funny?
+
+CD: In 0.8 there was an upgrade from BDB to LevelDB which caused a bug because of how many locks were available in each one, the limitation on locking. It is very deliberate. I get this phrase from Matt who texted it to me. I was like “I’m going to steal that.” Our consensus code as it is right now, everything it depends on and all the auxiliary things that are needed for it to work, whether it be caching or storage or whatever. That is very deliberate phrasing that I’m using to make sure that I’m being correct with how I say things.
+
+## Past efforts such as Jorge Timon’s libconsensus project
+
+https://github.com/bitcoin/bitcoin/projects/6
+
+AJ: So you are slowly teasing this out and unbundling it. Can you tell us about others who have made past efforts? It sounds like Matt started doing this.
+
+CD: Going chronologically backwards, the last effort was Matt’s effort. Matt is the one who introduced `CChainstate`. Before `CChainstate` there was a primordial soup of global mutable state in validation. He brought a lot of that together into `CChainstate`. That was supposed to be exported as a libbitcoinconsensus but that never happened. That is one of the first steps and I stand on the shoulders of giants. These are advancements that make my job much easier right now. I think before that Jorge had a big project to complete our libbitcoinconsensus into something that is more whole and encapsulates the consensus engine. Perhaps a good piece of context to give right now is that we do have a libbitcoinconsensus right now. It only does script verification, it doesn’t do anything else. It doesn’t connect blocks, it doesn’t do anything else. It is not a full consensus engine. Again to me these are lofty goals that are pretty far away. I want to look at what are some concrete steps where we can move towards a world where it is possible to do something like that to complete a library. What are some concrete steps that would benefit our codebase right now that move towards that. I think it is foolish to try to think about what would a perfect libbitcoinconsensus look like? Or what would perfect organization look like? I think it is good to take concrete steps that benefit us and then take a look from there. Once we get there we might have very different understandings of how the codebase should work. Maybe we discover new things and we take it a step at a time and learn and talk and discuss.
+
+AJ: Wouldn’t multiple implementations come in handy for this? We have to copy the bugs as they are part of consensus. Wouldn’t that be handy right now to have other people who are thinking about this and trying to isolate what consensus is?
+
+CD: One of the understandings of an [ABI](https://en.wikipedia.org/wiki/Application_binary_interface) is the bug interface. Bitcoin is unique in that it is a consensus system. You almost want to replicate the bugs. It sounds very weird to say. That’s basically what it is.
+
+AJ: Not want to, you have to.
+
+CD: Exactly. You have to replicate the bugs. This is very far off but if someday, maybe in the next ten years, we get to a place where we have a library that other applications can pull in and get a consensus engine that matches exactly with Bitcoin Core’s, then they can implement alternative implementations of Bitcoin without fear of being out of sync with the main chain. They can implement alternative implementations with different policies, mempool policies, different priorities.
+
+M: One of the things that were introduced by previous alternative implementations was that you could serve unconfirmed transactions or serve parts of the UTXO set. Or think about block explorers. Bitcoin Core does not have a full transaction index by default. You can start it with `txindex` but then you still don’t have address balances for example.
+
+CD: Exactly. This touches on one of the things that I felt was very compelling to me when I thought more about why I want to do this. It is a technical solution to a somewhat social problem. It can’t be that people try to cram all of the features that they want into Bitcoin Core. That is unmaintainable and not what we want. We don’t want a hundred different indexes to serve every single need. But if people have drastically different ways that they want to implement their node, having a library is so much more useful than telling them to fork the codebase. Forking the codebase means a major rebase every few years, that is not a practical thing to do.
+
+M: And you inherit all the design decisions. You have to move away from that. Bitcoin Core’s codebase is rather quirky.
+
+CD: For sure.
+
+AJ: Another lesson of why not to put a proof of concept into production.
+
+M: It kind of works.
+
+AJ: It does. Any parting shots? Any other things to talk about in terms of the modularizing?
+
+CD: I would encourage anyone listening to this to review the code. I have made it so that every commit is somewhat trivial to review. The more involved ones have very long commit messages to describe why it is the way it is.
+
+M: Does a full node need to have a wallet?
+
+CD: Maybe not.
+
+AJ: It certainly doesn’t need a GUI. Thank you for joining us. We have been trying for months to get you on. Appreciate the conversation.

--- a/chaincode-labs/chaincode-podcast/payment-points.md
+++ b/chaincode-labs/chaincode-podcast/payment-points.md
@@ -3,11 +3,11 @@ title: "Payment Points"
 transcript_by: tvpeter via review.btctranscripts.com
 media: https://www.youtube.com/watch?v=Y2mTjCldRAU
 speakers: ["Nadav Kohen"]
-categories: ["Podcast"]
+categories: ["podcast"]
 tags: ["ptlc"]
 date: 2020-03-30
+episode: 7
 ---
-
 Nadav Kohen: 00:00:00
 
 Right now in the Lightning Network, if I were to make a payment every single hop along that route, they would know that they're on the same route, because every single HTLC uses the same hash. It's a bad privacy leak. It's actually a much worse privacy leak now that we have multi-path payments, because every single path along your multi-path payment uses the same hash as well.

--- a/chaincode-labs/chaincode-podcast/privacy-and-robustness-in-lightning.md
+++ b/chaincode-labs/chaincode-podcast/privacy-and-robustness-in-lightning.md
@@ -1,0 +1,1119 @@
+---
+title: "Privacy and robustness in Lightning"
+transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+media: https://podcasters.spotify.com/pod/show/chaincode/episodes/Rusty-Russell-and-privacy-and-robustness-in-Lightning---episode-34-e27t6go
+tags: ['lightning', 'eltoo', 'privacy-enhancements']
+speakers: ['Rusty Russell']
+categories: ['podcast']
+date: 2023-08-09
+episode: 34
+---
+Speaker 0: 00:00:00
+
+Simplicity is a virtue in itself, right?
+So you can try to increase fairness.
+If you reduce simplicity, you end up actually often stepping backwards.
+So I really, the thing that really appeals about element symmetry is it's simple.
+And every scheme to fix things by introducing more fairness and try to reintroduce penalties and everything else ends up destroying the simplicity.
+
+Speaker 1: 00:00:27
+
+So soon again.
+
+Speaker 2: 00:00:28
+
+Yes.
+For those of you that aren't tracking us in real time, we are getting a bunch recorded today.
+So had Rusty Russell in the office.
+
+Speaker 1: 00:00:39
+
+Yeah.
+So this is one of my favorite podcast guests to listen to, and I'm very happy that-
+Why?
+Because he has the capacity to cut through a lot of the noise and get to the crux of things, say them as they are.
+Ugly truth, sort of.
+Very nice for engineers to actually talk about the elephants in the room.
+So I'm expecting that we'll hear a little bit about what's still broken and lightning where the ship is sailing.
+Okay, here come the elephants.
+Welcome,
+
+Speaker 2: 00:01:21
+
+Rusty.
+
+Speaker 0: 00:01:22
+
+It's great to have you here.
+Thank you.
+I am fresh off the boat.
+I literally arrived less than 24 hours before from the other side of the world.
+So I hope this will be coherent.
+
+Speaker 2: 00:01:30
+
+Our budget is for this podcast is incredible.
+We fly people from all over the world to this office.
+
+Speaker 0: 00:01:36
+
+I must say that private jet was lovely.
+Thank you for that.
+
+Speaker 2: 00:01:39
+
+It was delightful.
+You are here for the lightning summit.
+Let's talk about lighting.
+Just sort of just get into it.
+
+Speaker 0: 00:01:46
+
+Let's do that.
+Yeah.
+Okay.
+
+Speaker 2: 00:01:47
+
+Tell us what you think this group should be thinking about as you're as you're gathering together.
+There's going to be specific conversations that happen about specific proposals.
+But I guess more generally, as lightning has grown up, What are the kinds of things that you're thinking about and concerned about?
+
+Speaker 0: 00:02:04
+
+Yeah, okay.
+That's a fair question.
+There are obviously specific things that we're going to talk about at the summit.
+Definite concrete proposals and that's all great.
+This is always a fantastic time for everyone to come together.
+I think if we step back a bit, This is like eight years now for the Lightning Network.
+So we've been doing this for a while.
+And there are a couple of things that I think we really need to make sure we keep focusing on because it's easy to get in the weeds of specific things and I would love to go into those and we can totally go there.
+But I think robustness and privacy are the two things that are rarely actually on fire, but are always important.
+And they're both areas where we can definitely make incremental improvements, and I think we should.
+Privacy in particular is something that everyone cares about until you need to put the engineering effort in and there's other stuff.
+There's bugs, there's issues, there's, you know, there are always other things that are more urgent, even if they're not more important.
+And so I definitely try to keep the perspective of going, you know, if not now, when?
+And I think, you know, privacy is something that we definitely need to put more effort in.
+
+Speaker 2: 00:03:07
+
+Yeah, I imagine that privacy goes to the end of the line pretty much every time.
+But can we talk about robustness for a moment?
+Because robustness is definitely something that you think about in Bitcoin quite a bit.
+It's different though, in terms of layer one versus layer two, because layer two sort of promises to be this move fast and break things approach, because it needs to move fast and it needs to grow and it needs to catch up.
+Now things have broken, but I guess not to the same extent that I think people are trusting it.
+I mean, there's serious money on the line.
+
+Speaker 0: 00:03:42
+
+Oh yeah.
+
+Speaker 2: 00:03:43
+
+And I guess the question is, do you have to react to the amount of money that's in the system?
+Or is it still, well, we're still figuring this thing out.
+And that's up to you if you want to put that much money in there.
+But we, you know, we still need to experiment.
+And again, it is a robustness speed trade off in terms of what you can do.
+Yep.
+
+Speaker 0: 00:04:07
+
+So, okay, so robustness on some extent is always something we need to think about.
+But also, I think like the recent fee spike showed us that there are definitely places we can improve.
+Robustness from the protocol level means we want stuff where we become more immune to fee issues.
+I think that's something definitely, you know, we need longer term.
+The assumption is fees are going to go up, they're going to get more volatile, we're going to have these spikes, We need to handle that really well.
+And I certainly hope that we, you know, we have a number of tricks we can do.
+Some of which is like, well, we want some soft forks, right?
+
+## LN symmetry
+
+Speaker 0: 00:04:39
+
+If we can get L and symmetry, which used to be called L2, but L and symmetry is a much better name.
+Sorry to Christian who named L2.
+He blames me.
+I blame him.
+But that, for example, sidesteps a whole heap of, it reduces robustness by introducing simplicity.
+It does make it a lot simpler to maintain your Lightning channel.
+There's no longer toxic waste that you have to worry about, old states and stuff like that.
+Watchtower has become now almost trivial.
+So that adds some simplicity.
+
+Speaker 2: 00:05:05
+
+Can we take a quick side route on that?
+Sure.
+Because we've talked about LN symmetry specifically with Instagibs.
+
+## Do we want LN Symmetry to be symmetrical?
+
+Speaker 2: 00:05:12
+
+But I'd be interested in getting your take on, given that asymmetry seems to be healthy for the network, do you want it to be exactly symmetrical?
+
+Speaker 0: 00:05:21
+
+Okay, so this is a good question.
+So at the moment, let's step back.
+LN penalty, as it's retronamed into, is the current scheme where basically if you screw up, I take your money.
+
+Speaker 1: 00:05:31
+
+Yeah,
+
+Speaker 2: 00:05:31
+
+Tadge is over there, too.
+We can pull him in.
+
+Speaker 0: 00:05:33
+
+Yeah, okay.
+We can do that.
+Right now, so what we found in practice is that usually what happens is you screw up, I take your money, and I feel really sorry about it, and I try to give it back to you.
+Right?
+So, the current scheme is actually a little bit too harsh for the world that we actually live in, because we rarely see people actually trying to cheat, and we often see them do it accidentally because they're a store from backups and oops, that was bad, right?
+With the LN symmetry approach, simply if you screw up, I just fix up, right?
+There's no massive penalty for you doing so.
+The danger is then, have I created an incentive problem where you might try to cheat because it doesn't cost you anything?
+Now, this is interesting in a couple of ways.
+One is, is that actually always more expensive for you to close unilaterally, even under LN symmetry, than it is to do a mutual close.
+But you talk to me and we go forward and we produce a mutual close transaction that's got a tailored fee rate and everything else and it's smaller.
+So if you can talk to me, you're going to want to do that.
+But if I was unreachable, well, I might as well try to spend in an older state.
+So the cost of an attack has dropped significantly because that risk issue.
+Well, you're paying some fees for it, sure, but you're not risking that if you screw up, you're going to lose all your funds.
+But on the other side of the coin, my implementation is much simpler and watchtowers are now trivial.
+It's so much so that we can have many watchtowers looking out for these kind of things.
+They only have to remember one transaction, which is the last one.
+They see it, they drop it to chain, we're done.
+So the fact that watchtowers are much more scalable means that while your risk is reduced as an attacker, your probability of success is reduced even more.
+So there is less of an incentive problem than you might have originally thought with going for LN symmetry.
+
+Speaker 1: 00:07:09
+
+But it still costs you the same to broadcast in the old state or the newest state, so you don't lose anything, right?
+
+Speaker 0: 00:07:16
+
+Yes.
+But on the simple protocol level, you go, well, you didn't lose anything.
+But on a higher level, I'm not going to trust you again because you're obviously doing weird because they restored from backup.
+But you know, if you start doing this a lot, people are gonna be like, no, no, I don't trust them anymore.
+So, so if the potential benefit for you is so small, that that social convention that that, you know, if I want to become a big node, I'm not going to get there because I people have noticed that I keep double spending because it's really clear on chain.
+
+Speaker 2: 00:07:47
+
+Yeah, but that also changes with high fee environments, right?
+I mean, you start making it more difficult for people to...
+
+Speaker 0: 00:07:55
+
+Ah, but now, remember, in a high fee environment, the cost for you to do a unilateral close is much higher.
+I see.
+Right?
+You want to do a mutual close.
+So the only case where it really comes out is when I'm unavailable you can't do mutual close.
+You're gonna use the last three close anyway and now you're like well I might as well try to cheat.
+So you're already kind of in a corner case because that's already sending more money than if you just spoke to me and closed your channel.
+
+Speaker 1: 00:08:16
+
+So we've talked quite a bit about LN symmetry and how we want to retain the symmetric aspect of it.
+There was also a proposal where you would have some sort of penalty for the initiator of the closing transaction by having a larger output on the commitment transaction than input.
+So you would have to add a second input to provide additional funds.
+Could we talk about that proposal?
+
+Speaker 0: 00:08:42
+
+Simplicity is a virtue in itself, right?
+So you can try to increase fairness.
+If you reduce simplicity, you end up actually often stepping backwards.
+So the thing that really appeals about element symmetry is it's simple.
+And every scheme to fix things by introducing more fairness and try to reintroduce penalties and everything else ends up destroying the simplicity that, for me, is like, well, it depends on the ratio of attacks, right?
+At some point, how much engineering, how much effort is going in to save a few cents statistically on your attack probability.
+And so I've come around to the idea that making watchtowers ubiquitous is enough by itself to then go for a very simple and dumb protocol that at the end of the day will be far simpler to implement and have fewer corner cases and those things than trying to get fancy and bring back everything.
+Because then we end up back at basically somewhere like LN Penalty and I'm like, well no, we didn't like that.
+You know, there's definitely like, I'm not completely ruling out the design space, but I do like the simplicity of going, well, you've got one transaction, you spend it, you're done.
+It's nice.
+You know, and whoever spends it ends up having to fund the close.
+That's pretty nice too.
+The other argument for breaking symmetry is you can then tell who screwed up.
+If everything's symmetrical, I can make it look like you screwed up by just spending the n minus one transaction the nth transaction and then go, you spent that one and actually it was me.
+There's some cost to doing that, I'm going to have to pay fees on both of them.
+But no one can canonically assign blame for that kind of screw up.
+So you start to go, well, maybe we do make the mason metric but then you're like yeah you're reintroducing complexity and the real appeal is simplicity and simplicity is often underrated as far as going you know there's enough moving parts in lightning as we've discovered without making the base protocol.
+So I find the simplicity more compelling I think now than I did when the first idea was introduced.
+So I've definitely come along.
+The good news is that we need a soft fork, we need to roll this thing out, it's not going to happen overnight, we're going to have both side by side, and we will find the engineering tradeoffs, to be honest.
+If I'm wrong and we end up going, no, actually, we want some hybrid scheme, or we prefer LN penalty or everything else, but we'll get there as well.
+There's no huge hurry in this process.
+
+Speaker 1: 00:11:02
+
+Of course, people that still want a penalty can just continue to use ln penalty.
+
+Speaker 0: 00:11:07
+
+No, we'll rip the damn thing out as soon as we can.
+I mean, the simplicity argument only applies if you don't have to support both.
+Now, to be fair, you can migrate from LN penalty to LN symmetry, but you will have to handle a case where the other person goes back and spends one of those ones that needs a penalty, because you can't symmetry that afterwards.
+I can't come up with any scheme where you can just retro in and attach on.
+It's theoretically possible, but it's not actually possible as far as I can tell.
+So you will need to still be able to have your penalty code, even if you no longer open new ones.
+If you've got existing channels that have not been spliced or otherwise had some kind of on-chain commitment, you will still need to have the code that handles, oh crap, they spent the old one, I now have to do a penalty thing or whatever else.
+It's not a huge amount of code, it's not as complicated as some of the other parts, but it will still be there until the point where you go, no.
+Everyone has all those channels are dead.
+We've got all new channels.
+At that point, you would be able to get rid of the whole concept entirely.
+But this is the benefit of having different implementations and a simple protocol where a new implementation come along and go, I want to write it in whatever the language flavor of the week is, there's always somebody who's prepared to rewrite it.
+So by having a simple protocol, they may go, actually, I'm not going to implement all that crap.
+We're only going to implement the new one.
+And that may well be what carries us forward.
+I don't know.
+
+Speaker 1: 00:12:29
+
+And it might actually, it makes it way easier to have more than two parties, right?
+So it might be the roads to channel factories or you can still share your schemes.
+
+Speaker 0: 00:12:40
+
+So yeah, your point about opening the door to channel factories and multi-party channels and all that is definitely a huge impetus to do LN Symmetry because we can go multiparty, we can do all these wild and wonderful things on top.
+So I'm like, oh, we simplify it and then we add all new complexity by building another layer on top.
+But, you know, that's all good because I'm hoping that that won't be my problem and somebody else can do the implementation on top.
+
+Speaker 2: 00:13:04
+
+So we've covered robustness.
+Are there other things?
+Yeah, I mean, what else do you have in mind when you're talking about that principle?
+
+Speaker 0: 00:13:12
+
+So at the moment, we have a fairly complicated state machine with just the way that we deal with updates.
+And when Greg implemented L2, he did roll in the simplified update proposal that I made a couple years ago now, where basically instead of both of us proposing changes at the same time, So the basic way our peer-to-peer protocol works is that I go, okay, add this, add this, add this, resolve this, resolve this.
+
+## Peer to peer protocol
+
+Speaker 0: 00:13:37
+
+At the same time, you can be proposing changes and we commit to each other and we kind of roll this thing in and eventually it's okay.
+That protocol was something that is optimal, but also introduces a significant amount of complexity.
+And it turns out that if you just take turns in adding updates, then it's a lot easier to understand the protocol.
+It is theoretically slightly higher latency in the case where we both want to make changes because you end up having to wait for me and then it's your turn.
+But in practice, while that adds some latency in that corner case, it also gives you more opportunities for batching.
+So if you're really being hammered in both ways, you don't lose.
+Right?
+The latency of individual payments may go up, but the latency of the whole system is better because we end up just you end up doing five commitments at once because you've been waiting.
+So with that in mind, I think simplifying the pure level protocol can help us somewhat.
+And in fact, that simplification leads to it's a subset of the current state machine, in fact, so it turns out to be pretty nice.
+And once we've got that, we have then the ability to knack changes.
+So at the moment, I expressed to your node, there are certain things I will not allow.
+Here's your maximum of HTLCs, here's your maximum HTLC size, all these restrictions because there's no way in the protocol for you to send an update and me go, no, no, no, I don't like that one.
+We have to go through a whole round and then I have to close it out.
+At some point, I'm left holding the commitment transaction with that thing that you put in.
+I have to tell you what you can't do.
+If we have a NAC protocol where you're going to know I'm going to reject that and force you to go around again, then that means that I no longer have to tell you what my restrictions are.
+You can try everything and I just go no that doesn't work and close it out.
+Right.
+It's a fairly simple protocol change But if we tried to do it in the existing protocol where we can have change from both sides in flight, it's a bit of a nightmare.
+Whereas when we've got this turn taking protocol, it's much, much easier.
+The other thing that happens with the turn taking protocol is if we want to do some kind of upgrade to the channel, we want to splice or we want to upgrade to a new kind of channel.
+It turns out with the current protocol, we have to have a whole quiescence protocol to go, hold on, I want you to stop sending updates.
+You go, cool, I'm ready to stop sending updates.
+We clear all the updates and then we're ready to go.
+With turn taking, it happens automatically.
+When it's my turn, by definition, you haven't got anything in flight.
+So I can say, hey, it's time to upgrade.
+And it's much simpler in that way too.
+So this is something that we just learned through experience that we over-designed the original protocol.
+And now whether this becomes a separate change or goes in with an L2 change or not, this is something we're going to discuss at the summit.
+But from my point of view, we end up with a more robust and simple protocol at the end of this.
+And it turns out that supporting both is actually pretty easy.
+
+Speaker 2: 00:16:10
+
+So you're talking about when we were talking about L2, you're talking about changes and you're sort of casually mentioning the soft fork piece of it.
+I mean, there's not going well, there's Greg Sanders will be there and he's obviously thinking about this, but you don't really have the people at the table that are actually doing like would be pulling the soft fork together that are that really understand the lightning case, I guess.
+Maybe AJ, maybe InstaGibs.
+The list gets very short after that.
+So, like, how are you able to communicate those needs down to the lower layer?
+
+Speaker 0: 00:16:47
+
+Well, I think the any prep out cases have been pretty strong for a long time.
+The question's always been, do we want other soft fork as well?
+
+## CTV
+
+Speaker 0: 00:16:54
+
+And people are like, oh, if we had obstacle the check sick from stack, we can also do it.
+Sure.
+I can probably build a car out of matchsticks and snot, but I don't want to.
+And don't make me do it.
+
+Speaker 2: 00:17:09
+
+Could you do that?
+
+Speaker 0: 00:17:12
+
+A theoretical engineer probably could do that.
+I could not do that.
+I'm not crafty at all.
+But, okay.
+That is probably an aside.
+We don't need to go down.
+But, you know, check sync from stack is like, oh, it's cool that you can even make that work.
+But it is a terrible basis for just about anything.
+And it's more like a game we could play as far as what's the most obscure way we could do some kind of introspection.
+And the answer would be, you know, check-sig from stack.
+So any prep-out is a – and the proposals that are in that cluster, and there are a few, are pretty clean, pretty well understood.
+AJ would definitely be the person unfortunately he's not here in New York he's kind of you know done a fair bit of travel recently he was like no I'm not going.
+So I'm hoping that while we're in New York he is in his mountain lair somewhere coming up with a scheme to activate any prep out.
+That's if you're listening, AJ, I hope you're going to make that prophecy come true.
+I think, you know, we understand that we want this and we've wanted it for a fair period of time and nothing else has come up that's gone, oh no, we want this instead.
+Anyprepout by itself is a fairly simple piece.
+
+Speaker 2: 00:18:21
+
+Now.
+Not a precluding piece to other things that we can do in the future.
+
+Speaker 0: 00:18:24
+
+Absolutely.
+
+Speaker 2: 00:18:25
+
+This is the two-way door, one-way door kind of thing.
+
+Speaker 0: 00:18:28
+
+In this case, we will want anyprepout even when we have full covenants and everything else.
+So I'm pretty confident to say this is something that we should enable.
+Right.
+Now that said the detail the fine details you know hand wave hand wave I know try not to spend too much time coming over details but I'm pretty happy that you know somebody will come up with a proposal.
+We will vet it and make sure that it works.
+And away we go.
+Greg Sanders, of course, will be the person to talk to.
+He's been doing both sides.
+I know he and AJ are all over this.
+I trust them to weed through all the different possibilities, come out with a proposal, and then we'll tear it apart and then go again and do it properly.
+
+Speaker 1: 00:19:07
+
+So Yeah, I believe it's live in inquisition already.
+
+Speaker 0: 00:19:11
+
+Yeah, exactly.
+So, you know, I think we're, you know, we're well on the way to getting that.
+Now, just to set expectations correctly, even if we saw for tomorrow and it activated the week after, you know, there's a leer latency involved here, right?
+We still need to then go through and implement it, roll it out, you know, it gets it gets spec'd out, it gets, you know, packed together, then it gets, then we ratify it, We get two different independent implementations both to implement it and interoperate and make sure that works.
+Then it's spec final.
+Then everyone else can go ahead and implement it.
+Then it can roll out on the network.
+Then everyone can upgrade.
+Then once both your peers are upgraded, then now you can open a new channel.
+A new channel will be one of these cool, you know, L2 channels and everything else.
+So, you know, this is a long road, right?
+
+Speaker 1: 00:19:57
+
+Yeah, we were just talking with El and Oli, how one and a half years after Taproot's been active, simple Taproot channels are close to being spec'd out.
+
+Speaker 0: 00:20:07
+
+Yes, exactly.
+
+Speaker 1: 00:20:08
+
+We know what you mean.
+
+Speaker 0: 00:20:10
+
+And the other thing is that, look, it enables simplicity, it makes things a lot nicer for us, and it makes it cleaner, but not immediately.
+At the moment, it's just work.
+Because we don't get to drop anything that we're currently doing.
+Now, eventually, sure, we do.
+At the end of the road, there's this beautiful rainbow and there's unicorns dancing and everything else.
+But we have to trade through a lot of unicorn crap.
+
+## Pushing privacy and robustness to the front of the line
+
+Speaker 2: 00:20:35
+
+This goes back to the open, which is privacy and robustness.
+They always go to the end of the line.
+So if you're never prioritizing them,
+you're never prioritizing those things which never get attention.
+It's sort of the equivalent of like, it's not tech debt, it's like philosophical debt.
+And so, yeah, how do you push those to the front of the line and put them front and center?
+Is it because they can come in the form of new features that it's time for?
+Like, yeah, how do you push those forward?
+
+Speaker 0: 00:21:07
+
+How do you push those forward?
+You have that internal compass of, you need to spend a certain amount of your time on stuff that's literally broken on fire and everything else.
+You need to spend a certain amount of time on other things.
+As an engineer, this is the eternal battle between, you know, so just look at me personally, right?
+So I lead the core lightning team.
+There's a certain amount of just dealing with time sheets and just doing random managerial overhead that I have to do.
+There's a certain amount of like peering on random podcasts to talk about stuff.
+There's a certain amount of actual coding that I have to do on core lightning features that people want because, you know, scalability, whatever thing it is, right?
+Oh, well, this is a cool new feature.
+We should do that.
+And then there's the protocol work as well right so there's always more things to do well in any fun job like working on this there's always more things to do than you necessarily have time for you have to prioritize so to answer your question how do you do that And the answer is that you have to reserve a certain amount of time for long-term work.
+You just have to.
+And you have to be aware through experience that if you do not explicitly reinvent some of your time, It'll never be a good time.
+Right.
+
+## The dynamics of developing a spec with commercially associated implementations
+
+Speaker 2: 00:22:18
+
+So, but okay, I have two, I have two things to push back on.
+One is LDK is a little bit of a maybe a question mark for me, but the others are three commercially driven implementations.
+
+Speaker 0: 00:22:30
+
+I didn't realize we were commercially driven.
+Okay, good.
+I like that.
+
+Speaker 2: 00:22:35
+
+And so, well, they have to be, I mean, they're companies, if the companies don't exist, do these implementations exist, I guess?
+So that is a very good philosophical question.
+
+Speaker 0: 00:22:45
+
+And hey, I work for a startup, right?
+And you should always be thinking what happens if my startup collapses because almost by definition right that's the the endgame for most startups is like they fail right and so when you have an open source project and you're like well I'm running this what what happens what happens after this to some extent the answer is you know I'm gonna keep working on this whatever happens unfortunately my wife has given explicit approval for me to take some time off and work.
+Should all of us fail?
+We've had this discussion, right?
+She's been like, cool, that's okay.
+You can go do that.
+At least for a while before you have to get a real job again.
+So I feel fairly confident to go, you know, we're going to move forward.
+And maybe not as fast as we are at the moment.
+But, you know, there's some future there.
+
+Speaker 2: 00:23:24
+
+Now, I guess my other bit of that was Because they're commercially associated, maybe not driven, commercially associated.
+That means that features get pushed to the front of the line.
+Because I've worked for companies, I know how it works.
+So when you're talking about, you know, ring fencing things and making sure that we're, you know, thinking long term.
+These are different than just like building a product that's, you know, in JavaScript and you know, can wow an investor.
+There is a philosophical side to what's happening here.
+And there is a collaboration side of no implementation can do it by themselves.
+
+Speaker 0: 00:24:07
+
+Yes.
+
+Speaker 2: 00:24:07
+
+And so those dynamics just don't seem to add up to a, a long term thinking and long term, you know, moving, moving the ball forward in these kinds of dimensions.
+
+Speaker 0: 00:24:21
+
+So the piece that you're missing here is the pie is still growing, right?
+And so there is more emphasis on growing that pie and doing those bold new things because the world is still in front of us right light network as it is in 10 years time is much bigger than light network today with that assumption how do you lead how do you become the one everyone wants to be and the answer is you do the cool new things.
+And that's not so much features.
+It is that focus on the next, basically the light in 2.0. What are the cool new things coming down the pipe?
+Is it L2?
+Is it L-unsymmetry?
+Have you already got those, right?
+Is it taproot channels?
+Like look at LNDs, you know, huge amount of resources they're putting in to doing that.
+Now, you know, a lot of that is commercially driven.
+Why?
+Because it gives them cool points and it makes the rest of us sweat.
+And we have to then catch up, right?
+This is always the way.
+One of the implementations does something really cool.
+And I'm going, on the one hand, I'm going, wow, that's amazing.
+On the hand, I'm going, shit.
+Now we have to do that.
+Right?
+So it is, there is definitely a commercial reason to do these things.
+Now, is it theoretically possible that you could avoid doing any real work and just concentrate on, you know, adding features to your own implementation.
+I think it's too early.
+At the moment, you can't do that because no one else is doing that and you will get left behind.
+There are four implementations out there and there is choice in what you can run.
+So everyone is sweating at the moment a little bit.
+There's something of a treadmill effect.
+
+Speaker 2: 00:25:51
+
+My other side of that.
+
+Speaker 1: 00:25:54
+
+Isn't it five, meanwhile, with Electrum also in the mix now?
+
+Speaker 0: 00:25:58
+
+Electrum has been in the mix for a while, but we haven't really seen them pushing the boundaries of the spec process.
+They're quite happy to kind of follow along and meet the requirements.
+
+Speaker 1: 00:26:08
+
+Okay, so you're talking about four that are participating in the spec.
+
+Speaker 0: 00:26:12
+
+There are three other teams I can hit up when I want someone else to interoperate with on some new feature who are really going to drive it forward.
+And those are really reliable.
+
+## Expecting new implementations
+
+Speaker 0: 00:26:21
+
+So there's certainly other implementations to come up.
+And I actually expect to some extent that LN symmetry may open some new opportunities because people go, actually, I can implement that now.
+That is a serious subset.
+If I just implement that, maybe I've got an advantage over the others who have legacy they've got to still handle whereas I can just have a clean implementation that just does this new thing so we're gonna see these you know these new kids coming up with their you know I don't know Kotlin implementation I've heard of those I know some some some some of them one of those languages you know you're like you implemented in what I've heard of that kind of thing.
+That may be the next thing.
+And that's exciting for me.
+I think, you know, that brings, you know, new blood, just a new design space, a new point of view to the implementations, and that's always great.
+
+## Privacy revisited
+
+Speaker 2: 00:27:02
+
+Privacy.
+Privacy, yes.
+So we were talking about sort of the robustness dimension and that sort of that principle.
+What's on your mind about privacy?
+
+Speaker 0: 00:27:11
+
+Well, privacy, I think, you know, privacy is a bottomless well, right?
+You can keep going on privacy for just about forever.
+There are some fairly obvious things you can know on privacy.
+I think some of them are just like a quality of implementation.
+So the Oakland Protocol, which was discussed at the last summit, which is this idea that you can shield exposure to where HTLCs have gone through because you can make it a lot harder for people to probe.
+Hold on, you used to have this much in channel, now you've got this much.
+I can tell therefore that that payment that went through me went out this channel for you.
+So we can actually shield a lot of that using the Oakland protocol.
+So that requires widespread implementation.
+
+Speaker 1: 00:27:48
+
+As a reminder, that was basically just under-reporting your channel capacity.
+
+Speaker 0: 00:27:53
+
+That's right.
+Yeah.
+So basically you fake a couple of...
+You act as if the payment may have gone out multiple channels.
+You artificially restrict their capacity by some amount, in the case where your maximum HTLC size has hit the bounds of the capacity.
+So it doesn't actually make a difference in a lot of cases, because for most implementations, you set the maximum HTLC size that they can go through to, say, 10% of your channel capacity anyway.
+So as long as you've got more than 10%, they can't tell.
+They literally cannot tell.
+When you're under 10 you know the question is like when you're on the boundary you can you can start probing and so at that point you start the Oakland protocol and well you know we're going to actually let you use slightly less capacity than we actually have because we don't want to leak that we didn't send the HTLC out through there.
+
+Speaker 1: 00:28:34
+
+Couldn't prober still send multiple payments, lock up more funds and then probe like the 40 to 50% by having four other 10%?
+
+Speaker 0: 00:28:45
+
+Exactly.
+So you can do it with multiple probes, but the Oakland protocol basically restricts it because it gives you a fixed point where you go.
+And some implementations actually restrict the total HLC in flight.
+So they can't, you can have like a, you have another thing that they can't basically exhaust the whole channel.
+So there's that, there's low-hanging fruit like that.
+There's splicing, which just messes up your graph a little bit, so it makes it harder to...
+Dual funding particularly allows you to combine multiple things into one transaction, just the common ownership heuristics starts to break down.
+This is useful.
+There's a whole pile of different fun things you can do once you've got splicing and you can splice in and out and everything else And just mess people up which is kind of nice Particularly if we start to see things like page join of things coming out of splices and really really kind of a lot more So once your lightning channel is also used for unchain things through splicing, I think it becomes a lot more complicated to see exactly what's going on, which is just a nice low-hanging fruit that we're going to get.
+
+Speaker 1: 00:29:40
+
+Especially if we no longer announce which UTXO a channel is from.
+
+Speaker 0: 00:29:46
+
+The gossip question, right?
+Do we break the linkage between for anti-spam reasons?
+We say, hey, improve.
+I have this UTXO and this is the basis of our channel.
+We're going to have to weaken that slightly anyway, because chatbot channels are going to have a different form.
+So we need a new gossip thing anyway.
+At that point, we're going to have this debate this week as to whether we go all the way and say, hey, we don't have to prove the funds for this particular channel.
+One proposal is that you prove that you have some funds and that allows you to announce a certain number of channels or a certain capacity of channels, but they don't have to be related.
+Cool.
+Just prove that you have some funds.
+So you can't claim, hey, I've got all these giant channels without some anti-spam requirement.
+But we could loosen it out and say, cool, you know, you proved you got a million sats.
+You can advertise eight million sats worth of channels.
+Right.
+To hand wave, there have to be some other restrictions in there.
+But that would potentially allow us to break this heuristic where you're basically announcing your channels.
+Now, the gossip announcement, that's my fault actually, because I put that in the protocol.
+And I was thinking, well, you're public anyway, it's fine.
+But it turns out, of course, that leaking that one piece of information then often leads to a lot of other information that you did not intend to be leaked, particularly about unannounced channels, which we've recently had improvements on, right, with with SCID aliases, you know, we're no longer leaking those, but indirectly you can now start to tell what's happening with private channels, which was, or unannounced channels, which was never the intention.
+
+Speaker 1: 00:31:04
+
+Just through taint on on-chain transactions and pedigree?
+
+Speaker 0: 00:31:08
+
+Yeah, well, just the fact that now you can see, okay, I know this channel came from you, and therefore I can see this other UTXO went to a Lightning channel, I'm pretty much sure that that is yours as well.
+And you know, you can start to join things together just doing things like that.
+
+## What broke when fee rate spiked?
+
+Speaker 1: 00:31:22
+
+So I would like to call back to you said a bunch of things broke when the fee rates spiked.
+
+Speaker 0: 00:31:27
+
+Yeah.
+
+Speaker 1: 00:31:28
+
+And I was curious what what broke for various lightning implementations.
+
+Speaker 0: 00:31:32
+
+Can we get a little bit into that?
+
+Speaker 1: 00:31:33
+
+Yeah, absolutely.
+Robustness for fees folks.
+
+Speaker 0: 00:31:36
+
+So yeah, so part of the problem at the moment is that you basically have to agree on what fee you're going to pay.
+Now there's there's now only one side pays fees.
+It's the person who originally proposed it.
+And they're the only one who can propose fee changes.
+But fees are also charged on second stage HTLC transactions.
+And that comes out of the HTLC.
+So it may not be paid by the person.
+So as a result of this flow through, you actually care what the person normally paying the fees sets it to.
+So you have to have some agreement.
+We tend to be pretty broad.
+Now it turns out if you restart BitcoinD it seems that it often just drops a bundle of shit and starts to think that the floor for fees has dropped back down.
+So people will restart the BitcoinD, it would go, no, no, min relay fees, all good.
+We're, you know, we're back on like, you know, one set or whatever.
+And you would propose that to your peer who has not restarted and you fucking want no, and you could get forced closures that way.
+
+Speaker 1: 00:32:29
+
+Sure.
+Yeah, this is meant to run consistently, and we don't get good fee estimates until a couple blocks have been found.
+
+Speaker 0: 00:32:36
+
+That's right.
+So some of that is just a learning experience, right?
+The answer is that basically you shouldn't let the min fee drop over some period of time.
+You just go, we're going to ratchet it up to a certain amount.
+And then if it's been there for an hour and we're still getting, okay, then we start to let it down.
+This is a workaround for that.
+There's another issue that the Eclair people spotted that I think actually Bastien spotted, which is where you go on chain, you go to redeem an HLC, you go, it's actually not worth me paying the fee that would be involved to redeem this because fees are high, whatever else, so I'm not going to, you still have to close it upstream at that point.
+Normally you'd wait till it spans and then you go, whatever, but if you're not going to spend or you're not gonna push paying a fee to force it through, you now need to make the call to fail it upstream.
+You're at risk at that point because you could lose the HTLC, but you've already decided to write that money off because it's not worth.
+But if you don't close it upstream, upstream then closes on you because you've left this HTLC and clock's ticking.
+Upstream goes, right, I'm going to close the news.
+So you can end up with channel failure because of this issue.
+
+Speaker 1: 00:33:37
+
+Right, so you have an HTLC that's so small that at a high fee, it's not worth claiming.
+That's right.
+You write it off, but you have to.
+
+Speaker 0: 00:33:44
+
+But you don't actually close it out to the peer.
+So that's a quality of implementation issue and you end up closing another channel, not just the first one, right?
+So you end up this cascade effect.
+So we had a little bit of that.
+
+Speaker 1: 00:33:56
+
+Could you clarify?
+So the fee in a commitment transaction is paid by the channel proposer?
+Yes.
+Like the person that started the channel.
+So it's always the one that started the channel that has to cough up the fees.
+
+Speaker 0: 00:34:09
+
+Okay.
+Yes.
+But remember with modern anchor channels, your fee is actually pretty low ball.
+It's just going to be enough to get you into the mempool, and you're going to use child pays for parent on one of the anchor outputs to actually bump the fee where it is.
+So it reduces the problem that we have.
+Just like I have to guess what the fee rate is going to be in future whenever I want to spend this to, I have to guess what the min fee is going to be in future.
+
+Speaker 1: 00:34:30
+
+So I can spend this.
+The dynamic mempool minimum fee.
+
+Speaker 0: 00:34:32
+
+Yeah, that's right.
+
+Speaker 1: 00:34:34
+
+Which can be higher in the last few months.
+
+Speaker 0: 00:34:36
+
+It's not actually that much of an easier problem, but at least the number is probably less.
+So, you can lowball fees to some extent, whereas before we had to bump fees up quite a lot.
+We used a magnifying factor to go, well, I could go as high as this.
+The ultimate answer to this is to package relay, version 3, all those things.
+So we can actually have no fees here and have all the fees in the child.
+Well, the ultimate answer for this is L2 and everything else.
+But meanwhile, package relay lets us not have-
+
+Speaker 1: 00:35:03
+
+But even with L2, you still need to have a mechanism to be able to broadcast on-chain.
+
+Speaker 0: 00:35:07
+
+But in that case, we use a SIGHASH signal.
+Anyone can pay.
+You have to bring your own fees.
+And you bring your own fees through, right?
+
+Speaker 2: 00:35:13
+
+Yeah, sure.
+
+Speaker 0: 00:35:14
+
+And in a more efficient way than child pays for parent, you actually bring your own fees on the board, which is really cool.
+
+Speaker 1: 00:35:18
+
+Anyway,
+
+Speaker 0: 00:35:22
+
+so this means that then the person closing actually is the one who bumps it and then pays fees above some de minimis level at the moment.
+So that actually works a little bit better and is a bit more incentive compatible.
+So you want to close the channel, you're paying the fees.
+Whereas the moment like, you know, sometimes you want to close the channel, it's just like, I'm paying the fees.
+That's not right.
+Right.
+So, so it does help to some extent to solve that.
+So yeah.
+Okay.
+
+Speaker 1: 00:35:42
+
+So, so basically the commitment transaction must at least with anchor output still meet the dynamic minimum of the mempool.
+We've seen that spike to above 10, I think 15 maybe in the last few months.
+
+Speaker 0: 00:35:57
+
+That's right.
+Now you've got some time, you have a longer delay on your channel, you've got some time to get it in.
+So a transient spike doesn't hurt you so much, but you do have to get in.
+And this is one of the reasons that we talk about, you know, Bitcoin Core traditionally has divided rules into like the hard rules of what can go in a block and then the software rules about what can propagate.
+It's like when you're using it at a layer two, you don't care.
+Like if you, you don't care why your transaction doesn't go in, whether it's because it's illegal or whether it's because it's considered immoral by the network, right?
+Just these soft rules don't actually make a difference to you.
+They're both really good, really important rules.
+And so there's been more focus than there perhaps has been in the past, where these soft rules about what's allowed to propagate through the network have been seen as less important.
+Yes, to some extent they are because they're changeable, but in a sense of you're operating, building on top of it, they're both really good.
+So there's been a proposal to have a workaround where we actually start spraying things through the Lightning Network so that people will jam them into their local nodes.
+It may still happen at some point if we really need to.
+As long as we can get them to miners.
+
+Speaker 1: 00:36:57
+
+Oh, is that the third approach next to Nostra and- Yeah, that's right.
+
+Speaker 0: 00:37:00
+
+Exactly.
+You know, we just all you separate them over all the networks as long as there's a minor missing, you might pick them up.
+I know there was there was a proposal to have some kind of local package relay where you could kind of inject a package locally.
+And then we could just paper over the rest if we needed to.
+Obviously, we'd like to just go all the way to the you know, hey, do the whole peer-to-peer protocol for an upgrade, we're all good.
+But you know, that's something that we could potentially do if we had to.
+But you know, in the meantime, it's interesting to see the phenomenon.
+This stuff happened because fees were so low for so long that it got pushed to the back of the line, right?
+Even we were one of the first people to implement the old anchor system, which had fees built in.
+And then when people implemented it, they went, actually, we want zero fee anchors.
+And so that became whatever else implemented, we lacked.
+Core Lightning did not implement that because it meant basically you always had to bring your own fees and you had to have a reserve for that and you had to basically be able to do a lot more dynamic fee stuff.
+And it just wasn't on fire until it was.
+And that PR is sitting there.
+It's going to get merged.
+And it is going to get merged because I'm release captain and it's damn well going to get merged before the release.
+So we're finally fixing that.
+The one good thing about volatility like this is it does shake your priorities up a bit and reminds you that you've got to address these things.
+
+Speaker 1: 00:38:11
+
+Pushes adoption of best practices, better fee estimation, better output type usage, your excel management, you know, all the things.
+
+Speaker 0: 00:38:20
+
+All these things that are not important until they suddenly are and you put the engineering work in.
+Look, you know, life's all about trade-offs and I actually can't, you can't be too harsh on people for going well, you know, I decided to defer that.
+Like people give crap to Moon Wallet for example for using on-chain transactions.
+I'm like look it's an engineering trade-off that's fine you know as long as you go in with your eyes open.
+Now sure your timing isn't gonna be perfect but hell if you'd asked me two years ago I would have said no no this stuff is critical you know fees are going up you've got to do it.
+I mean really?
+You actually had two years to get away with it.
+And you could kind of bumble your way through the recent fees spike and go, okay, for all I know, we'll have another two years of low fees.
+And you go, oh, okay, maybe you panicked a bit too hard.
+Just for the record, I do not think that's true.
+And you should totally get your shit together now.
+But I can't blame anyone else who made the same kind of decision and went, well, actually, if you're not on fire right now.
+But yeah, it is part of a robustness approach means addressing these things.
+I think we are slowly moving our way through the list, but there will always be things that you wish you had done earlier, but that's engineering.
+You can't do all the things.
+
+Speaker 1: 00:39:19
+
+Right.
+So the rainbows and unicorns in this case look like v3 transactions with ephemeral anchors, zero fee commitment transactions, package relay.
+Package relay.
+And L2 also solves some of these problems.
+
+Speaker 0: 00:39:33
+
+But we have similar incentive problems, and you need to have the package relay as well, and v3, I think, for it to get L2 to be secure as well.
+We currently have two anchor outputs, and that makes your transactions bigger.
+So in a low fee environment, you could argue that you shouldn't implement anchors because you're just making a bigger transaction for unilateral closes.
+And you're spending, basically, your transaction is almost twice as big because it's got these two extra outputs.
+With package relay and v3, I think we only need one anchor that we can share.
+We're still in anchors.
+You know, you're still a little bit bigger.
+
+Speaker 1: 00:40:06
+
+And the ephemeral anchor is smaller because it's just an uptrue.
+
+Speaker 0: 00:40:10
+
+Yeah, that point, the ephemeral anchor, it shrinks right down.
+So it's pretty good.
+And at that point, you start to go, yeah, OK, it's a bit of a wash.
+And output's still not free, but you know, it's cheap nine bytes nine bytes Someone's on the math.
+Cool.
+So yeah, yeah that look that that's definitely the where we want to get to and again, it's an Maybe no one will notice if it takes a while to get there, but definitely it's one of those, the engineers look at these things and see problems.
+And this is one of the problems we see and we crossed off the list and then we'll work on the next one.
+
+Speaker 1: 00:40:38
+
+Yeah, Gloria and I have been writing, waiting for confirmation series and uptake newsletter.
+Next week we're going to talk about mempool policy as an interface for layer 2 protocols.
+Yeah.
+So, not preparing for that yet, but I'm thinking already.
+
+Speaker 0: 00:40:56
+
+Yeah, I look forward to reading it.
+It's going to be interesting.
+
+Speaker 2: 00:40:58
+
+What else is on your mind, Rusty?
+Anything else to mention?
+
+Speaker 0: 00:41:02
+
+Okay.
+I think my mind is still somewhere over the Pacific Ocean right now.
+So I'm not sure that it's all present.
+Look, as I said, we've been going eight years on this and it's been a fantastic journey just to go through with this incredibly bright set of inspired engineers.
+I'm not a morning person, but I still get up for 5.30 a.m. Calls every two weeks on Tuesday, my time, Monday, everyone else's time, to hang out and like, and collaborate on the SPAC and do everything else.
+And, you know, it was really interesting to go through those days when there was excitement about lightning in the early days, and then everyone was pretty much pivoted to, no, Bitcoin's a store of value, payments aren't important.
+And we're like, but we're working on payments.
+Like, we're working really hard, you know.
+And you know, to see it kind of come back around, now people are like, wow, this is actually usable.
+Like, it's really cool.
+I think it's a little bit of, it's a little bit gratifying to kind of, everyone to kind of come back to oh yeah this is this is actually pretty nice thank you that's good but you know we still have so much more to do and I think everyone's pretty aware of that to some extent you know this is a job that will never be finished, but it's going to get harder and harder as the network grows to change things.
+And so there's a lot of effort on trying to make sure that we've got things correct now, we've laid the foundation correctly.
+So that, you know, while, you know, unlike Bitcoin, which is completely, you know, ground into stone.
+We do have some ability to move on the protocol, but over time it will become less and less just because of the weight and the inertia of things.
+I look at the IPv4 to v6 transition, right?
+It's going great.
+It's going great.
+Any day now, right?
+Two weeks, TM.
+You know, so, so, you know, and there were things that we put in the protocol that were way overkill.
+The onion stuff, like the onion routing, but just with everyone was very clear that while nobody's screaming for this today, it is a critical component that needs to be in the version zero.
+It needs to be in there before anything else.
+So I think we're in, you know, all up.
+You step back and you were in reasonably good shape.
+And yeah, as I said, engineers tend to focus on the problem.
+We tend to focus on this needs fixing and this needs fixing.
+We need to do this and this.
+We don't often look back and go look at, you know, all the things that we've achieved over this time.
+And so for me, this week is a little bit of both.
+A little bit of kind of going, yeah, look at all the stuff that we've done.
+Look at the excitement that has moved up.
+The people building things on top of what we're doing.
+That's really exciting.
+And that's where more people will come into there and they're going to come into the low level and go, you know what I want to do?
+I want to implement Lightning Protocols from scratch.
+You know, I welcome the crazies.
+If you're listening to this and going, that's what I want to do, I want to implement that.
+You're my people.
+I love that.
+But I just accept that most people will be building on layers above us.
+And that's where the excitement will move up to.
+But still, our job is going to be to just continue that incremental engineering and just making it better, little by little, and those wins will accumulate.
+
+Speaker 1: 00:43:36
+
+Saurabh Mishra What are the things that you're excited to see being built on top of Lightning?
+Well, I'll let you answer first, but I might have follow up.
+
+Speaker 0: 00:43:43
+
+Jason Tucker Oh, yeah.
+What is exciting?
+I always said that there will be some killer application of lightning that I will think is stupid because I'm old.
+And you know,
+
+Speaker 1: 00:43:52
+
+how I feel about inscriptions.
+
+Speaker 0: 00:43:55
+
+Yeah, yeah, exactly.
+You know, it'll be you know, I don't even know what it will be.
+And part of that is just the problem is that when you don't have a technology, when you don't have a way of making micro payments, what we would call real micro payments, not like making tiny payments, by definition, any business model or things or infrastructure that would require that do not exist because they can't.
+And so there's an inertia behind that, right?
+You create a technology, but then there's no immediate use for it.
+There are a few fringe uses and people who can use it and, you know, they can kind of like enhance things they're already doing.
+But the whole Greenfields thing of things that didn't exist or didn't make sense before that suddenly makes sense.
+And you know, I think at this point, Noster tipping is probably something where people think, oh, it didn't make sense before.
+You couldn't really do that with credit cards.
+
+Speaker 1: 00:44:43
+
+It didn't.
+I must admit, like on Stacker News, when I want to tip a post, and the little lightning zooms across the screen when I tip.
+Yeah.
+It's just like I started Lightning Wallet, but I put in a few thousand sets and I got some tips back, bigger account number now.
+It's neat.
+If I ever want to get those sets back, I can just pull them back to my Lightning wallet.
+It's pretty neat.
+
+Speaker 0: 00:45:08
+
+And look at Cashew and some of the other things, the Fetty Mint and stuff using Lightning as a glue, right?
+
+Speaker 1: 00:45:12
+
+Yeah.
+And just international payments.
+So simple.
+I traveled to Central America a while back and being able to just go and pay with my money there, everywhere, that made it very real, much more real than all this theoretical pondering on what the world will look like.
+
+Speaker 0: 00:45:35
+
+Yeah, absolutely.
+And which of these will be the, is it like slow accretion of all these things?
+I don't know.
+I'm not smart enough to tell what's happening, but it is exciting.
+It is fantastic to see people actually use this and explore things.
+And these people will build things that I could not even conceive of.
+I certainly couldn't have built myself.
+
+Speaker 1: 00:45:54
+
+It's hard to see the potential of the black box thing when you're in the nitty gritty building the black box.
+
+Speaker 0: 00:45:59
+
+That's right.
+Yeah, And I'm sure any guesses that I would make about what it would do will become horribly dated and will be wrong.
+Because you're a product of the pre-existing conditions, right?
+It will take someone for whom someone lightning native will come along and do something that yeah, probably the shaggiest, dumbest thing I've ever heard of.
+It'll turn out to be a huge success and it shows that I knew.
+That's why I'm not a business guy.
+I'm just an engineer.
+
+Speaker 2: 00:46:25
+
+Where are we at?
+Thank you.
+Thank you for doing this.
+Thank you.
+
+Speaker 0: 00:46:30
+
+Thanks for having me.
+
+Speaker 1: 00:46:31
+
+Yeah, thanks.
+
+Speaker 2: 00:46:39
+
+So did that live up to your expectations?
+
+Speaker 1: 00:46:42
+
+Yeah, I think so.
+Looking back eight years in with people that got in really early that had a 20-year vision for it from the get-go.
+It's refreshing.
+I think it's really nice thinking back, writing so much, reading so much about it when Lightning just came out.
+Yes, there's been a lot done.
+It's getting used by people.
+It's very cool.
+
+Speaker 2: 00:47:05
+
+So eight out of 20 means we're 40 percent and are we 40 percent there?
+
+Speaker 1: 00:47:09
+
+I don't know.
+Maybe it'll be a little faster.
+It's already usable.
+We're seeing some projects being built on Lightning.
+I mean, last year I could buy pupusas in a place with stomped earth ground but lightning network payments and I don't know that was my plan so it's it's it feels like we're definitely some part there where you can use it, but some of the features that I've been hearing about for years still need to happen.
+So yeah, maybe 40% is a good value.
+I don't know if 20 years is the right amount, but taking that sort of approach and having that in mind makes it easier to.
+
+Speaker 2: 00:47:49
+
+Is it always just 20 years out?
+Do you take this?
+
+Speaker 1: 00:47:54
+
+I don't think it's like block times.
+It's more like building a new protocol and also getting that person that will be a lightning network that builds the killer use case just takes a generation maybe.
+Anything really big that changes stuff progresses in 10 year steps.
+So two steps.
+Yeah, I think so.
+
+Speaker 2: 00:48:15
+
+Cool.
+Well, hope you enjoyed listening to it and we'll see you

--- a/chaincode-labs/chaincode-podcast/utxos-chaincode-decoded.md
+++ b/chaincode-labs/chaincode-podcast/utxos-chaincode-decoded.md
@@ -4,8 +4,10 @@ transcript_by: sasa-buklijas via review.btctranscripts.com
 media: https://www.youtube.com/watch?v=sNLbg9BUV4Y
 tags: ["bitcoin-core"]
 speakers: ["Adam Jonas", "John Newbery"]
-categories: ["Podcast"]
-date: 2020-12-01
+categories: ["podcast"]
+date: 2020-02-26
+episode: 5
+aliases: ['/chaincode-labs/chaincode-podcast/utxos-chaincode-decoded']
 ---
 ## Introduction
 


### PR DESCRIPTION
This adds 15 new AI-generated transcripts:
- `adopting-bitcoin/2021`: 1
- `adopting-bitcoin/2022`: 1
- `bitcoin-explained`: 4
- `bitcoin-design/learning-bitcoin-and-design`: 4 (related https://github.com/BitcoinDesign/Guide/issues/1062)
- `chaincode-labs/chaincode-podcast`: 5