### PR TITLE
Add privacy-and-robustness-in-lightning review to chaincode-labs/chaincode-podcast

### DIFF
--- a/chaincode-labs/chaincode-podcast/privacy-and-robustness-in-lightning.md
+++ b/chaincode-labs/chaincode-podcast/privacy-and-robustness-in-lightning.md
@@ -1,12 +1,11 @@
 ---
 title: "Privacy and robustness in Lightning"
-transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
+transcript_by: pancamarga41 via review.btctranscripts.com
 media: https://podcasters.spotify.com/pod/show/chaincode/episodes/Rusty-Russell-and-privacy-and-robustness-in-Lightning---episode-34-e27t6go
-tags: ['lightning', 'eltoo', 'privacy-enhancements']
-speakers: ['Rusty Russell']
-categories: ['podcast']
+tags: ["lightning","eltoo","privacy-enhancements"]
+speakers: ["Rusty Russell"]
+categories: ["podcast"]
 date: 2023-08-09
-episode: 34
 ---
 Speaker 0: 00:00:00
 


### PR DESCRIPTION
This PR adds [privacy-and-robustness-in-lightning](https://podcasters.spotify.com/pod/show/chaincode/episodes/Rusty-Russell-and-privacy-and-robustness-in-Lightning---episode-34-e27t6go) transcript review to the chaincode-labs/chaincode-podcast directory.