### PR TITLE
Add schnorr-musig-frost-and-more review to chaincode-labs/chaincode-podcast

### DIFF
--- a/chaincode-labs/chaincode-podcast/schnorr-musig-frost-and-more.md
+++ b/chaincode-labs/chaincode-podcast/schnorr-musig-frost-and-more.md
@@ -1,22 +1,28 @@
 ---
-title: "Schnorr, MuSig, FROST and more"
-transcript_by: kouloumos via tstbtc v1.0.0 --needs-review
-media: https://podcasters.spotify.com/pod/show/chaincode/episodes/Pieter-Wuille-and-Tim-Ruffing--Schnorr--MuSig--FROST-and-more---Episode-26-e1sav0l
-tags: ['cryptography', 'musig', 'schnorr-signatures']
-speakers: ['Pieter Wuille', 'Tim Ruffing']
-categories: ['podcast']
-summary: "Pieter Wuille and Tim Ruffing treat us to a conversation about Schnorr, multi-signatures, MuSig, and more. We covered a lot so this is part one of a two part conversation."
+title: 'Schnorr, MuSig, FROST and more'
+transcript_by: 'Wbaker7702 via review.btctranscripts.com'
+media: 'https://podcasters.spotify.com/pod/show/chaincode/episodes/Pieter-Wuille-and-Tim-Ruffing--Schnorr--MuSig--FROST-and-more---Episode-26-e1sav0l'
+date: '2022-12-15'
+tags:
+  - 'cryptography'
+  - 'musig'
+  - 'schnorr-signatures'
+speakers:
+  - 'Pieter Wuille'
+  - 'Tim Ruffing'
+categories:
+  - 'podcast'
+summary: 'Pieter Wuille and Tim Ruffing treat us to a conversation about Schnorr, multi-signatures, MuSig, and more. We covered a lot so this is part one of a two part conversation.'
 episode: 26
-date: 2022-12-16
 additional_resources:
--   title: MuSig
-    url: https://bitcoinops.org/en/topics/musig/
--   title: Yannick Seurin
-    url: http://yannickseurin.free.fr/
--   title: Bellare-Neven
-    url: https://btctranscripts.com/bitcoin-core-dev-tech/2018-03-05-bellare-neven/
--   title: FROST
-    url: https://eprint.iacr.org/2020/852.pdf
+  - title: 'MuSig'
+    url: 'https://bitcoinops.org/en/topics/musig/'
+  - title: 'Yannick Seurin'
+    url: 'http://yannickseurin.free.fr/'
+  - title: 'Bellare-Neven'
+    url: 'https://btctranscripts.com/bitcoin-core-dev-tech/2018-03-05-bellare-neven/'
+  - title: 'FROST'
+    url: 'https://eprint.iacr.org/2020/852.pdf'
 ---
 Speaker 0: 00:00:00
 


### PR DESCRIPTION
This PR adds [schnorr-musig-frost-and-more](https://podcasters.spotify.com/pod/show/chaincode/episodes/Pieter-Wuille-and-Tim-Ruffing--Schnorr--MuSig--FROST-and-more---Episode-26-e1sav0l) transcript review to the chaincode-labs/chaincode-podcast directory.