### PR TITLE
Add scaling-bitcoin-off-chain-with-pipes to bitcoinplusplus/insider-edition

### DIFF
--- a/bitcoinplusplus/insider-edition/_index.md
+++ b/bitcoinplusplus/insider-edition/_index.md
@@ -1,0 +1,5 @@
+---
+title: Insider Edition
+---
+
+{{< childpages >}}

--- a/bitcoinplusplus/insider-edition/scaling-bitcoin-off-chain-with-pipes.md
+++ b/bitcoinplusplus/insider-edition/scaling-bitcoin-off-chain-with-pipes.md
@@ -1,0 +1,7 @@
+---
+title: ' Scaling bitcoin off-chain with PIPEs'
+media: 'https://youtu.be/IJl3z6ZhSVQ'
+needs: 'transcript'
+---
+
+


### PR DESCRIPTION
This PR adds [ Scaling bitcoin off-chain with PIPEs](https://youtu.be/IJl3z6ZhSVQ) transcript to the bitcoinplusplus/insider-edition directory.