### PR TITLE
Add silent-payments-output-descriptors to bitcoinplusplus/sovereignty-edition

### DIFF
--- a/bitcoinplusplus/sovereignty-edition/silent-payments-output-descriptors.md
+++ b/bitcoinplusplus/sovereignty-edition/silent-payments-output-descriptors.md
@@ -1,0 +1,7 @@
+---
+title: 'Silent Payments Output Descriptors '
+media: 'https://youtu.be/QQO0pMQB-QU'
+needs: 'transcript'
+---
+
+


### PR DESCRIPTION
This PR adds [Silent Payments Output Descriptors ](https://youtu.be/QQO0pMQB-QU) transcript to the bitcoinplusplus/sovereignty-edition directory.