### PR TITLE
Add build preview trigger

### DIFF
--- a/.github/workflows/create-preview-link.yml
+++ b/.github/workflows/create-preview-link.yml
@@ -2,18 +2,68 @@ name: Build Transcripts Preview Site
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - '**' 
   workflow_dispatch:
+  issue_comment:
+    types: [created]
     
 jobs:
   build-preview:
     runs-on: ubuntu-latest
+    
+    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'external-fork-preview' || '' }}
+
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' && 
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/build-preview') &&
+       (github.event.comment.author_association == 'OWNER' || 
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'))
 
     steps:
-      - name: Setup Checkout for Bitcoin Transcripts
+      - name: Get PR details for comment trigger
+        id: pr-details
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            return JSON.stringify({
+              head_sha: pr.data.head.sha,
+              head_ref: pr.data.head.ref,
+              head_repo_fullname: pr.data.head.repo.full_name
+            });
+
+      - name: Setup Checkout for Bitcoin Transcripts (PR Target)
+        if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: transcripts
+
+      - name: Setup Checkout for Bitcoin Transcripts (Comment Trigger)
+        if: github.event_name == 'issue_comment'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ fromJson(steps.pr-details.outputs.result).head_repo_fullname }}
+          ref: ${{ fromJson(steps.pr-details.outputs.result).head_sha }}
+          path: transcripts
+
+      - name: Setup Checkout for Bitcoin Transcripts (Workflow Dispatch)
+        if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v4
         with:
           path: transcripts
@@ -96,7 +146,6 @@ jobs:
       - name: Comment PR with Preview URL
         uses: actions/github-script@v7
         with:
-       
           script: |
               const fs = require('fs');
               const url = fs.readFileSync('vercel-preview-url.txt', 'utf8').trim();
@@ -112,9 +161,11 @@ jobs:
                 }
                   commentBody += `- [View All Transcript Sources](${url}/sources)\n`;
               }
+              
+              const prNumber = context.issue?.number || context.payload.pull_request?.number;
        
               github.rest.issues.createComment({          
-                issue_number: context.issue.number,
+                issue_number: prNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 body: commentBody


### PR DESCRIPTION
From  [this comment](https://github.com/bitcointranscripts/bitcointranscripts/pull/591#issuecomment-3187877317) it turns out our current setup from PR #590 doesn't work for fork PR, the reason might be because fork PRs don't directly have access to secrets [here](https://github.com/orgs/community/discussions/44322#discussioncomment-4914222).

So this PR triggers the `pull_request_target` when an admin or collaborator has `/build-preview` in their comment, this will give access to the secrets when the workflow runs