### PR TITLE
Add chipboards to misc

### DIFF
--- a/misc/chipboards.md
+++ b/misc/chipboards.md
@@ -1,0 +1,7 @@
+---
+title: 'Chipboards'
+media: 'https://chipboards.io'
+needs: 'transcript'
+---
+
+


### PR DESCRIPTION
This PR adds [Chipboards](https://chipboards.io) transcript to the misc directory.