### PR TITLE
Add preventing-xpub-reuse-across-wallets to bitcoinplusplus/sovereignty-edition

### DIFF
--- a/bitcoinplusplus/sovereignty-edition/preventing-xpub-reuse-across-wallets.md
+++ b/bitcoinplusplus/sovereignty-edition/preventing-xpub-reuse-across-wallets.md
@@ -1,0 +1,7 @@
+---
+title: 'Preventing xpub reuse across wallets '
+media: 'https://youtu.be/zIek9svy1oc'
+needs: 'transcript'
+---
+
+


### PR DESCRIPTION
This PR adds [Preventing xpub reuse across wallets ](https://youtu.be/zIek9svy1oc) transcript to the bitcoinplusplus/sovereignty-edition directory.