### PR TITLE
Add crashing-bitcoin-core-with-niklas-gogges-fuzzamoto to bitcoinplusplus/insider-edition

### DIFF
--- a/bitcoinplusplus/insider-edition/_index.md
+++ b/bitcoinplusplus/insider-edition/_index.md
@@ -1,0 +1,5 @@
+---
+title: Insider Edition
+---
+
+{{< childpages >}}

--- a/bitcoinplusplus/insider-edition/crashing-bitcoin-core-with-niklas-gogges-fuzzamoto.md
+++ b/bitcoinplusplus/insider-edition/crashing-bitcoin-core-with-niklas-gogges-fuzzamoto.md
@@ -1,0 +1,7 @@
+---
+title: ' Crashing Bitcoin Core with Niklas Gögge''s Fuzzamoto'
+media: 'https://youtu.be/_TsK_3bYpu8'
+needs: 'transcript'
+---
+
+


### PR DESCRIPTION
This PR adds [ Crashing Bitcoin Core with Niklas Gögge's Fuzzamoto](https://youtu.be/_TsK_3bYpu8) transcript to the bitcoinplusplus/insider-edition directory.